### PR TITLE
Refactor: all function rename camelCase to snake_case

### DIFF
--- a/packages/array/README.md
+++ b/packages/array/README.md
@@ -38,56 +38,56 @@ bunx jsr add @checker/array
 
 ## Functions
 
-### `checkIsArray`
+### `check_is_array`
 
 Checks if the given value is an array.
 
 ```ts
-checkIsArray([1, 2, 3]); // true
-checkIsArray(42); // false
+check_is_array([1, 2, 3]); // true
+check_is_array(42); // false
 ```
 
-### `checkIsNotArray`
+### `check_is_not_array`
 
 Checks if the given value is not an array.
 
 ```ts
-checkIsNotArray(42); // true
-checkIsNotArray([1, 2, 3]); // false
+check_is_not_array(42); // true
+check_is_not_array([1, 2, 3]); // false
 ```
 
-### `checkIsEmptyArray`
+### `check_is_empty`
 
 Checks if the given array is empty.
 
 ```ts
-checkIsEmptyArray([]); // true
-checkIsEmptyArray([1, 2, 3]); // false
+check_is_empty([]); // true
+check_is_empty([1, 2, 3]); // false
 ```
 
-### `checkIsNotEmptyArray`
+### `check_is_not_empty`
 
 Checks if the given array is not empty.
 
 ```ts
-checkIsNotEmptyArray([1, 2, 3]); // true
-checkIsNotEmptyArray([]); // false
+check_is_not_empty([1, 2, 3]); // true
+check_is_not_empty([]); // false
 ```
 
-### `checkIsFirstIteration`
+### `check_is_first_iteration`
 
 Checks if the given index corresponds to the first iteration.
 
 ```ts
-checkIsFirstIteration(0); // true
-checkIsFirstIteration(1); // false
+check_is_first_iteration(0); // true
+check_is_first_iteration(1); // false
 ```
 
 ```ts
 const numbers = [1, 2, 3];
 
 numbers.map((number, index) => {
-  if (checkIsFirstIteration(index)) {
+  if (check_is_first_iteration(index)) {
     return number + 1;
   }
   return number;
@@ -95,20 +95,20 @@ numbers.map((number, index) => {
 // => [2, 2, 3]
 ```
 
-### `checkIsNotFirstIteration`
+### `check_is_not_first_iteration`
 
 Checks if the given index does not correspond to the first iteration.
 
 ```ts
-checkIsNotFirstIteration(1); // true
-checkIsNotFirstIteration(0); // false
+check_is_not_first_iteration(1); // true
+check_is_not_first_iteration(0); // false
 ```
 
 ```ts
 const numbers = [1, 2, 3];
 
 numbers.map((number, index) => {
-  if (checkIsNotFirstIteration(index)) {
+  if (check_is_not_first_iteration(index)) {
     return number + 1;
   }
   return number;
@@ -116,56 +116,56 @@ numbers.map((number, index) => {
 // => [1, 3, 4]
 ```
 
-### `checkArrayHasValue`
+### `check_array_has_value`
 
 Checks if an array contains a specific value.
 
 ```ts
-checkArrayHasValue([1, 2, 3], 2); // true
-checkArrayHasValue([1, 2, 3], 4); // false
+check_array_has_value([1, 2, 3], 2); // true
+check_array_has_value([1, 2, 3], 4); // false
 ```
 
-### `checkArrayDoesNotHaveValue`
+### `check_array_does_not_have_value`
 
 Checks if an array does not contain a specific value.
 
 ```ts
-checkArrayDoesNotHaveValue([1, 2, 3], 4); // true
-checkArrayDoesNotHaveValue([1, 2, 3], 2); // false
+check_array_does_not_have_value([1, 2, 3], 4); // true
+check_array_does_not_have_value([1, 2, 3], 2); // false
 ```
 
-### `checkIsLastIteration`
+### `check_is_last_iteration`
 
 Checks if the given index is the last iteration in the array.
 
 ```ts
-checkIsLastIteration(2, [10, 20, 30]); // true
-checkIsLastIteration(1, [10, 20, 30]); // false
+check_is_last_iteration(2, [10, 20, 30]); // true
+check_is_last_iteration(1, [10, 20, 30]); // false
 ```
 
-### `checkIsNotLastIteration`
+### `check_is_not_last_iteration`
 
 Checks if the given index is not the last iteration in the array.
 
 ```ts
-checkIsNotLastIteration(1, [10, 20, 30]); // true
-checkIsNotLastIteration(2, [10, 20, 30]); // false
+check_is_not_last_iteration(1, [10, 20, 30]); // true
+check_is_not_last_iteration(2, [10, 20, 30]); // false
 ```
 
-### `checkIsSpecificIteration`
+### `check_is_specific_iteration`
 
 Checks if the current iteration index matches a specific target index.
 
 ```ts
-checkIsSpecificIteration(3, 3); // true
-checkIsSpecificIteration(2, 3); // false
+check_is_specific_iteration(3, 3); // true
+check_is_specific_iteration(2, 3); // false
 ```
 
 ```ts
 const numbers = [1, 2, 3];
 
 numbers.map((number, index) => {
-  if (checkIsSpecificIteration(index, 1)) {
+  if (check_is_specific_iteration(index, 1)) {
     return number + 1;
   }
   return number;
@@ -173,20 +173,20 @@ numbers.map((number, index) => {
 // => [1, 3, 3]
 ```
 
-### `checkIsNotSpecificIteration`
+### `check_is_not_specific_iteration`
 
 Checks if the current iteration index does not match a specific target index.
 
 ```ts
-checkIsNotSpecificIteration(2, 3); // true
-checkIsNotSpecificIteration(3, 3); // false
+check_is_not_specific_iteration(2, 3); // true
+check_is_not_specific_iteration(3, 3); // false
 ```
 
 ```ts
 const numbers = [1, 2, 3];
 
 numbers.map((number, index) => {
-  if (checkIsSpecificIteration(index, 1)) {
+  if (check_is_specific_iteration(index, 1)) {
     return number + 1;
   }
   return number;

--- a/packages/array/mod.ts
+++ b/packages/array/mod.ts
@@ -1,36 +1,36 @@
 import { check_is_array, check_is_not_array } from "./src/checkArray/main.ts";
 import {
-	check_is_empty_array,
-	check_is_not_empty_array,
+  check_is_empty_array,
+  check_is_not_empty_array,
 } from "./src/checkEmptyArray/main.ts";
 import {
-	check_is_first_iteration,
-	check_is_not_first_iteration,
+  check_is_first_iteration,
+  check_is_not_first_iteration,
 } from "./src/checkFirstIteration/main.ts";
 import {
-	check_is_last_iteration,
-	check_is_not_last_iteration,
+  check_is_last_iteration,
+  check_is_not_last_iteration,
 } from "./src/checkLastIteration/main.ts";
 import {
-	check_is_not_specific_iteration,
-	check_is_specific_iteration,
+  check_is_not_specific_iteration,
+  check_is_specific_iteration,
 } from "./src/checkSpecificIteration/main.ts";
 import {
-	check_array_does_not_have_value,
-	check_array_has_value,
+  check_array_does_not_have_value,
+  check_array_has_value,
 } from "./src/checkHasValue/main.ts";
 
 export {
-	check_array_does_not_have_value,
-	check_array_has_value,
-	check_is_array,
-	check_is_empty_array,
-	check_is_first_iteration,
-	check_is_last_iteration,
-	check_is_not_array,
-	check_is_not_empty_array,
-	check_is_not_first_iteration,
-	check_is_not_last_iteration,
-	check_is_not_specific_iteration,
-	check_is_specific_iteration,
+  check_array_does_not_have_value,
+  check_array_has_value,
+  check_is_array,
+  check_is_empty_array,
+  check_is_first_iteration,
+  check_is_last_iteration,
+  check_is_not_array,
+  check_is_not_empty_array,
+  check_is_not_first_iteration,
+  check_is_not_last_iteration,
+  check_is_not_specific_iteration,
+  check_is_specific_iteration,
 };

--- a/packages/array/mod.ts
+++ b/packages/array/mod.ts
@@ -1,36 +1,36 @@
-import { checkIsArray, checkIsNotArray } from "./src/checkArray/main.ts";
+import { check_is_array, check_is_not_array } from "./src/checkArray/main.ts";
 import {
-  checkIsEmptyArray,
-  checkIsNotEmptyArray,
+	check_is_empty_array,
+	check_is_not_empty_array,
 } from "./src/checkEmptyArray/main.ts";
 import {
-  checkIsFirstIteration,
-  checkIsNotFirstIteration,
+	check_is_first_iteration,
+	check_is_not_first_iteration,
 } from "./src/checkFirstIteration/main.ts";
 import {
-  checkIsLastIteration,
-  checkIsNotLastIteration,
+	check_is_last_iteration,
+	check_is_not_last_iteration,
 } from "./src/checkLastIteration/main.ts";
 import {
-  checkIsNotSpecificIteration,
-  checkIsSpecificIteration,
+	check_is_not_specific_iteration,
+	check_is_specific_iteration,
 } from "./src/checkSpecificIteration/main.ts";
 import {
-  checkArrayDoesNotHaveValue,
-  checkArrayHasValue,
+	check_array_does_not_have_value,
+	check_array_has_value,
 } from "./src/checkHasValue/main.ts";
 
 export {
-  checkArrayDoesNotHaveValue,
-  checkArrayHasValue,
-  checkIsArray,
-  checkIsEmptyArray,
-  checkIsFirstIteration,
-  checkIsLastIteration,
-  checkIsNotArray,
-  checkIsNotEmptyArray,
-  checkIsNotFirstIteration,
-  checkIsNotLastIteration,
-  checkIsNotSpecificIteration,
-  checkIsSpecificIteration,
+	check_array_does_not_have_value,
+	check_array_has_value,
+	check_is_array,
+	check_is_empty_array,
+	check_is_first_iteration,
+	check_is_last_iteration,
+	check_is_not_array,
+	check_is_not_empty_array,
+	check_is_not_first_iteration,
+	check_is_not_last_iteration,
+	check_is_not_specific_iteration,
+	check_is_specific_iteration,
 };

--- a/packages/array/src/checkArray/main.ts
+++ b/packages/array/src/checkArray/main.ts
@@ -6,34 +6,32 @@
  *
  * @example
  * // Returns true
- * checkIsArray([1, 2, 3]); // The value is an array
+ * check_is_array([1, 2, 3]); // The value is an array
  *
  * @example
  * // Returns false
- * checkIsArray(42); // The value is not an array
+ * check_is_array(42); // The value is not an array
  */
-export const checkIsArray = <T>(value: unknown): value is T[] => {
-  return Array.isArray(value);
+export const check_is_array = <T>(value: unknown): value is T[] => {
+	return Array.isArray(value);
 };
 
 /**
  * Checks if the given value is not an array.
  *
- * This is the inverse of `checkIsArray`.
+ * This is the inverse of `check_is_array`.
  *
  * @param {unknown} value - The value to check.
  * @returns {value is Exclude<T, T[]>} True if the value is not an array, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotArray(42); // The value is not an array
+ * check_is_not_array(42); // The value is not an array
  *
  * @example
  * // Returns false
- * checkIsNotArray([1, 2, 3]); // The value is an array
+ * check_is_not_array([1, 2, 3]); // The value is an array
  */
-export const checkIsNotArray = <T>(
-  value: T,
-): value is Exclude<T, T[]> => {
-  return !checkIsArray(value);
+export const check_is_not_array = <T>(value: T): value is Exclude<T, T[]> => {
+	return !check_is_array(value);
 };

--- a/packages/array/src/checkArray/main.ts
+++ b/packages/array/src/checkArray/main.ts
@@ -13,7 +13,7 @@
  * check_is_array(42); // The value is not an array
  */
 export const check_is_array = <T>(value: unknown): value is T[] => {
-	return Array.isArray(value);
+  return Array.isArray(value);
 };
 
 /**
@@ -33,5 +33,5 @@ export const check_is_array = <T>(value: unknown): value is T[] => {
  * check_is_not_array([1, 2, 3]); // The value is an array
  */
 export const check_is_not_array = <T>(value: T): value is Exclude<T, T[]> => {
-	return !check_is_array(value);
+  return !check_is_array(value);
 };

--- a/packages/array/src/checkArray/test.ts
+++ b/packages/array/src/checkArray/test.ts
@@ -1,48 +1,48 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkIsArray, checkIsNotArray } from "./main.ts";
+import { check_is_array, check_is_not_array } from "./main.ts";
 
-Deno.test("checkIsArray", async (t) => {
-  await t.step("should return true for arrays", () => {
-    assertEquals(checkIsArray([1, 2, 3]), true);
-    assertEquals(checkIsArray([]), true);
-  });
+Deno.test("check_is_array", async (t) => {
+	await t.step("should return true for arrays", () => {
+		assertEquals(check_is_array([1, 2, 3]), true);
+		assertEquals(check_is_array([]), true);
+	});
 
-  await t.step("should return false for non-arrays", () => {
-    assertEquals(checkIsArray("string"), false);
-    assertEquals(checkIsArray(123), false);
-    assertEquals(checkIsArray({ key: "value" }), false);
-    assertEquals(checkIsArray(null), false);
-    assertEquals(checkIsArray(undefined), false);
-  });
+	await t.step("should return false for non-arrays", () => {
+		assertEquals(check_is_array("string"), false);
+		assertEquals(check_is_array(123), false);
+		assertEquals(check_is_array({ key: "value" }), false);
+		assertEquals(check_is_array(null), false);
+		assertEquals(check_is_array(undefined), false);
+	});
 
-  await t.step("should narrow down to array type", () => {
-    type Value = [] | string;
-    const value = {} as Value;
-    if (checkIsArray(value)) {
-      assertType<IsExact<typeof value, []>>(true);
-    }
-  });
+	await t.step("should narrow down to array type", () => {
+		type Value = [] | string;
+		const value = {} as Value;
+		if (check_is_array(value)) {
+			assertType<IsExact<typeof value, []>>(true);
+		}
+	});
 });
 
-Deno.test("checkIsNotArray", async (t) => {
-  await t.step("should return true for non-arrays", () => {
-    assertEquals(checkIsNotArray<string>("string"), true);
-    assertEquals(checkIsNotArray<number>(123), true);
-    assertEquals(checkIsNotArray<object>({ key: "value" }), true);
-    assertEquals(checkIsNotArray<null>(null), true);
-    assertEquals(checkIsNotArray<undefined>(undefined), true);
-  });
+Deno.test("check_is_not_array", async (t) => {
+	await t.step("should return true for non-arrays", () => {
+		assertEquals(check_is_not_array<string>("string"), true);
+		assertEquals(check_is_not_array<number>(123), true);
+		assertEquals(check_is_not_array<object>({ key: "value" }), true);
+		assertEquals(check_is_not_array<null>(null), true);
+		assertEquals(check_is_not_array<undefined>(undefined), true);
+	});
 
-  await t.step("should return false for arrays", () => {
-    assertEquals(checkIsNotArray<number[]>([1, 2, 3]), false);
-    assertEquals(checkIsNotArray<number[]>([]), false);
-  });
+	await t.step("should return false for arrays", () => {
+		assertEquals(check_is_not_array<number[]>([1, 2, 3]), false);
+		assertEquals(check_is_not_array<number[]>([]), false);
+	});
 
-  await t.step("should exclude array type", () => {
-    type Value = [] | string;
-    const value = {} as Value;
-    if (checkIsNotArray(value)) {
-      assertType<IsExact<typeof value, string>>(true);
-    }
-  });
+	await t.step("should exclude array type", () => {
+		type Value = [] | string;
+		const value = {} as Value;
+		if (check_is_not_array(value)) {
+			assertType<IsExact<typeof value, string>>(true);
+		}
+	});
 });

--- a/packages/array/src/checkArray/test.ts
+++ b/packages/array/src/checkArray/test.ts
@@ -2,47 +2,47 @@ import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import { check_is_array, check_is_not_array } from "./main.ts";
 
 Deno.test("check_is_array", async (t) => {
-	await t.step("should return true for arrays", () => {
-		assertEquals(check_is_array([1, 2, 3]), true);
-		assertEquals(check_is_array([]), true);
-	});
+  await t.step("should return true for arrays", () => {
+    assertEquals(check_is_array([1, 2, 3]), true);
+    assertEquals(check_is_array([]), true);
+  });
 
-	await t.step("should return false for non-arrays", () => {
-		assertEquals(check_is_array("string"), false);
-		assertEquals(check_is_array(123), false);
-		assertEquals(check_is_array({ key: "value" }), false);
-		assertEquals(check_is_array(null), false);
-		assertEquals(check_is_array(undefined), false);
-	});
+  await t.step("should return false for non-arrays", () => {
+    assertEquals(check_is_array("string"), false);
+    assertEquals(check_is_array(123), false);
+    assertEquals(check_is_array({ key: "value" }), false);
+    assertEquals(check_is_array(null), false);
+    assertEquals(check_is_array(undefined), false);
+  });
 
-	await t.step("should narrow down to array type", () => {
-		type Value = [] | string;
-		const value = {} as Value;
-		if (check_is_array(value)) {
-			assertType<IsExact<typeof value, []>>(true);
-		}
-	});
+  await t.step("should narrow down to array type", () => {
+    type Value = [] | string;
+    const value = {} as Value;
+    if (check_is_array(value)) {
+      assertType<IsExact<typeof value, []>>(true);
+    }
+  });
 });
 
 Deno.test("check_is_not_array", async (t) => {
-	await t.step("should return true for non-arrays", () => {
-		assertEquals(check_is_not_array<string>("string"), true);
-		assertEquals(check_is_not_array<number>(123), true);
-		assertEquals(check_is_not_array<object>({ key: "value" }), true);
-		assertEquals(check_is_not_array<null>(null), true);
-		assertEquals(check_is_not_array<undefined>(undefined), true);
-	});
+  await t.step("should return true for non-arrays", () => {
+    assertEquals(check_is_not_array<string>("string"), true);
+    assertEquals(check_is_not_array<number>(123), true);
+    assertEquals(check_is_not_array<object>({ key: "value" }), true);
+    assertEquals(check_is_not_array<null>(null), true);
+    assertEquals(check_is_not_array<undefined>(undefined), true);
+  });
 
-	await t.step("should return false for arrays", () => {
-		assertEquals(check_is_not_array<number[]>([1, 2, 3]), false);
-		assertEquals(check_is_not_array<number[]>([]), false);
-	});
+  await t.step("should return false for arrays", () => {
+    assertEquals(check_is_not_array<number[]>([1, 2, 3]), false);
+    assertEquals(check_is_not_array<number[]>([]), false);
+  });
 
-	await t.step("should exclude array type", () => {
-		type Value = [] | string;
-		const value = {} as Value;
-		if (check_is_not_array(value)) {
-			assertType<IsExact<typeof value, string>>(true);
-		}
-	});
+  await t.step("should exclude array type", () => {
+    type Value = [] | string;
+    const value = {} as Value;
+    if (check_is_not_array(value)) {
+      assertType<IsExact<typeof value, string>>(true);
+    }
+  });
 });

--- a/packages/array/src/checkEmptyArray/main.ts
+++ b/packages/array/src/checkEmptyArray/main.ts
@@ -6,34 +6,34 @@
  *
  * @example
  * // Returns true
- * checkIsEmptyArray([]); // The array is empty
+ * check_is_empty_array([]); // The array is empty
  *
  * @example
  * // Returns false
- * checkIsEmptyArray([1, 2, 3]); // The array is not empty
+ * check_is_empty_array([1, 2, 3]); // The array is not empty
  */
-export const checkIsEmptyArray = (array: unknown[]): array is [] => {
-  return array.length === 0;
+export const check_is_empty_array = (array: unknown[]): array is [] => {
+	return array.length === 0;
 };
 
 /**
  * Checks if the given array is not empty.
  *
- * This is the inverse of `checkIsEmptyArray`.
+ * This is the inverse of `check_is_empty_array`.
  *
  * @param {T} array - The array to check.
  * @returns {array is Exclude<T, []>} True if the array is not empty, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotEmptyArray([1, 2, 3]); // The array is not empty
+ * check_is_not_empty_array([1, 2, 3]); // The array is not empty
  *
  * @example
  * // Returns false
- * checkIsNotEmptyArray([]); // The array is empty
+ * check_is_not_empty_array([]); // The array is empty
  */
-export const checkIsNotEmptyArray = <T extends unknown[]>(
-  array: T,
+export const check_is_not_empty_array = <T extends unknown[]>(
+	array: T
 ): array is Exclude<T, []> => {
-  return !checkIsEmptyArray(array);
+	return !check_is_empty_array(array);
 };

--- a/packages/array/src/checkEmptyArray/main.ts
+++ b/packages/array/src/checkEmptyArray/main.ts
@@ -13,7 +13,7 @@
  * check_is_empty_array([1, 2, 3]); // The array is not empty
  */
 export const check_is_empty_array = (array: unknown[]): array is [] => {
-	return array.length === 0;
+  return array.length === 0;
 };
 
 /**
@@ -33,7 +33,7 @@ export const check_is_empty_array = (array: unknown[]): array is [] => {
  * check_is_not_empty_array([]); // The array is empty
  */
 export const check_is_not_empty_array = <T extends unknown[]>(
-	array: T
+  array: T,
 ): array is Exclude<T, []> => {
-	return !check_is_empty_array(array);
+  return !check_is_empty_array(array);
 };

--- a/packages/array/src/checkEmptyArray/test.ts
+++ b/packages/array/src/checkEmptyArray/test.ts
@@ -1,39 +1,39 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkIsEmptyArray, checkIsNotEmptyArray } from "./main.ts";
+import { check_is_empty_array, check_is_not_empty_array } from "./main.ts";
 
-Deno.test("checkIsEmptyArray", async (t) => {
-  await t.step("should return true for empty arrays", () => {
-    assertEquals(checkIsEmptyArray([]), true);
-  });
+Deno.test("check_is_empty_array", async (t) => {
+	await t.step("should return true for empty arrays", () => {
+		assertEquals(check_is_empty_array([]), true);
+	});
 
-  await t.step("should return false for non-empty arrays", () => {
-    assertEquals(checkIsEmptyArray([1, 2, 3]), false);
-    assertEquals(checkIsEmptyArray(["a", "b", "c"]), false);
-  });
+	await t.step("should return false for non-empty arrays", () => {
+		assertEquals(check_is_empty_array([1, 2, 3]), false);
+		assertEquals(check_is_empty_array(["a", "b", "c"]), false);
+	});
 
-  await t.step("should narrow down to an empty array type", () => {
-    const value = {} as string[];
-    if (checkIsEmptyArray(value)) {
-      assertType<IsExact<typeof value, []>>(true);
-    }
-  });
+	await t.step("should narrow down to an empty array type", () => {
+		const value = {} as string[];
+		if (check_is_empty_array(value)) {
+			assertType<IsExact<typeof value, []>>(true);
+		}
+	});
 });
 
-Deno.test("checkIsNotEmptyArray", async (t) => {
-  await t.step("should return true for non-empty arrays", () => {
-    assertEquals(checkIsNotEmptyArray([1, 2, 3]), true);
-    assertEquals(checkIsNotEmptyArray(["a", "b", "c"]), true);
-  });
+Deno.test("check_is_not_empty_array", async (t) => {
+	await t.step("should return true for non-empty arrays", () => {
+		assertEquals(check_is_not_empty_array([1, 2, 3]), true);
+		assertEquals(check_is_not_empty_array(["a", "b", "c"]), true);
+	});
 
-  await t.step("should return false for empty arrays", () => {
-    assertEquals(checkIsNotEmptyArray([]), false);
-  });
+	await t.step("should return false for empty arrays", () => {
+		assertEquals(check_is_not_empty_array([]), false);
+	});
 
-  await t.step("should exclude empty array type", () => {
-    type Value = string[] | [];
-    const value = {} as Value;
-    if (checkIsNotEmptyArray(value)) {
-      assertType<IsExact<typeof value, string[]>>(true);
-    }
-  });
+	await t.step("should exclude empty array type", () => {
+		type Value = string[] | [];
+		const value = {} as Value;
+		if (check_is_not_empty_array(value)) {
+			assertType<IsExact<typeof value, string[]>>(true);
+		}
+	});
 });

--- a/packages/array/src/checkEmptyArray/test.ts
+++ b/packages/array/src/checkEmptyArray/test.ts
@@ -2,38 +2,38 @@ import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import { check_is_empty_array, check_is_not_empty_array } from "./main.ts";
 
 Deno.test("check_is_empty_array", async (t) => {
-	await t.step("should return true for empty arrays", () => {
-		assertEquals(check_is_empty_array([]), true);
-	});
+  await t.step("should return true for empty arrays", () => {
+    assertEquals(check_is_empty_array([]), true);
+  });
 
-	await t.step("should return false for non-empty arrays", () => {
-		assertEquals(check_is_empty_array([1, 2, 3]), false);
-		assertEquals(check_is_empty_array(["a", "b", "c"]), false);
-	});
+  await t.step("should return false for non-empty arrays", () => {
+    assertEquals(check_is_empty_array([1, 2, 3]), false);
+    assertEquals(check_is_empty_array(["a", "b", "c"]), false);
+  });
 
-	await t.step("should narrow down to an empty array type", () => {
-		const value = {} as string[];
-		if (check_is_empty_array(value)) {
-			assertType<IsExact<typeof value, []>>(true);
-		}
-	});
+  await t.step("should narrow down to an empty array type", () => {
+    const value = {} as string[];
+    if (check_is_empty_array(value)) {
+      assertType<IsExact<typeof value, []>>(true);
+    }
+  });
 });
 
 Deno.test("check_is_not_empty_array", async (t) => {
-	await t.step("should return true for non-empty arrays", () => {
-		assertEquals(check_is_not_empty_array([1, 2, 3]), true);
-		assertEquals(check_is_not_empty_array(["a", "b", "c"]), true);
-	});
+  await t.step("should return true for non-empty arrays", () => {
+    assertEquals(check_is_not_empty_array([1, 2, 3]), true);
+    assertEquals(check_is_not_empty_array(["a", "b", "c"]), true);
+  });
 
-	await t.step("should return false for empty arrays", () => {
-		assertEquals(check_is_not_empty_array([]), false);
-	});
+  await t.step("should return false for empty arrays", () => {
+    assertEquals(check_is_not_empty_array([]), false);
+  });
 
-	await t.step("should exclude empty array type", () => {
-		type Value = string[] | [];
-		const value = {} as Value;
-		if (check_is_not_empty_array(value)) {
-			assertType<IsExact<typeof value, string[]>>(true);
-		}
-	});
+  await t.step("should exclude empty array type", () => {
+    type Value = string[] | [];
+    const value = {} as Value;
+    if (check_is_not_empty_array(value)) {
+      assertType<IsExact<typeof value, string[]>>(true);
+    }
+  });
 });

--- a/packages/array/src/checkFirstIteration/main.ts
+++ b/packages/array/src/checkFirstIteration/main.ts
@@ -13,7 +13,7 @@
  * check_is_first_iteration(1); // The index is not 0, not the first iteration
  */
 export const check_is_first_iteration = (index: number): boolean => {
-	return index === 0;
+  return index === 0;
 };
 
 /**
@@ -33,5 +33,5 @@ export const check_is_first_iteration = (index: number): boolean => {
  * check_is_not_first_iteration(0); // The index is 0, indicating the first iteration
  */
 export const check_is_not_first_iteration = (index: number): boolean => {
-	return !check_is_first_iteration(index);
+  return !check_is_first_iteration(index);
 };

--- a/packages/array/src/checkFirstIteration/main.ts
+++ b/packages/array/src/checkFirstIteration/main.ts
@@ -6,32 +6,32 @@
  *
  * @example
  * // Returns true
- * checkIsFirstIteration(0); // The index is 0, indicating the first iteration
+ * check_is_first_iteration(0); // The index is 0, indicating the first iteration
  *
  * @example
  * // Returns false
- * checkIsFirstIteration(1); // The index is not 0, not the first iteration
+ * check_is_first_iteration(1); // The index is not 0, not the first iteration
  */
-export const checkIsFirstIteration = (index: number): boolean => {
-  return index === 0;
+export const check_is_first_iteration = (index: number): boolean => {
+	return index === 0;
 };
 
 /**
  * Checks if the given index does not correspond to the first iteration.
  *
- * This is the inverse of `checkIsFirstIteration`.
+ * This is the inverse of `check_is_first_iteration`.
  *
  * @param {number} index - The index to check.
  * @returns {boolean} True if the index is not 0, indicating it is not the first iteration, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotFirstIteration(1); // The index is not 0, not the first iteration
+ * check_is_not_first_iteration(1); // The index is not 0, not the first iteration
  *
  * @example
  * // Returns false
- * checkIsNotFirstIteration(0); // The index is 0, indicating the first iteration
+ * check_is_not_first_iteration(0); // The index is 0, indicating the first iteration
  */
-export const checkIsNotFirstIteration = (index: number): boolean => {
-  return !checkIsFirstIteration(index);
+export const check_is_not_first_iteration = (index: number): boolean => {
+	return !check_is_first_iteration(index);
 };

--- a/packages/array/src/checkFirstIteration/test.ts
+++ b/packages/array/src/checkFirstIteration/test.ts
@@ -1,27 +1,27 @@
 import { assertEquals } from "../../deps.ts";
 import {
-	check_is_first_iteration,
-	check_is_not_first_iteration,
+  check_is_first_iteration,
+  check_is_not_first_iteration,
 } from "./main.ts";
 
 Deno.test("check_is_first_iteration", async (t) => {
-	await t.step("should return true for the first iteration", () => {
-		assertEquals(check_is_first_iteration(0), true);
-	});
+  await t.step("should return true for the first iteration", () => {
+    assertEquals(check_is_first_iteration(0), true);
+  });
 
-	await t.step("should return false for non-first iterations", () => {
-		assertEquals(check_is_first_iteration(1), false);
-		assertEquals(check_is_first_iteration(10), false);
-	});
+  await t.step("should return false for non-first iterations", () => {
+    assertEquals(check_is_first_iteration(1), false);
+    assertEquals(check_is_first_iteration(10), false);
+  });
 });
 
 Deno.test("check_is_not_first_iteration", async (t) => {
-	await t.step("should return true for non-first iterations", () => {
-		assertEquals(check_is_not_first_iteration(1), true);
-		assertEquals(check_is_not_first_iteration(10), true);
-	});
+  await t.step("should return true for non-first iterations", () => {
+    assertEquals(check_is_not_first_iteration(1), true);
+    assertEquals(check_is_not_first_iteration(10), true);
+  });
 
-	await t.step("should return false for the first iteration", () => {
-		assertEquals(check_is_not_first_iteration(0), false);
-	});
+  await t.step("should return false for the first iteration", () => {
+    assertEquals(check_is_not_first_iteration(0), false);
+  });
 });

--- a/packages/array/src/checkFirstIteration/test.ts
+++ b/packages/array/src/checkFirstIteration/test.ts
@@ -1,24 +1,27 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsFirstIteration, checkIsNotFirstIteration } from "./main.ts";
+import {
+	check_is_first_iteration,
+	check_is_not_first_iteration,
+} from "./main.ts";
 
-Deno.test("checkIsFirstIteration", async (t) => {
-  await t.step("should return true for the first iteration", () => {
-    assertEquals(checkIsFirstIteration(0), true);
-  });
+Deno.test("check_is_first_iteration", async (t) => {
+	await t.step("should return true for the first iteration", () => {
+		assertEquals(check_is_first_iteration(0), true);
+	});
 
-  await t.step("should return false for non-first iterations", () => {
-    assertEquals(checkIsFirstIteration(1), false);
-    assertEquals(checkIsFirstIteration(10), false);
-  });
+	await t.step("should return false for non-first iterations", () => {
+		assertEquals(check_is_first_iteration(1), false);
+		assertEquals(check_is_first_iteration(10), false);
+	});
 });
 
-Deno.test("checkIsNotFirstIteration", async (t) => {
-  await t.step("should return true for non-first iterations", () => {
-    assertEquals(checkIsNotFirstIteration(1), true);
-    assertEquals(checkIsNotFirstIteration(10), true);
-  });
+Deno.test("check_is_not_first_iteration", async (t) => {
+	await t.step("should return true for non-first iterations", () => {
+		assertEquals(check_is_not_first_iteration(1), true);
+		assertEquals(check_is_not_first_iteration(10), true);
+	});
 
-  await t.step("should return false for the first iteration", () => {
-    assertEquals(checkIsNotFirstIteration(0), false);
-  });
+	await t.step("should return false for the first iteration", () => {
+		assertEquals(check_is_not_first_iteration(0), false);
+	});
 });

--- a/packages/array/src/checkHasValue/main.ts
+++ b/packages/array/src/checkHasValue/main.ts
@@ -14,7 +14,7 @@
  * check_array_has_value([1, 2, 3], 4); // The array does not contain the value 4
  */
 export const check_array_has_value = <T>(array: T[], value: T): boolean => {
-	return array.includes(value);
+  return array.includes(value);
 };
 
 /**
@@ -35,8 +35,8 @@ export const check_array_has_value = <T>(array: T[], value: T): boolean => {
  * check_array_does_not_have_value([1, 2, 3], 2); // The array contains the value 2
  */
 export const check_array_does_not_have_value = <T>(
-	array: T[],
-	value: T
+  array: T[],
+  value: T,
 ): boolean => {
-	return !check_array_has_value(array, value);
+  return !check_array_has_value(array, value);
 };

--- a/packages/array/src/checkHasValue/main.ts
+++ b/packages/array/src/checkHasValue/main.ts
@@ -7,20 +7,20 @@
  *
  * @example
  * // Returns true
- * checkArrayHasValue([1, 2, 3], 2); // The array contains the value 2
+ * check_array_has_value([1, 2, 3], 2); // The array contains the value 2
  *
  * @example
  * // Returns false
- * checkArrayHasValue([1, 2, 3], 4); // The array does not contain the value 4
+ * check_array_has_value([1, 2, 3], 4); // The array does not contain the value 4
  */
-export const checkArrayHasValue = <T>(array: T[], value: T): boolean => {
-  return array.includes(value);
+export const check_array_has_value = <T>(array: T[], value: T): boolean => {
+	return array.includes(value);
 };
 
 /**
  * Checks if an array does not contain a specific value.
  *
- * This is the inverse of `checkArrayContainsValue`.
+ * This is the inverse of `check_array_has_value`.
  *
  * @param {T[]} array - The array to check.
  * @param {T} value - The value to search for in the array.
@@ -28,15 +28,15 @@ export const checkArrayHasValue = <T>(array: T[], value: T): boolean => {
  *
  * @example
  * // Returns true
- * checkArrayDoesNotHaveValue([1, 2, 3], 4); // The array does not contain the value 4
+ * check_array_does_not_have_value([1, 2, 3], 4); // The array does not contain the value 4
  *
  * @example
  * // Returns false
- * checkArrayDoesNotHaveValue([1, 2, 3], 2); // The array contains the value 2
+ * check_array_does_not_have_value([1, 2, 3], 2); // The array contains the value 2
  */
-export const checkArrayDoesNotHaveValue = <T>(
-  array: T[],
-  value: T,
+export const check_array_does_not_have_value = <T>(
+	array: T[],
+	value: T
 ): boolean => {
-  return !checkArrayHasValue(array, value);
+	return !check_array_has_value(array, value);
 };

--- a/packages/array/src/checkHasValue/test.ts
+++ b/packages/array/src/checkHasValue/test.ts
@@ -1,27 +1,29 @@
 import { assertEquals } from "../../deps.ts";
-import { checkArrayDoesNotHaveValue, checkArrayHasValue } from "./main.ts";
+import {
+	check_array_does_not_have_value,
+	check_array_has_value,
+} from "./main.ts";
 
-Deno.test("checkHaveValueInArray", async (t) => {
-  await t.step("should return true when the value is in the array", () => {
-    assertEquals(checkArrayHasValue([1, 2, 3, 4], 3), true);
-    assertEquals(checkArrayHasValue(["a", "b", "c"], "b"), true);
-  });
+Deno.test("check_array_has_value", async (t) => {
+	await t.step("should return true when the value is in the array", () => {
+		assertEquals(check_array_has_value([1, 2, 3, 4], 3), true);
+		assertEquals(check_array_has_value(["a", "b", "c"], "b"), true);
+	});
 
-  await t.step("should return false when the value is not in the array", () => {
-    assertEquals(checkArrayHasValue([1, 2, 3, 4], 5), false);
-    assertEquals(checkArrayHasValue(["a", "b", "c"], "d"), false);
-  });
+	await t.step("should return false when the value is not in the array", () => {
+		assertEquals(check_array_has_value([1, 2, 3, 4], 5), false);
+		assertEquals(check_array_has_value(["a", "b", "c"], "d"), false);
+	});
 });
 
-// Test for checkNotHaveValueInArray
-Deno.test("checkNotHaveValueInArray", async (t) => {
-  await t.step("should return true when the value is not in the array", () => {
-    assertEquals(checkArrayDoesNotHaveValue([1, 2, 3, 4], 5), true);
-    assertEquals(checkArrayDoesNotHaveValue(["a", "b", "c"], "d"), true);
-  });
+Deno.test("check_array_does_not_have_value", async (t) => {
+	await t.step("should return true when the value is not in the array", () => {
+		assertEquals(check_array_does_not_have_value([1, 2, 3, 4], 5), true);
+		assertEquals(check_array_does_not_have_value(["a", "b", "c"], "d"), true);
+	});
 
-  await t.step("should return false when the value is in the array", () => {
-    assertEquals(checkArrayDoesNotHaveValue([1, 2, 3, 4], 3), false);
-    assertEquals(checkArrayDoesNotHaveValue(["a", "b", "c"], "b"), false);
-  });
+	await t.step("should return false when the value is in the array", () => {
+		assertEquals(check_array_does_not_have_value([1, 2, 3, 4], 3), false);
+		assertEquals(check_array_does_not_have_value(["a", "b", "c"], "b"), false);
+	});
 });

--- a/packages/array/src/checkHasValue/test.ts
+++ b/packages/array/src/checkHasValue/test.ts
@@ -1,29 +1,29 @@
 import { assertEquals } from "../../deps.ts";
 import {
-	check_array_does_not_have_value,
-	check_array_has_value,
+  check_array_does_not_have_value,
+  check_array_has_value,
 } from "./main.ts";
 
 Deno.test("check_array_has_value", async (t) => {
-	await t.step("should return true when the value is in the array", () => {
-		assertEquals(check_array_has_value([1, 2, 3, 4], 3), true);
-		assertEquals(check_array_has_value(["a", "b", "c"], "b"), true);
-	});
+  await t.step("should return true when the value is in the array", () => {
+    assertEquals(check_array_has_value([1, 2, 3, 4], 3), true);
+    assertEquals(check_array_has_value(["a", "b", "c"], "b"), true);
+  });
 
-	await t.step("should return false when the value is not in the array", () => {
-		assertEquals(check_array_has_value([1, 2, 3, 4], 5), false);
-		assertEquals(check_array_has_value(["a", "b", "c"], "d"), false);
-	});
+  await t.step("should return false when the value is not in the array", () => {
+    assertEquals(check_array_has_value([1, 2, 3, 4], 5), false);
+    assertEquals(check_array_has_value(["a", "b", "c"], "d"), false);
+  });
 });
 
 Deno.test("check_array_does_not_have_value", async (t) => {
-	await t.step("should return true when the value is not in the array", () => {
-		assertEquals(check_array_does_not_have_value([1, 2, 3, 4], 5), true);
-		assertEquals(check_array_does_not_have_value(["a", "b", "c"], "d"), true);
-	});
+  await t.step("should return true when the value is not in the array", () => {
+    assertEquals(check_array_does_not_have_value([1, 2, 3, 4], 5), true);
+    assertEquals(check_array_does_not_have_value(["a", "b", "c"], "d"), true);
+  });
 
-	await t.step("should return false when the value is in the array", () => {
-		assertEquals(check_array_does_not_have_value([1, 2, 3, 4], 3), false);
-		assertEquals(check_array_does_not_have_value(["a", "b", "c"], "b"), false);
-	});
+  await t.step("should return false when the value is in the array", () => {
+    assertEquals(check_array_does_not_have_value([1, 2, 3, 4], 3), false);
+    assertEquals(check_array_does_not_have_value(["a", "b", "c"], "b"), false);
+  });
 });

--- a/packages/array/src/checkLastIteration/main.ts
+++ b/packages/array/src/checkLastIteration/main.ts
@@ -14,10 +14,10 @@
  * check_is_last_iteration(1, [10, 20, 30]); // The index 1 is not the last iteration
  */
 export const check_is_last_iteration = (
-	index: number,
-	array: unknown[]
+  index: number,
+  array: unknown[],
 ): boolean => {
-	return index === array.length - 1;
+  return index === array.length - 1;
 };
 
 /**
@@ -38,8 +38,8 @@ export const check_is_last_iteration = (
  * check_is_not_last_iteration(2, [10, 20, 30]); // The index 2 is the last iteration
  */
 export const check_is_not_last_iteration = (
-	index: number,
-	array: unknown[]
+  index: number,
+  array: unknown[],
 ): boolean => {
-	return !check_is_last_iteration(index, array);
+  return !check_is_last_iteration(index, array);
 };

--- a/packages/array/src/checkLastIteration/main.ts
+++ b/packages/array/src/checkLastIteration/main.ts
@@ -7,23 +7,23 @@
  *
  * @example
  * // Returns true
- * checkIsLastIteration(2, [10, 20, 30]); // The index 2 is the last iteration
+ * check_is_last_iteration(2, [10, 20, 30]); // The index 2 is the last iteration
  *
  * @example
  * // Returns false
- * checkIsLastIteration(1, [10, 20, 30]); // The index 1 is not the last iteration
+ * check_is_last_iteration(1, [10, 20, 30]); // The index 1 is not the last iteration
  */
-export const checkIsLastIteration = (
-  index: number,
-  array: unknown[],
+export const check_is_last_iteration = (
+	index: number,
+	array: unknown[]
 ): boolean => {
-  return index === array.length - 1;
+	return index === array.length - 1;
 };
 
 /**
  * Checks if the given index is not the last iteration in the array.
  *
- * This is the inverse of `checkIsLastIteration`.
+ * This is the inverse of `check_is_last_iteration`.
  *
  * @param {number} index - The index to check.
  * @param {unknown[]} array - The array to check against.
@@ -31,15 +31,15 @@ export const checkIsLastIteration = (
  *
  * @example
  * // Returns true
- * checkIsNotLastIteration(1, [10, 20, 30]); // The index 1 is not the last iteration
+ * check_is_not_last_iteration(1, [10, 20, 30]); // The index 1 is not the last iteration
  *
  * @example
  * // Returns false
- * checkIsNotLastIteration(2, [10, 20, 30]); // The index 2 is the last iteration
+ * check_is_not_last_iteration(2, [10, 20, 30]); // The index 2 is the last iteration
  */
-export const checkIsNotLastIteration = (
-  index: number,
-  array: unknown[],
+export const check_is_not_last_iteration = (
+	index: number,
+	array: unknown[]
 ): boolean => {
-  return !checkIsLastIteration(index, array);
+	return !check_is_last_iteration(index, array);
 };

--- a/packages/array/src/checkLastIteration/test.ts
+++ b/packages/array/src/checkLastIteration/test.ts
@@ -1,30 +1,33 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsLastIteration, checkIsNotLastIteration } from "./main.ts";
+import {
+	check_is_last_iteration,
+	check_is_not_last_iteration,
+} from "./main.ts";
 
-Deno.test("checkIsLastIteration", async (t) => {
-  const array = [1, 2, 3, 4, 5];
+Deno.test("check_is_last_iteration", async (t) => {
+	const array = [1, 2, 3, 4, 5];
 
-  await t.step("should return true for the last iteration", () => {
-    assertEquals(checkIsLastIteration(array.length - 1, array), true);
-  });
+	await t.step("should return true for the last iteration", () => {
+		assertEquals(check_is_last_iteration(array.length - 1, array), true);
+	});
 
-  await t.step("should return false for non-last iterations", () => {
-    assertEquals(checkIsLastIteration(0, array), false);
-    assertEquals(checkIsLastIteration(2, array), false);
-    assertEquals(checkIsLastIteration(3, array), false);
-  });
+	await t.step("should return false for non-last iterations", () => {
+		assertEquals(check_is_last_iteration(0, array), false);
+		assertEquals(check_is_last_iteration(2, array), false);
+		assertEquals(check_is_last_iteration(3, array), false);
+	});
 });
 
-Deno.test("checkIsNotLastIteration", async (t) => {
-  const array = [1, 2, 3, 4, 5];
+Deno.test("check_is_not_last_iteration", async (t) => {
+	const array = [1, 2, 3, 4, 5];
 
-  await t.step("should return true for non-last iterations", () => {
-    assertEquals(checkIsNotLastIteration(0, array), true);
-    assertEquals(checkIsNotLastIteration(2, array), true);
-    assertEquals(checkIsNotLastIteration(3, array), true);
-  });
+	await t.step("should return true for non-last iterations", () => {
+		assertEquals(check_is_not_last_iteration(0, array), true);
+		assertEquals(check_is_not_last_iteration(2, array), true);
+		assertEquals(check_is_not_last_iteration(3, array), true);
+	});
 
-  await t.step("should return false for the last iteration", () => {
-    assertEquals(checkIsNotLastIteration(array.length - 1, array), false);
-  });
+	await t.step("should return false for the last iteration", () => {
+		assertEquals(check_is_not_last_iteration(array.length - 1, array), false);
+	});
 });

--- a/packages/array/src/checkLastIteration/test.ts
+++ b/packages/array/src/checkLastIteration/test.ts
@@ -1,33 +1,33 @@
 import { assertEquals } from "../../deps.ts";
 import {
-	check_is_last_iteration,
-	check_is_not_last_iteration,
+  check_is_last_iteration,
+  check_is_not_last_iteration,
 } from "./main.ts";
 
 Deno.test("check_is_last_iteration", async (t) => {
-	const array = [1, 2, 3, 4, 5];
+  const array = [1, 2, 3, 4, 5];
 
-	await t.step("should return true for the last iteration", () => {
-		assertEquals(check_is_last_iteration(array.length - 1, array), true);
-	});
+  await t.step("should return true for the last iteration", () => {
+    assertEquals(check_is_last_iteration(array.length - 1, array), true);
+  });
 
-	await t.step("should return false for non-last iterations", () => {
-		assertEquals(check_is_last_iteration(0, array), false);
-		assertEquals(check_is_last_iteration(2, array), false);
-		assertEquals(check_is_last_iteration(3, array), false);
-	});
+  await t.step("should return false for non-last iterations", () => {
+    assertEquals(check_is_last_iteration(0, array), false);
+    assertEquals(check_is_last_iteration(2, array), false);
+    assertEquals(check_is_last_iteration(3, array), false);
+  });
 });
 
 Deno.test("check_is_not_last_iteration", async (t) => {
-	const array = [1, 2, 3, 4, 5];
+  const array = [1, 2, 3, 4, 5];
 
-	await t.step("should return true for non-last iterations", () => {
-		assertEquals(check_is_not_last_iteration(0, array), true);
-		assertEquals(check_is_not_last_iteration(2, array), true);
-		assertEquals(check_is_not_last_iteration(3, array), true);
-	});
+  await t.step("should return true for non-last iterations", () => {
+    assertEquals(check_is_not_last_iteration(0, array), true);
+    assertEquals(check_is_not_last_iteration(2, array), true);
+    assertEquals(check_is_not_last_iteration(3, array), true);
+  });
 
-	await t.step("should return false for the last iteration", () => {
-		assertEquals(check_is_not_last_iteration(array.length - 1, array), false);
-	});
+  await t.step("should return false for the last iteration", () => {
+    assertEquals(check_is_not_last_iteration(array.length - 1, array), false);
+  });
 });

--- a/packages/array/src/checkSpecificIteration/main.ts
+++ b/packages/array/src/checkSpecificIteration/main.ts
@@ -14,10 +14,10 @@
  * check_is_specific_iteration(2, 3); // The current index is 2 and does not match the target index
  */
 export const check_is_specific_iteration = (
-	index: number,
-	targetIndex: number
+  index: number,
+  targetIndex: number,
 ): boolean => {
-	return index === targetIndex;
+  return index === targetIndex;
 };
 
 /**
@@ -38,8 +38,8 @@ export const check_is_specific_iteration = (
  * check_is_not_specific_iteration(3, 3); // The current index is 3 and matches the target index
  */
 export const check_is_not_specific_iteration = (
-	index: number,
-	targetIndex: number
+  index: number,
+  targetIndex: number,
 ): boolean => {
-	return !check_is_specific_iteration(index, targetIndex);
+  return !check_is_specific_iteration(index, targetIndex);
 };

--- a/packages/array/src/checkSpecificIteration/main.ts
+++ b/packages/array/src/checkSpecificIteration/main.ts
@@ -7,23 +7,23 @@
  *
  * @example
  * // Returns true
- * checkIsSpecificIteration(3, 3); // The current index is 3 and matches the target index
+ * check_is_specific_iteration(3, 3); // The current index is 3 and matches the target index
  *
  * @example
  * // Returns false
- * checkIsSpecificIteration(2, 3); // The current index is 2 and does not match the target index
+ * check_is_specific_iteration(2, 3); // The current index is 2 and does not match the target index
  */
-export const checkIsSpecificIteration = (
-  index: number,
-  targetIndex: number,
+export const check_is_specific_iteration = (
+	index: number,
+	targetIndex: number
 ): boolean => {
-  return index === targetIndex;
+	return index === targetIndex;
 };
 
 /**
  * Checks if the current iteration index does not match a specific target index.
  *
- * This is the inverse of `checkIsSpecificIteration`.
+ * This is the inverse of `check_is_specific_iteration`.
  *
  * @param {number} index - The current iteration index.
  * @param {number} targetIndex - The target index to check against.
@@ -31,15 +31,15 @@ export const checkIsSpecificIteration = (
  *
  * @example
  * // Returns true
- * checkIsNotSpecificIteration(2, 3); // The current index is 2 and does not match the target index
+ * check_is_not_specific_iteration(2, 3); // The current index is 2 and does not match the target index
  *
  * @example
  * // Returns false
- * checkIsNotSpecificIteration(3, 3); // The current index is 3 and matches the target index
+ * check_is_not_specific_iteration(3, 3); // The current index is 3 and matches the target index
  */
-export const checkIsNotSpecificIteration = (
-  index: number,
-  targetIndex: number,
+export const check_is_not_specific_iteration = (
+	index: number,
+	targetIndex: number
 ): boolean => {
-  return !checkIsSpecificIteration(index, targetIndex);
+	return !check_is_specific_iteration(index, targetIndex);
 };

--- a/packages/array/src/checkSpecificIteration/test.ts
+++ b/packages/array/src/checkSpecificIteration/test.ts
@@ -1,39 +1,39 @@
 import { assertEquals } from "../../deps.ts";
 import {
-	check_is_not_specific_iteration,
-	check_is_specific_iteration,
+  check_is_not_specific_iteration,
+  check_is_specific_iteration,
 } from "./main.ts";
 
 Deno.test("check_is_specific_iteration", async (t) => {
-	await t.step("should return true when index matches targetIndex", () => {
-		assertEquals(check_is_specific_iteration(2, 2), true);
-		assertEquals(check_is_specific_iteration(0, 0), true);
-		assertEquals(check_is_specific_iteration(5, 5), true);
-	});
+  await t.step("should return true when index matches targetIndex", () => {
+    assertEquals(check_is_specific_iteration(2, 2), true);
+    assertEquals(check_is_specific_iteration(0, 0), true);
+    assertEquals(check_is_specific_iteration(5, 5), true);
+  });
 
-	await t.step(
-		"should return false when index does not match targetIndex",
-		() => {
-			assertEquals(check_is_specific_iteration(1, 2), false);
-			assertEquals(check_is_specific_iteration(3, 2), false);
-			assertEquals(check_is_specific_iteration(4, 0), false);
-		}
-	);
+  await t.step(
+    "should return false when index does not match targetIndex",
+    () => {
+      assertEquals(check_is_specific_iteration(1, 2), false);
+      assertEquals(check_is_specific_iteration(3, 2), false);
+      assertEquals(check_is_specific_iteration(4, 0), false);
+    },
+  );
 });
 
 Deno.test("check_is_not_specific_iteration", async (t) => {
-	await t.step(
-		"should return true when index does not match targetIndex",
-		() => {
-			assertEquals(check_is_not_specific_iteration(1, 2), true);
-			assertEquals(check_is_not_specific_iteration(3, 2), true);
-			assertEquals(check_is_not_specific_iteration(4, 0), true);
-		}
-	);
+  await t.step(
+    "should return true when index does not match targetIndex",
+    () => {
+      assertEquals(check_is_not_specific_iteration(1, 2), true);
+      assertEquals(check_is_not_specific_iteration(3, 2), true);
+      assertEquals(check_is_not_specific_iteration(4, 0), true);
+    },
+  );
 
-	await t.step("should return false when index matches targetIndex", () => {
-		assertEquals(check_is_not_specific_iteration(2, 2), false);
-		assertEquals(check_is_not_specific_iteration(0, 0), false);
-		assertEquals(check_is_not_specific_iteration(5, 5), false);
-	});
+  await t.step("should return false when index matches targetIndex", () => {
+    assertEquals(check_is_not_specific_iteration(2, 2), false);
+    assertEquals(check_is_not_specific_iteration(0, 0), false);
+    assertEquals(check_is_not_specific_iteration(5, 5), false);
+  });
 });

--- a/packages/array/src/checkSpecificIteration/test.ts
+++ b/packages/array/src/checkSpecificIteration/test.ts
@@ -1,39 +1,39 @@
 import { assertEquals } from "../../deps.ts";
 import {
-  checkIsNotSpecificIteration,
-  checkIsSpecificIteration,
+	check_is_not_specific_iteration,
+	check_is_specific_iteration,
 } from "./main.ts";
 
-Deno.test("checkIsSpecificIteration", async (t) => {
-  await t.step("should return true when index matches targetIndex", () => {
-    assertEquals(checkIsSpecificIteration(2, 2), true);
-    assertEquals(checkIsSpecificIteration(0, 0), true);
-    assertEquals(checkIsSpecificIteration(5, 5), true);
-  });
+Deno.test("check_is_specific_iteration", async (t) => {
+	await t.step("should return true when index matches targetIndex", () => {
+		assertEquals(check_is_specific_iteration(2, 2), true);
+		assertEquals(check_is_specific_iteration(0, 0), true);
+		assertEquals(check_is_specific_iteration(5, 5), true);
+	});
 
-  await t.step(
-    "should return false when index does not match targetIndex",
-    () => {
-      assertEquals(checkIsSpecificIteration(1, 2), false);
-      assertEquals(checkIsSpecificIteration(3, 2), false);
-      assertEquals(checkIsSpecificIteration(4, 0), false);
-    },
-  );
+	await t.step(
+		"should return false when index does not match targetIndex",
+		() => {
+			assertEquals(check_is_specific_iteration(1, 2), false);
+			assertEquals(check_is_specific_iteration(3, 2), false);
+			assertEquals(check_is_specific_iteration(4, 0), false);
+		}
+	);
 });
 
-Deno.test("checkIsNotSpecificIteration", async (t) => {
-  await t.step(
-    "should return true when index does not match targetIndex",
-    () => {
-      assertEquals(checkIsNotSpecificIteration(1, 2), true);
-      assertEquals(checkIsNotSpecificIteration(3, 2), true);
-      assertEquals(checkIsNotSpecificIteration(4, 0), true);
-    },
-  );
+Deno.test("check_is_not_specific_iteration", async (t) => {
+	await t.step(
+		"should return true when index does not match targetIndex",
+		() => {
+			assertEquals(check_is_not_specific_iteration(1, 2), true);
+			assertEquals(check_is_not_specific_iteration(3, 2), true);
+			assertEquals(check_is_not_specific_iteration(4, 0), true);
+		}
+	);
 
-  await t.step("should return false when index matches targetIndex", () => {
-    assertEquals(checkIsNotSpecificIteration(2, 2), false);
-    assertEquals(checkIsNotSpecificIteration(0, 0), false);
-    assertEquals(checkIsNotSpecificIteration(5, 5), false);
-  });
+	await t.step("should return false when index matches targetIndex", () => {
+		assertEquals(check_is_not_specific_iteration(2, 2), false);
+		assertEquals(check_is_not_specific_iteration(0, 0), false);
+		assertEquals(check_is_not_specific_iteration(5, 5), false);
+	});
 });

--- a/packages/boolean/README.md
+++ b/packages/boolean/README.md
@@ -39,94 +39,94 @@ bunx jsr add @checker/boolean
 
 ## Functions
 
-### `checkIsBoolean`
+### `check_is_boolean`
 
 Checks if the given value is a boolean.
 
 ```ts
-checkIsBoolean(true); // true
-checkIsBoolean("string"); // false
+check_is_boolean(true); // true
+check_is_boolean("string"); // false
 ```
 
-### `checkIsNotBoolean`
+### `check_is_not_boolean`
 
 Checks if the given value is not a boolean.
 
 ```ts
-checkIsNotBoolean("string"); // true
-checkIsNotBoolean(true); // false
+check_is_not_boolean("string"); // true
+check_is_not_boolean(true); // false
 ```
 
-### `checkIsFalse`
+### `check_is_false`
 
 Checks if the given value is strictly `false`.
 
 ```ts
-checkIsFalse(false); // true
-checkIsFalse(0); // false
+check_is_false(false); // true
+check_is_false(0); // false
 ```
 
-### `checkIsNotFalse`
+### `check_is_not_false`
 
 Checks if the given value is not strictly `false`.
 
 ```ts
-checkIsNotFalse(0); // true
-checkIsNotFalse(false); // false
+check_is_not_false(0); // true
+check_is_not_false(false); // false
 ```
 
-### `checkIsTruthy`
+### `check_is_truthy`
 
 Checks if the given value is truthy.
 
 ```ts
-checkIsTruthy(1); // true
-checkIsTruthy(0); // false
+check_is_truthy(1); // true
+check_is_truthy(0); // false
 ```
 
-### `checkIsNotTruthy`
+### `check_is_not_truthy`
 
 Checks if the given value is not truthy (i.e., falsy).
 
 ```ts
-checkIsNotTruthy(0); // true
-checkIsNotTruthy(1); // false
+check_is_not_truthy(0); // true
+check_is_not_truthy(1); // false
 ```
 
-### `checkIsFalsy`
+### `check_is_falsy`
 
 Checks if the given value is falsy.
 
 ```ts
-checkIsFalsy(0); // true
-checkIsFalsy(1); // false
+check_is_falsy(0); // true
+check_is_falsy(1); // false
 ```
 
-### `checkIsNotFalsy`
+### `check_is_not_falsy`
 
 Checks if the given value is not falsy.
 
 ```ts
-checkIsNotFalsy(1); // true
-checkIsNotFalsy(0); // false
+check_is_not_falsy(1); // true
+check_is_not_falsy(0); // false
 ```
 
-### `checkIsTrue`
+### `check_is_true`
 
 Checks if the given value is strictly `true`.
 
 ```ts
-checkIsTrue(true); // true
-checkIsTrue(1); // false
+check_is_true(true); // true
+check_is_true(1); // false
 ```
 
-### `checkIsNotTrue`
+### `check_is_not_true`
 
 Checks if the given value is not strictly `true`.
 
 ```ts
-checkIsNotTrue(0); // true
-checkIsNotTrue(true); // false
+check_is_not_true(0); // true
+check_is_not_true(true); // false
 ```
 
 ## License

--- a/packages/boolean/mod.ts
+++ b/packages/boolean/mod.ts
@@ -1,20 +1,26 @@
 import type { Falsy } from "./src/types.ts";
-import { checkIsBoolean, checkIsNotBoolean } from "./src/checkBoolean/main.ts";
-import { checkIsNotTrue, checkIsTrue } from "./src/checkTrue/main.ts";
-import { checkIsFalse, checkIsNotFalse } from "./src/checkFalse/main.ts";
-import { checkIsNotTruthy, checkIsTruthy } from "./src/checkTruthy/main.ts";
-import { checkIsFalsy, checkIsNotFalsy } from "./src/checkFalsy/main.ts";
+import {
+	check_is_boolean,
+	check_is_not_boolean,
+} from "./src/checkBoolean/main.ts";
+import { check_is_not_true, check_is_true } from "./src/checkTrue/main.ts";
+import { check_is_false, check_is_not_false } from "./src/checkFalse/main.ts";
+import {
+	check_is_not_truthy,
+	check_is_truthy,
+} from "./src/checkTruthy/main.ts";
+import { check_is_falsy, check_is_not_falsy } from "./src/checkFalsy/main.ts";
 
 export {
-  checkIsBoolean,
-  checkIsFalse,
-  checkIsFalsy,
-  checkIsNotBoolean,
-  checkIsNotFalse,
-  checkIsNotFalsy,
-  checkIsNotTrue,
-  checkIsNotTruthy,
-  checkIsTrue,
-  checkIsTruthy,
-  type Falsy,
+	check_is_boolean,
+	check_is_false,
+	check_is_falsy,
+	check_is_not_boolean,
+	check_is_not_false,
+	check_is_not_falsy,
+	check_is_not_true,
+	check_is_not_truthy,
+	check_is_true,
+	check_is_truthy,
+	type Falsy,
 };

--- a/packages/boolean/mod.ts
+++ b/packages/boolean/mod.ts
@@ -1,26 +1,26 @@
 import type { Falsy } from "./src/types.ts";
 import {
-	check_is_boolean,
-	check_is_not_boolean,
+  check_is_boolean,
+  check_is_not_boolean,
 } from "./src/checkBoolean/main.ts";
 import { check_is_not_true, check_is_true } from "./src/checkTrue/main.ts";
 import { check_is_false, check_is_not_false } from "./src/checkFalse/main.ts";
 import {
-	check_is_not_truthy,
-	check_is_truthy,
+  check_is_not_truthy,
+  check_is_truthy,
 } from "./src/checkTruthy/main.ts";
 import { check_is_falsy, check_is_not_falsy } from "./src/checkFalsy/main.ts";
 
 export {
-	check_is_boolean,
-	check_is_false,
-	check_is_falsy,
-	check_is_not_boolean,
-	check_is_not_false,
-	check_is_not_falsy,
-	check_is_not_true,
-	check_is_not_truthy,
-	check_is_true,
-	check_is_truthy,
-	type Falsy,
+  check_is_boolean,
+  check_is_false,
+  check_is_falsy,
+  check_is_not_boolean,
+  check_is_not_false,
+  check_is_not_falsy,
+  check_is_not_true,
+  check_is_not_truthy,
+  check_is_true,
+  check_is_truthy,
+  type Falsy,
 };

--- a/packages/boolean/src/checkBoolean/main.ts
+++ b/packages/boolean/src/checkBoolean/main.ts
@@ -6,20 +6,20 @@
  *
  * @example
  * // Returns true
- * checkIsBoolean(true); // The value is a boolean
+ * check_is_boolean(true); // The value is a boolean
  *
  * @example
  * // Returns false
- * checkIsBoolean("true"); // The value is not a boolean
+ * check_is_boolean("true"); // The value is not a boolean
  */
-export const checkIsBoolean = (value: unknown): value is boolean => {
-  return typeof value === "boolean";
+export const check_is_boolean = (value: unknown): value is boolean => {
+	return typeof value === "boolean";
 };
 
 /**
  * Checks if the given value is not a boolean.
  *
- * This is the inverse of `checkIsBoolean`.
+ * This is the inverse of `check_is_boolean`.
  *
  * @param {T} value - The value to check.
  * @returns {value is Exclude<T, boolean>} True if the value is not a boolean, otherwise false.
@@ -32,8 +32,8 @@ export const checkIsBoolean = (value: unknown): value is boolean => {
  * // Returns false
  * checkIsNotBoolean(true); // The value is a boolean
  */
-export const checkIsNotBoolean = <T>(
-  value: T,
+export const check_is_not_boolean = <T>(
+	value: T
 ): value is Exclude<T, boolean> => {
-  return !checkIsBoolean(value);
+	return !check_is_boolean(value);
 };

--- a/packages/boolean/src/checkBoolean/main.ts
+++ b/packages/boolean/src/checkBoolean/main.ts
@@ -13,7 +13,7 @@
  * check_is_boolean("true"); // The value is not a boolean
  */
 export const check_is_boolean = (value: unknown): value is boolean => {
-	return typeof value === "boolean";
+  return typeof value === "boolean";
 };
 
 /**
@@ -33,7 +33,7 @@ export const check_is_boolean = (value: unknown): value is boolean => {
  * checkIsNotBoolean(true); // The value is a boolean
  */
 export const check_is_not_boolean = <T>(
-	value: T
+  value: T,
 ): value is Exclude<T, boolean> => {
-	return !check_is_boolean(value);
+  return !check_is_boolean(value);
 };

--- a/packages/boolean/src/checkBoolean/test.ts
+++ b/packages/boolean/src/checkBoolean/test.ts
@@ -1,48 +1,48 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkIsBoolean, checkIsNotBoolean } from "./main.ts";
+import { check_is_boolean, check_is_not_boolean } from "./main.ts";
 
-Deno.test("checkIsBoolean", async (t) => {
-  await t.step("should return true for boolean values", () => {
-    assertEquals(checkIsBoolean(true), true);
-    assertEquals(checkIsBoolean(false), true);
-  });
+Deno.test("check_is_boolean", async (t) => {
+	await t.step("should return true for boolean values", () => {
+		assertEquals(check_is_boolean(true), true);
+		assertEquals(check_is_boolean(false), true);
+	});
 
-  await t.step("should return false for non-boolean values", () => {
-    assertEquals(checkIsBoolean(1), false);
-    assertEquals(checkIsBoolean("true"), false);
-    assertEquals(checkIsBoolean(null), false);
-    assertEquals(checkIsBoolean(undefined), false);
-    assertEquals(checkIsBoolean({}), false);
-  });
+	await t.step("should return false for non-boolean values", () => {
+		assertEquals(check_is_boolean(1), false);
+		assertEquals(check_is_boolean("true"), false);
+		assertEquals(check_is_boolean(null), false);
+		assertEquals(check_is_boolean(undefined), false);
+		assertEquals(check_is_boolean({}), false);
+	});
 
-  await t.step("should narrow down to boolean type", () => {
-    type Value = string | boolean;
-    const value = {} as Value;
-    if (checkIsBoolean(value)) {
-      assertType<IsExact<typeof value, boolean>>(true);
-    }
-  });
+	await t.step("should narrow down to boolean type", () => {
+		type Value = string | boolean;
+		const value = {} as Value;
+		if (check_is_boolean(value)) {
+			assertType<IsExact<typeof value, boolean>>(true);
+		}
+	});
 });
 
-Deno.test("checkIsNotBoolean", async (t) => {
-  await t.step("should return true for non-boolean values", () => {
-    assertEquals(checkIsNotBoolean(1), true);
-    assertEquals(checkIsNotBoolean("false"), true);
-    assertEquals(checkIsNotBoolean(null), true);
-    assertEquals(checkIsNotBoolean(undefined), true);
-    assertEquals(checkIsNotBoolean({}), true);
-  });
+Deno.test("check_is_not_boolean", async (t) => {
+	await t.step("should return true for non-boolean values", () => {
+		assertEquals(check_is_not_boolean(1), true);
+		assertEquals(check_is_not_boolean("false"), true);
+		assertEquals(check_is_not_boolean(null), true);
+		assertEquals(check_is_not_boolean(undefined), true);
+		assertEquals(check_is_not_boolean({}), true);
+	});
 
-  await t.step("should return false for boolean values", () => {
-    assertEquals(checkIsNotBoolean(true), false);
-    assertEquals(checkIsNotBoolean(false), false);
-  });
+	await t.step("should return false for boolean values", () => {
+		assertEquals(check_is_not_boolean(true), false);
+		assertEquals(check_is_not_boolean(false), false);
+	});
 
-  await t.step("should exclude boolean type", () => {
-    type Value = string | boolean;
-    const value = {} as Value;
-    if (checkIsNotBoolean(value)) {
-      assertType<IsExact<typeof value, string>>(true);
-    }
-  });
+	await t.step("should exclude boolean type", () => {
+		type Value = string | boolean;
+		const value = {} as Value;
+		if (check_is_not_boolean(value)) {
+			assertType<IsExact<typeof value, string>>(true);
+		}
+	});
 });

--- a/packages/boolean/src/checkBoolean/test.ts
+++ b/packages/boolean/src/checkBoolean/test.ts
@@ -2,47 +2,47 @@ import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import { check_is_boolean, check_is_not_boolean } from "./main.ts";
 
 Deno.test("check_is_boolean", async (t) => {
-	await t.step("should return true for boolean values", () => {
-		assertEquals(check_is_boolean(true), true);
-		assertEquals(check_is_boolean(false), true);
-	});
+  await t.step("should return true for boolean values", () => {
+    assertEquals(check_is_boolean(true), true);
+    assertEquals(check_is_boolean(false), true);
+  });
 
-	await t.step("should return false for non-boolean values", () => {
-		assertEquals(check_is_boolean(1), false);
-		assertEquals(check_is_boolean("true"), false);
-		assertEquals(check_is_boolean(null), false);
-		assertEquals(check_is_boolean(undefined), false);
-		assertEquals(check_is_boolean({}), false);
-	});
+  await t.step("should return false for non-boolean values", () => {
+    assertEquals(check_is_boolean(1), false);
+    assertEquals(check_is_boolean("true"), false);
+    assertEquals(check_is_boolean(null), false);
+    assertEquals(check_is_boolean(undefined), false);
+    assertEquals(check_is_boolean({}), false);
+  });
 
-	await t.step("should narrow down to boolean type", () => {
-		type Value = string | boolean;
-		const value = {} as Value;
-		if (check_is_boolean(value)) {
-			assertType<IsExact<typeof value, boolean>>(true);
-		}
-	});
+  await t.step("should narrow down to boolean type", () => {
+    type Value = string | boolean;
+    const value = {} as Value;
+    if (check_is_boolean(value)) {
+      assertType<IsExact<typeof value, boolean>>(true);
+    }
+  });
 });
 
 Deno.test("check_is_not_boolean", async (t) => {
-	await t.step("should return true for non-boolean values", () => {
-		assertEquals(check_is_not_boolean(1), true);
-		assertEquals(check_is_not_boolean("false"), true);
-		assertEquals(check_is_not_boolean(null), true);
-		assertEquals(check_is_not_boolean(undefined), true);
-		assertEquals(check_is_not_boolean({}), true);
-	});
+  await t.step("should return true for non-boolean values", () => {
+    assertEquals(check_is_not_boolean(1), true);
+    assertEquals(check_is_not_boolean("false"), true);
+    assertEquals(check_is_not_boolean(null), true);
+    assertEquals(check_is_not_boolean(undefined), true);
+    assertEquals(check_is_not_boolean({}), true);
+  });
 
-	await t.step("should return false for boolean values", () => {
-		assertEquals(check_is_not_boolean(true), false);
-		assertEquals(check_is_not_boolean(false), false);
-	});
+  await t.step("should return false for boolean values", () => {
+    assertEquals(check_is_not_boolean(true), false);
+    assertEquals(check_is_not_boolean(false), false);
+  });
 
-	await t.step("should exclude boolean type", () => {
-		type Value = string | boolean;
-		const value = {} as Value;
-		if (check_is_not_boolean(value)) {
-			assertType<IsExact<typeof value, string>>(true);
-		}
-	});
+  await t.step("should exclude boolean type", () => {
+    type Value = string | boolean;
+    const value = {} as Value;
+    if (check_is_not_boolean(value)) {
+      assertType<IsExact<typeof value, string>>(true);
+    }
+  });
 });

--- a/packages/boolean/src/checkFalse/main.ts
+++ b/packages/boolean/src/checkFalse/main.ts
@@ -13,7 +13,7 @@
  * check_is_false(0); // The value is not strictly false, but falsy
  */
 export const check_is_false = (value: unknown): value is false => {
-	return value === false;
+  return value === false;
 };
 
 /**
@@ -33,5 +33,5 @@ export const check_is_false = (value: unknown): value is false => {
  * check_is_not_false(false); // The value is strictly false
  */
 export const check_is_not_false = <T>(value: T): value is Exclude<T, false> => {
-	return !check_is_false(value);
+  return !check_is_false(value);
 };

--- a/packages/boolean/src/checkFalse/main.ts
+++ b/packages/boolean/src/checkFalse/main.ts
@@ -6,32 +6,32 @@
  *
  * @example
  * // Returns true
- * checkIsFalse(false); // The value is strictly false
+ * check_is_false(false); // The value is strictly false
  *
  * @example
  * // Returns false
- * checkIsFalse(0); // The value is not strictly false, but falsy
+ * check_is_false(0); // The value is not strictly false, but falsy
  */
-export const checkIsFalse = (value: unknown): value is false => {
-  return value === false;
+export const check_is_false = (value: unknown): value is false => {
+	return value === false;
 };
 
 /**
  * Checks if the given value is not strictly `false`.
  *
- * This is the inverse of `checkIsFalse`.
+ * This is the inverse of `check_is_false`.
  *
  * @param {T} value - The value to check.
  * @returns {value is Exclude<T, false>} True if the value is not strictly `false`, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotFalse(0); // The value is not strictly false, even though it's falsy
+ * check_is_not_false(0); // The value is not strictly false, even though it's falsy
  *
  * @example
  * // Returns false
- * checkIsNotFalse(false); // The value is strictly false
+ * check_is_not_false(false); // The value is strictly false
  */
-export const checkIsNotFalse = <T>(value: T): value is Exclude<T, false> => {
-  return !checkIsFalse(value);
+export const check_is_not_false = <T>(value: T): value is Exclude<T, false> => {
+	return !check_is_false(value);
 };

--- a/packages/boolean/src/checkFalse/test.ts
+++ b/packages/boolean/src/checkFalse/test.ts
@@ -2,47 +2,47 @@ import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import { check_is_false, check_is_not_false } from "./main.ts";
 
 Deno.test("check_is_false", async (t) => {
-	await t.step("should return true for false value", () => {
-		assertEquals(check_is_false(false), true);
-	});
+  await t.step("should return true for false value", () => {
+    assertEquals(check_is_false(false), true);
+  });
 
-	await t.step("should return false for non-false values", () => {
-		assertEquals(check_is_false(true), false);
-		assertEquals(check_is_false(null), false);
-		assertEquals(check_is_false(undefined), false);
-		assertEquals(check_is_false(0), false);
-		assertEquals(check_is_false(1), false);
-		assertEquals(check_is_false("false"), false);
-	});
+  await t.step("should return false for non-false values", () => {
+    assertEquals(check_is_false(true), false);
+    assertEquals(check_is_false(null), false);
+    assertEquals(check_is_false(undefined), false);
+    assertEquals(check_is_false(0), false);
+    assertEquals(check_is_false(1), false);
+    assertEquals(check_is_false("false"), false);
+  });
 
-	await t.step("should narrow false type", () => {
-		type Value = string | false;
-		const value = {} as Value;
-		if (check_is_false(value)) {
-			assertType<IsExact<typeof value, false>>(true);
-		}
-	});
+  await t.step("should narrow false type", () => {
+    type Value = string | false;
+    const value = {} as Value;
+    if (check_is_false(value)) {
+      assertType<IsExact<typeof value, false>>(true);
+    }
+  });
 });
 
 Deno.test("check_is_not_false", async (t) => {
-	await t.step("should return true for non-false values", () => {
-		assertEquals(check_is_not_false(true), true);
-		assertEquals(check_is_not_false(null), true);
-		assertEquals(check_is_not_false(undefined), true);
-		assertEquals(check_is_not_false(0), true);
-		assertEquals(check_is_not_false(1), true);
-		assertEquals(check_is_not_false("false"), true);
-	});
+  await t.step("should return true for non-false values", () => {
+    assertEquals(check_is_not_false(true), true);
+    assertEquals(check_is_not_false(null), true);
+    assertEquals(check_is_not_false(undefined), true);
+    assertEquals(check_is_not_false(0), true);
+    assertEquals(check_is_not_false(1), true);
+    assertEquals(check_is_not_false("false"), true);
+  });
 
-	await t.step("should return false for false value", () => {
-		assertEquals(check_is_not_false(false), false);
-	});
+  await t.step("should return false for false value", () => {
+    assertEquals(check_is_not_false(false), false);
+  });
 
-	await t.step("should exclude false type", () => {
-		type Value = string | false;
-		const value = {} as Value;
-		if (check_is_not_false(value)) {
-			assertType<IsExact<typeof value, string>>(true);
-		}
-	});
+  await t.step("should exclude false type", () => {
+    type Value = string | false;
+    const value = {} as Value;
+    if (check_is_not_false(value)) {
+      assertType<IsExact<typeof value, string>>(true);
+    }
+  });
 });

--- a/packages/boolean/src/checkFalse/test.ts
+++ b/packages/boolean/src/checkFalse/test.ts
@@ -1,48 +1,48 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkIsFalse, checkIsNotFalse } from "./main.ts";
+import { check_is_false, check_is_not_false } from "./main.ts";
 
-Deno.test("checkIsFalse", async (t) => {
-  await t.step("should return true for false value", () => {
-    assertEquals(checkIsFalse(false), true);
-  });
+Deno.test("check_is_false", async (t) => {
+	await t.step("should return true for false value", () => {
+		assertEquals(check_is_false(false), true);
+	});
 
-  await t.step("should return false for non-false values", () => {
-    assertEquals(checkIsFalse(true), false);
-    assertEquals(checkIsFalse(null), false);
-    assertEquals(checkIsFalse(undefined), false);
-    assertEquals(checkIsFalse(0), false);
-    assertEquals(checkIsFalse(1), false);
-    assertEquals(checkIsFalse("false"), false);
-  });
+	await t.step("should return false for non-false values", () => {
+		assertEquals(check_is_false(true), false);
+		assertEquals(check_is_false(null), false);
+		assertEquals(check_is_false(undefined), false);
+		assertEquals(check_is_false(0), false);
+		assertEquals(check_is_false(1), false);
+		assertEquals(check_is_false("false"), false);
+	});
 
-  await t.step("should narrow false type", () => {
-    type Value = string | false;
-    const value = {} as Value;
-    if (checkIsFalse(value)) {
-      assertType<IsExact<typeof value, false>>(true);
-    }
-  });
+	await t.step("should narrow false type", () => {
+		type Value = string | false;
+		const value = {} as Value;
+		if (check_is_false(value)) {
+			assertType<IsExact<typeof value, false>>(true);
+		}
+	});
 });
 
-Deno.test("checkIsNotFalse", async (t) => {
-  await t.step("should return true for non-false values", () => {
-    assertEquals(checkIsNotFalse(true), true);
-    assertEquals(checkIsNotFalse(null), true);
-    assertEquals(checkIsNotFalse(undefined), true);
-    assertEquals(checkIsNotFalse(0), true);
-    assertEquals(checkIsNotFalse(1), true);
-    assertEquals(checkIsNotFalse("false"), true);
-  });
+Deno.test("check_is_not_false", async (t) => {
+	await t.step("should return true for non-false values", () => {
+		assertEquals(check_is_not_false(true), true);
+		assertEquals(check_is_not_false(null), true);
+		assertEquals(check_is_not_false(undefined), true);
+		assertEquals(check_is_not_false(0), true);
+		assertEquals(check_is_not_false(1), true);
+		assertEquals(check_is_not_false("false"), true);
+	});
 
-  await t.step("should return false for false value", () => {
-    assertEquals(checkIsNotFalse(false), false);
-  });
+	await t.step("should return false for false value", () => {
+		assertEquals(check_is_not_false(false), false);
+	});
 
-  await t.step("should exclude false type", () => {
-    type Value = string | false;
-    const value = {} as Value;
-    if (checkIsNotFalse(value)) {
-      assertType<IsExact<typeof value, string>>(true);
-    }
-  });
+	await t.step("should exclude false type", () => {
+		type Value = string | false;
+		const value = {} as Value;
+		if (check_is_not_false(value)) {
+			assertType<IsExact<typeof value, string>>(true);
+		}
+	});
 });

--- a/packages/boolean/src/checkFalsy/main.ts
+++ b/packages/boolean/src/checkFalsy/main.ts
@@ -10,32 +10,32 @@ import type { Falsy } from "../types.ts";
  *
  * @example
  * // Returns true
- * checkIsFalsy(0); // 0 is a falsy value
+ * check_is_falsy(0); // 0 is a falsy value
  *
  * @example
  * // Returns false
- * checkIsFalsy(1); // 1 is a truthy value
+ * check_is_falsy(1); // 1 is a truthy value
  */
-export const checkIsFalsy = <T>(value: T): value is Extract<T, Falsy> => {
-  return Boolean(value) === false;
+export const check_is_falsy = <T>(value: T): value is Extract<T, Falsy> => {
+	return Boolean(value) === false;
 };
 
 /**
  * Checks if the given value is not falsy.
  *
- * This is the inverse of `checkIsFalsy`.
+ * This is the inverse of `check_is_falsy`.
  *
  * @param {T} value - The value to check.
  * @returns {value is Exclude<T, Falsy>} True if the value is not falsy, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotFalsy(1); // 1 is a truthy value
+ * check_is_not_falsy(1); // 1 is a truthy value
  *
  * @example
  * // Returns false
- * checkIsNotFalsy(0); // 0 is a falsy value
+ * check_is_not_falsy(0); // 0 is a falsy value
  */
-export const checkIsNotFalsy = <T>(value: T): value is Exclude<T, Falsy> => {
-  return !checkIsFalsy(value);
+export const check_is_not_falsy = <T>(value: T): value is Exclude<T, Falsy> => {
+	return !check_is_falsy(value);
 };

--- a/packages/boolean/src/checkFalsy/main.ts
+++ b/packages/boolean/src/checkFalsy/main.ts
@@ -17,7 +17,7 @@ import type { Falsy } from "../types.ts";
  * check_is_falsy(1); // 1 is a truthy value
  */
 export const check_is_falsy = <T>(value: T): value is Extract<T, Falsy> => {
-	return Boolean(value) === false;
+  return Boolean(value) === false;
 };
 
 /**
@@ -37,5 +37,5 @@ export const check_is_falsy = <T>(value: T): value is Extract<T, Falsy> => {
  * check_is_not_falsy(0); // 0 is a falsy value
  */
 export const check_is_not_falsy = <T>(value: T): value is Exclude<T, Falsy> => {
-	return !check_is_falsy(value);
+  return !check_is_falsy(value);
 };

--- a/packages/boolean/src/checkFalsy/test.ts
+++ b/packages/boolean/src/checkFalsy/test.ts
@@ -1,58 +1,58 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkIsFalsy, checkIsNotFalsy } from "./main.ts";
+import { check_is_falsy, check_is_not_falsy } from "./main.ts";
 
-Deno.test("checkIsFalsy", async (t) => {
-  await t.step("should return true for falsy values", () => {
-    assertEquals(checkIsFalsy(false), true);
-    assertEquals(checkIsFalsy(0), true);
-    assertEquals(checkIsFalsy(""), true);
-    assertEquals(checkIsFalsy(null), true);
-    assertEquals(checkIsFalsy(undefined), true);
-    assertEquals(checkIsFalsy(NaN), true);
-    assertEquals(checkIsFalsy(0n), true);
-  });
+Deno.test("check_is_falsy", async (t) => {
+	await t.step("should return true for falsy values", () => {
+		assertEquals(check_is_falsy(false), true);
+		assertEquals(check_is_falsy(0), true);
+		assertEquals(check_is_falsy(""), true);
+		assertEquals(check_is_falsy(null), true);
+		assertEquals(check_is_falsy(undefined), true);
+		assertEquals(check_is_falsy(NaN), true);
+		assertEquals(check_is_falsy(0n), true);
+	});
 
-  await t.step("should return false for truthy values", () => {
-    assertEquals(checkIsFalsy(true), false);
-    assertEquals(checkIsFalsy(1), false);
-    assertEquals(checkIsFalsy("string"), false);
-    assertEquals(checkIsFalsy({}), false);
-    assertEquals(checkIsFalsy([]), false);
-  });
+	await t.step("should return false for truthy values", () => {
+		assertEquals(check_is_falsy(true), false);
+		assertEquals(check_is_falsy(1), false);
+		assertEquals(check_is_falsy("string"), false);
+		assertEquals(check_is_falsy({}), false);
+		assertEquals(check_is_falsy([]), false);
+	});
 
-  await t.step("should narrow falsy types", () => {
-    type Value = string | 0 | null | undefined | false;
-    const value = {} as Value;
-    if (checkIsFalsy(value)) {
-      assertType<IsExact<typeof value, Exclude<Value, string>>>(true);
-    }
-  });
+	await t.step("should narrow falsy types", () => {
+		type Value = string | 0 | null | undefined | false;
+		const value = {} as Value;
+		if (check_is_falsy(value)) {
+			assertType<IsExact<typeof value, Exclude<Value, string>>>(true);
+		}
+	});
 });
 
-Deno.test("checkIsNotFalsy", async (t) => {
-  await t.step("should return true for truthy values", () => {
-    assertEquals(checkIsNotFalsy(true), true);
-    assertEquals(checkIsNotFalsy(1), true);
-    assertEquals(checkIsNotFalsy("string"), true);
-    assertEquals(checkIsNotFalsy({}), true);
-    assertEquals(checkIsNotFalsy([]), true);
-  });
+Deno.test("check_is_not_falsy", async (t) => {
+	await t.step("should return true for truthy values", () => {
+		assertEquals(check_is_not_falsy(true), true);
+		assertEquals(check_is_not_falsy(1), true);
+		assertEquals(check_is_not_falsy("string"), true);
+		assertEquals(check_is_not_falsy({}), true);
+		assertEquals(check_is_not_falsy([]), true);
+	});
 
-  await t.step("should return false for falsy values", () => {
-    assertEquals(checkIsNotFalsy(false), false);
-    assertEquals(checkIsNotFalsy(0), false);
-    assertEquals(checkIsNotFalsy(""), false);
-    assertEquals(checkIsNotFalsy(null), false);
-    assertEquals(checkIsNotFalsy(undefined), false);
-    assertEquals(checkIsNotFalsy(NaN), false);
-    assertEquals(checkIsNotFalsy(0n), false);
-  });
+	await t.step("should return false for falsy values", () => {
+		assertEquals(check_is_not_falsy(false), false);
+		assertEquals(check_is_not_falsy(0), false);
+		assertEquals(check_is_not_falsy(""), false);
+		assertEquals(check_is_not_falsy(null), false);
+		assertEquals(check_is_not_falsy(undefined), false);
+		assertEquals(check_is_not_falsy(NaN), false);
+		assertEquals(check_is_not_falsy(0n), false);
+	});
 
-  await t.step("should exclude falsy types", () => {
-    type Value = string | 0 | null | undefined | false;
-    const value = {} as Value;
-    if (checkIsNotFalsy(value)) {
-      assertType<IsExact<typeof value, string>>(true);
-    }
-  });
+	await t.step("should exclude falsy types", () => {
+		type Value = string | 0 | null | undefined | false;
+		const value = {} as Value;
+		if (check_is_not_falsy(value)) {
+			assertType<IsExact<typeof value, string>>(true);
+		}
+	});
 });

--- a/packages/boolean/src/checkFalsy/test.ts
+++ b/packages/boolean/src/checkFalsy/test.ts
@@ -2,57 +2,57 @@ import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import { check_is_falsy, check_is_not_falsy } from "./main.ts";
 
 Deno.test("check_is_falsy", async (t) => {
-	await t.step("should return true for falsy values", () => {
-		assertEquals(check_is_falsy(false), true);
-		assertEquals(check_is_falsy(0), true);
-		assertEquals(check_is_falsy(""), true);
-		assertEquals(check_is_falsy(null), true);
-		assertEquals(check_is_falsy(undefined), true);
-		assertEquals(check_is_falsy(NaN), true);
-		assertEquals(check_is_falsy(0n), true);
-	});
+  await t.step("should return true for falsy values", () => {
+    assertEquals(check_is_falsy(false), true);
+    assertEquals(check_is_falsy(0), true);
+    assertEquals(check_is_falsy(""), true);
+    assertEquals(check_is_falsy(null), true);
+    assertEquals(check_is_falsy(undefined), true);
+    assertEquals(check_is_falsy(NaN), true);
+    assertEquals(check_is_falsy(0n), true);
+  });
 
-	await t.step("should return false for truthy values", () => {
-		assertEquals(check_is_falsy(true), false);
-		assertEquals(check_is_falsy(1), false);
-		assertEquals(check_is_falsy("string"), false);
-		assertEquals(check_is_falsy({}), false);
-		assertEquals(check_is_falsy([]), false);
-	});
+  await t.step("should return false for truthy values", () => {
+    assertEquals(check_is_falsy(true), false);
+    assertEquals(check_is_falsy(1), false);
+    assertEquals(check_is_falsy("string"), false);
+    assertEquals(check_is_falsy({}), false);
+    assertEquals(check_is_falsy([]), false);
+  });
 
-	await t.step("should narrow falsy types", () => {
-		type Value = string | 0 | null | undefined | false;
-		const value = {} as Value;
-		if (check_is_falsy(value)) {
-			assertType<IsExact<typeof value, Exclude<Value, string>>>(true);
-		}
-	});
+  await t.step("should narrow falsy types", () => {
+    type Value = string | 0 | null | undefined | false;
+    const value = {} as Value;
+    if (check_is_falsy(value)) {
+      assertType<IsExact<typeof value, Exclude<Value, string>>>(true);
+    }
+  });
 });
 
 Deno.test("check_is_not_falsy", async (t) => {
-	await t.step("should return true for truthy values", () => {
-		assertEquals(check_is_not_falsy(true), true);
-		assertEquals(check_is_not_falsy(1), true);
-		assertEquals(check_is_not_falsy("string"), true);
-		assertEquals(check_is_not_falsy({}), true);
-		assertEquals(check_is_not_falsy([]), true);
-	});
+  await t.step("should return true for truthy values", () => {
+    assertEquals(check_is_not_falsy(true), true);
+    assertEquals(check_is_not_falsy(1), true);
+    assertEquals(check_is_not_falsy("string"), true);
+    assertEquals(check_is_not_falsy({}), true);
+    assertEquals(check_is_not_falsy([]), true);
+  });
 
-	await t.step("should return false for falsy values", () => {
-		assertEquals(check_is_not_falsy(false), false);
-		assertEquals(check_is_not_falsy(0), false);
-		assertEquals(check_is_not_falsy(""), false);
-		assertEquals(check_is_not_falsy(null), false);
-		assertEquals(check_is_not_falsy(undefined), false);
-		assertEquals(check_is_not_falsy(NaN), false);
-		assertEquals(check_is_not_falsy(0n), false);
-	});
+  await t.step("should return false for falsy values", () => {
+    assertEquals(check_is_not_falsy(false), false);
+    assertEquals(check_is_not_falsy(0), false);
+    assertEquals(check_is_not_falsy(""), false);
+    assertEquals(check_is_not_falsy(null), false);
+    assertEquals(check_is_not_falsy(undefined), false);
+    assertEquals(check_is_not_falsy(NaN), false);
+    assertEquals(check_is_not_falsy(0n), false);
+  });
 
-	await t.step("should exclude falsy types", () => {
-		type Value = string | 0 | null | undefined | false;
-		const value = {} as Value;
-		if (check_is_not_falsy(value)) {
-			assertType<IsExact<typeof value, string>>(true);
-		}
-	});
+  await t.step("should exclude falsy types", () => {
+    type Value = string | 0 | null | undefined | false;
+    const value = {} as Value;
+    if (check_is_not_falsy(value)) {
+      assertType<IsExact<typeof value, string>>(true);
+    }
+  });
 });

--- a/packages/boolean/src/checkTrue/main.ts
+++ b/packages/boolean/src/checkTrue/main.ts
@@ -13,7 +13,7 @@
  * check_is_true(1); // The value is not strictly true, but truthy
  */
 export const check_is_true = (value: unknown): value is true => {
-	return value === true;
+  return value === true;
 };
 
 /**
@@ -33,5 +33,5 @@ export const check_is_true = (value: unknown): value is true => {
  * check_is_not_true(true); // The value is strictly true
  */
 export const check_is_not_true = <T>(value: T): value is Exclude<T, true> => {
-	return !check_is_true(value);
+  return !check_is_true(value);
 };

--- a/packages/boolean/src/checkTrue/main.ts
+++ b/packages/boolean/src/checkTrue/main.ts
@@ -6,32 +6,32 @@
  *
  * @example
  * // Returns true
- * checkIsTrue(true); // The value is strictly true
+ * check_is_true(true); // The value is strictly true
  *
  * @example
  * // Returns false
- * checkIsTrue(1); // The value is not strictly true, but truthy
+ * check_is_true(1); // The value is not strictly true, but truthy
  */
-export const checkIsTrue = (value: unknown): value is true => {
-  return value === true;
+export const check_is_true = (value: unknown): value is true => {
+	return value === true;
 };
 
 /**
  * Checks if the given value is not strictly `true`.
  *
- * This is the inverse of `checkIsTrue`.
+ * This is the inverse of `check_is_true`.
  *
  * @param {T} value - The value to check.
  * @returns {value is Exclude<T, true>} True if the value is not strictly `true`, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotTrue(0); // The value is not strictly true, and it's falsy
+ * check_is_not_true(0); // The value is not strictly true, and it's falsy
  *
  * @example
  * // Returns false
- * checkIsNotTrue(true); // The value is strictly true
+ * check_is_not_true(true); // The value is strictly true
  */
-export const checkIsNotTrue = <T>(value: T): value is Exclude<T, true> => {
-  return !checkIsTrue(value);
+export const check_is_not_true = <T>(value: T): value is Exclude<T, true> => {
+	return !check_is_true(value);
 };

--- a/packages/boolean/src/checkTrue/test.ts
+++ b/packages/boolean/src/checkTrue/test.ts
@@ -1,48 +1,48 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkIsNotTrue, checkIsTrue } from "./main.ts";
+import { check_is_not_true, check_is_true } from "./main.ts";
 
-Deno.test("checkIsTrue", async (t) => {
-  await t.step("should return true for true value", () => {
-    assertEquals(checkIsTrue(true), true);
-  });
+Deno.test("check_is_true", async (t) => {
+	await t.step("should return true for true value", () => {
+		assertEquals(check_is_true(true), true);
+	});
 
-  await t.step("should return false for non-true values", () => {
-    assertEquals(checkIsTrue(false), false);
-    assertEquals(checkIsTrue(null), false);
-    assertEquals(checkIsTrue(undefined), false);
-    assertEquals(checkIsTrue(0), false);
-    assertEquals(checkIsTrue(1), false);
-    assertEquals(checkIsTrue("true"), false);
-  });
+	await t.step("should return false for non-true values", () => {
+		assertEquals(check_is_true(false), false);
+		assertEquals(check_is_true(null), false);
+		assertEquals(check_is_true(undefined), false);
+		assertEquals(check_is_true(0), false);
+		assertEquals(check_is_true(1), false);
+		assertEquals(check_is_true("true"), false);
+	});
 
-  await t.step("should narrow true type", () => {
-    type Value = string | true;
-    const value = {} as Value;
-    if (checkIsTrue(value)) {
-      assertType<IsExact<typeof value, true>>(true);
-    }
-  });
+	await t.step("should narrow true type", () => {
+		type Value = string | true;
+		const value = {} as Value;
+		if (check_is_true(value)) {
+			assertType<IsExact<typeof value, true>>(true);
+		}
+	});
 });
 
-Deno.test("checkIsNotTrue", async (t) => {
-  await t.step("should return true for non-true values", () => {
-    assertEquals(checkIsNotTrue(false), true);
-    assertEquals(checkIsNotTrue(null), true);
-    assertEquals(checkIsNotTrue(undefined), true);
-    assertEquals(checkIsNotTrue(0), true);
-    assertEquals(checkIsNotTrue(1), true);
-    assertEquals(checkIsNotTrue("true"), true);
-  });
+Deno.test("check_is_not_true", async (t) => {
+	await t.step("should return true for non-true values", () => {
+		assertEquals(check_is_not_true(false), true);
+		assertEquals(check_is_not_true(null), true);
+		assertEquals(check_is_not_true(undefined), true);
+		assertEquals(check_is_not_true(0), true);
+		assertEquals(check_is_not_true(1), true);
+		assertEquals(check_is_not_true("true"), true);
+	});
 
-  await t.step("should return false for true value", () => {
-    assertEquals(checkIsNotTrue(true), false);
-  });
+	await t.step("should return false for true value", () => {
+		assertEquals(check_is_not_true(true), false);
+	});
 
-  await t.step("should exclude true type", () => {
-    type Value = string | true;
-    const value = {} as Value;
-    if (checkIsNotTrue(value)) {
-      assertType<IsExact<typeof value, string>>(true);
-    }
-  });
+	await t.step("should exclude true type", () => {
+		type Value = string | true;
+		const value = {} as Value;
+		if (check_is_not_true(value)) {
+			assertType<IsExact<typeof value, string>>(true);
+		}
+	});
 });

--- a/packages/boolean/src/checkTrue/test.ts
+++ b/packages/boolean/src/checkTrue/test.ts
@@ -2,47 +2,47 @@ import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import { check_is_not_true, check_is_true } from "./main.ts";
 
 Deno.test("check_is_true", async (t) => {
-	await t.step("should return true for true value", () => {
-		assertEquals(check_is_true(true), true);
-	});
+  await t.step("should return true for true value", () => {
+    assertEquals(check_is_true(true), true);
+  });
 
-	await t.step("should return false for non-true values", () => {
-		assertEquals(check_is_true(false), false);
-		assertEquals(check_is_true(null), false);
-		assertEquals(check_is_true(undefined), false);
-		assertEquals(check_is_true(0), false);
-		assertEquals(check_is_true(1), false);
-		assertEquals(check_is_true("true"), false);
-	});
+  await t.step("should return false for non-true values", () => {
+    assertEquals(check_is_true(false), false);
+    assertEquals(check_is_true(null), false);
+    assertEquals(check_is_true(undefined), false);
+    assertEquals(check_is_true(0), false);
+    assertEquals(check_is_true(1), false);
+    assertEquals(check_is_true("true"), false);
+  });
 
-	await t.step("should narrow true type", () => {
-		type Value = string | true;
-		const value = {} as Value;
-		if (check_is_true(value)) {
-			assertType<IsExact<typeof value, true>>(true);
-		}
-	});
+  await t.step("should narrow true type", () => {
+    type Value = string | true;
+    const value = {} as Value;
+    if (check_is_true(value)) {
+      assertType<IsExact<typeof value, true>>(true);
+    }
+  });
 });
 
 Deno.test("check_is_not_true", async (t) => {
-	await t.step("should return true for non-true values", () => {
-		assertEquals(check_is_not_true(false), true);
-		assertEquals(check_is_not_true(null), true);
-		assertEquals(check_is_not_true(undefined), true);
-		assertEquals(check_is_not_true(0), true);
-		assertEquals(check_is_not_true(1), true);
-		assertEquals(check_is_not_true("true"), true);
-	});
+  await t.step("should return true for non-true values", () => {
+    assertEquals(check_is_not_true(false), true);
+    assertEquals(check_is_not_true(null), true);
+    assertEquals(check_is_not_true(undefined), true);
+    assertEquals(check_is_not_true(0), true);
+    assertEquals(check_is_not_true(1), true);
+    assertEquals(check_is_not_true("true"), true);
+  });
 
-	await t.step("should return false for true value", () => {
-		assertEquals(check_is_not_true(true), false);
-	});
+  await t.step("should return false for true value", () => {
+    assertEquals(check_is_not_true(true), false);
+  });
 
-	await t.step("should exclude true type", () => {
-		type Value = string | true;
-		const value = {} as Value;
-		if (check_is_not_true(value)) {
-			assertType<IsExact<typeof value, string>>(true);
-		}
-	});
+  await t.step("should exclude true type", () => {
+    type Value = string | true;
+    const value = {} as Value;
+    if (check_is_not_true(value)) {
+      assertType<IsExact<typeof value, string>>(true);
+    }
+  });
 });

--- a/packages/boolean/src/checkTruthy/main.ts
+++ b/packages/boolean/src/checkTruthy/main.ts
@@ -17,7 +17,7 @@ import type { Falsy } from "../types.ts";
  * check_is_truthy(0); // 0 is falsy
  */
 export const check_is_truthy = <T>(value: T): value is Exclude<T, Falsy> => {
-	return Boolean(value) === true;
+  return Boolean(value) === true;
 };
 
 /**
@@ -37,7 +37,7 @@ export const check_is_truthy = <T>(value: T): value is Exclude<T, Falsy> => {
  * check_is_not_truthy(1); // 1 is truthy
  */
 export const check_is_not_truthy = <T>(
-	value: T
+  value: T,
 ): value is Extract<T, Falsy> => {
-	return !check_is_truthy(value);
+  return !check_is_truthy(value);
 };

--- a/packages/boolean/src/checkTruthy/main.ts
+++ b/packages/boolean/src/checkTruthy/main.ts
@@ -10,14 +10,14 @@ import type { Falsy } from "../types.ts";
  *
  * @example
  * // Returns true
- * checkIsTruthy(1); // 1 is truthy
+ * check_is_truthy(1); // 1 is truthy
  *
  * @example
  * // Returns false
- * checkIsTruthy(0); // 0 is falsy
+ * check_is_truthy(0); // 0 is falsy
  */
-export const checkIsTruthy = <T>(value: T): value is Exclude<T, Falsy> => {
-  return Boolean(value) === true;
+export const check_is_truthy = <T>(value: T): value is Exclude<T, Falsy> => {
+	return Boolean(value) === true;
 };
 
 /**
@@ -30,12 +30,14 @@ export const checkIsTruthy = <T>(value: T): value is Exclude<T, Falsy> => {
  *
  * @example
  * // Returns true
- * checkIsNotTruthy(0); // 0 is falsy
+ * check_is_not_truthy(0); // 0 is falsy
  *
  * @example
  * // Returns false
- * checkIsNotTruthy(1); // 1 is truthy
+ * check_is_not_truthy(1); // 1 is truthy
  */
-export const checkIsNotTruthy = <T>(value: T): value is Extract<T, Falsy> => {
-  return !checkIsTruthy(value);
+export const check_is_not_truthy = <T>(
+	value: T
+): value is Extract<T, Falsy> => {
+	return !check_is_truthy(value);
 };

--- a/packages/boolean/src/checkTruthy/test.ts
+++ b/packages/boolean/src/checkTruthy/test.ts
@@ -2,57 +2,57 @@ import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import { check_is_not_truthy, check_is_truthy } from "./main.ts";
 
 Deno.test("check_is_truthy", async (t) => {
-	await t.step("should return true for truthy values", () => {
-		assertEquals(check_is_truthy(1), true);
-		assertEquals(check_is_truthy("string"), true);
-		assertEquals(check_is_truthy(true), true);
-		assertEquals(check_is_truthy([]), true);
-		assertEquals(check_is_truthy({}), true);
-	});
+  await t.step("should return true for truthy values", () => {
+    assertEquals(check_is_truthy(1), true);
+    assertEquals(check_is_truthy("string"), true);
+    assertEquals(check_is_truthy(true), true);
+    assertEquals(check_is_truthy([]), true);
+    assertEquals(check_is_truthy({}), true);
+  });
 
-	await t.step("should return false for falsy values", () => {
-		assertEquals(check_is_truthy(false), false);
-		assertEquals(check_is_truthy(0), false);
-		assertEquals(check_is_truthy(""), false);
-		assertEquals(check_is_truthy(null), false);
-		assertEquals(check_is_truthy(undefined), false);
-		assertEquals(check_is_truthy(0n), false);
-		assertEquals(check_is_truthy(NaN), false);
-	});
+  await t.step("should return false for falsy values", () => {
+    assertEquals(check_is_truthy(false), false);
+    assertEquals(check_is_truthy(0), false);
+    assertEquals(check_is_truthy(""), false);
+    assertEquals(check_is_truthy(null), false);
+    assertEquals(check_is_truthy(undefined), false);
+    assertEquals(check_is_truthy(0n), false);
+    assertEquals(check_is_truthy(NaN), false);
+  });
 
-	await t.step("should narrow truthy types", () => {
-		type Value = string | number | true | null | undefined | false;
-		const value = {} as Value;
-		if (check_is_truthy(value)) {
-			assertType<IsExact<typeof value, string | number | true>>(true);
-		}
-	});
+  await t.step("should narrow truthy types", () => {
+    type Value = string | number | true | null | undefined | false;
+    const value = {} as Value;
+    if (check_is_truthy(value)) {
+      assertType<IsExact<typeof value, string | number | true>>(true);
+    }
+  });
 });
 
 Deno.test("check_is_not_truthy", async (t) => {
-	await t.step("should return true for falsy values", () => {
-		assertEquals(check_is_not_truthy(false), true);
-		assertEquals(check_is_not_truthy(0), true);
-		assertEquals(check_is_not_truthy(""), true);
-		assertEquals(check_is_not_truthy(null), true);
-		assertEquals(check_is_not_truthy(undefined), true);
-		assertEquals(check_is_not_truthy(0n), true);
-		assertEquals(check_is_not_truthy(NaN), true);
-	});
+  await t.step("should return true for falsy values", () => {
+    assertEquals(check_is_not_truthy(false), true);
+    assertEquals(check_is_not_truthy(0), true);
+    assertEquals(check_is_not_truthy(""), true);
+    assertEquals(check_is_not_truthy(null), true);
+    assertEquals(check_is_not_truthy(undefined), true);
+    assertEquals(check_is_not_truthy(0n), true);
+    assertEquals(check_is_not_truthy(NaN), true);
+  });
 
-	await t.step("should return false for truthy values", () => {
-		assertEquals(check_is_not_truthy(1), false);
-		assertEquals(check_is_not_truthy("string"), false);
-		assertEquals(check_is_not_truthy(true), false);
-		assertEquals(check_is_not_truthy([]), false);
-		assertEquals(check_is_not_truthy({}), false);
-	});
+  await t.step("should return false for truthy values", () => {
+    assertEquals(check_is_not_truthy(1), false);
+    assertEquals(check_is_not_truthy("string"), false);
+    assertEquals(check_is_not_truthy(true), false);
+    assertEquals(check_is_not_truthy([]), false);
+    assertEquals(check_is_not_truthy({}), false);
+  });
 
-	await t.step("should exclude truthy types", () => {
-		type Value = string | number | true | null | undefined | false;
-		const value = {} as Value;
-		if (check_is_not_truthy(value)) {
-			assertType<IsExact<typeof value, null | undefined | false>>(true);
-		}
-	});
+  await t.step("should exclude truthy types", () => {
+    type Value = string | number | true | null | undefined | false;
+    const value = {} as Value;
+    if (check_is_not_truthy(value)) {
+      assertType<IsExact<typeof value, null | undefined | false>>(true);
+    }
+  });
 });

--- a/packages/boolean/src/checkTruthy/test.ts
+++ b/packages/boolean/src/checkTruthy/test.ts
@@ -1,58 +1,58 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkIsNotTruthy, checkIsTruthy } from "./main.ts";
+import { check_is_not_truthy, check_is_truthy } from "./main.ts";
 
-Deno.test("checkIsTruthy", async (t) => {
-  await t.step("should return true for truthy values", () => {
-    assertEquals(checkIsTruthy(1), true);
-    assertEquals(checkIsTruthy("string"), true);
-    assertEquals(checkIsTruthy(true), true);
-    assertEquals(checkIsTruthy([]), true);
-    assertEquals(checkIsTruthy({}), true);
-  });
+Deno.test("check_is_truthy", async (t) => {
+	await t.step("should return true for truthy values", () => {
+		assertEquals(check_is_truthy(1), true);
+		assertEquals(check_is_truthy("string"), true);
+		assertEquals(check_is_truthy(true), true);
+		assertEquals(check_is_truthy([]), true);
+		assertEquals(check_is_truthy({}), true);
+	});
 
-  await t.step("should return false for falsy values", () => {
-    assertEquals(checkIsTruthy(false), false);
-    assertEquals(checkIsTruthy(0), false);
-    assertEquals(checkIsTruthy(""), false);
-    assertEquals(checkIsTruthy(null), false);
-    assertEquals(checkIsTruthy(undefined), false);
-    assertEquals(checkIsTruthy(0n), false);
-    assertEquals(checkIsTruthy(NaN), false);
-  });
+	await t.step("should return false for falsy values", () => {
+		assertEquals(check_is_truthy(false), false);
+		assertEquals(check_is_truthy(0), false);
+		assertEquals(check_is_truthy(""), false);
+		assertEquals(check_is_truthy(null), false);
+		assertEquals(check_is_truthy(undefined), false);
+		assertEquals(check_is_truthy(0n), false);
+		assertEquals(check_is_truthy(NaN), false);
+	});
 
-  await t.step("should narrow truthy types", () => {
-    type Value = string | number | true | null | undefined | false;
-    const value = {} as Value;
-    if (checkIsTruthy(value)) {
-      assertType<IsExact<typeof value, string | number | true>>(true);
-    }
-  });
+	await t.step("should narrow truthy types", () => {
+		type Value = string | number | true | null | undefined | false;
+		const value = {} as Value;
+		if (check_is_truthy(value)) {
+			assertType<IsExact<typeof value, string | number | true>>(true);
+		}
+	});
 });
 
-Deno.test("checkIsNotTruthy", async (t) => {
-  await t.step("should return true for falsy values", () => {
-    assertEquals(checkIsNotTruthy(false), true);
-    assertEquals(checkIsNotTruthy(0), true);
-    assertEquals(checkIsNotTruthy(""), true);
-    assertEquals(checkIsNotTruthy(null), true);
-    assertEquals(checkIsNotTruthy(undefined), true);
-    assertEquals(checkIsNotTruthy(0n), true);
-    assertEquals(checkIsNotTruthy(NaN), true);
-  });
+Deno.test("check_is_not_truthy", async (t) => {
+	await t.step("should return true for falsy values", () => {
+		assertEquals(check_is_not_truthy(false), true);
+		assertEquals(check_is_not_truthy(0), true);
+		assertEquals(check_is_not_truthy(""), true);
+		assertEquals(check_is_not_truthy(null), true);
+		assertEquals(check_is_not_truthy(undefined), true);
+		assertEquals(check_is_not_truthy(0n), true);
+		assertEquals(check_is_not_truthy(NaN), true);
+	});
 
-  await t.step("should return false for truthy values", () => {
-    assertEquals(checkIsNotTruthy(1), false);
-    assertEquals(checkIsNotTruthy("string"), false);
-    assertEquals(checkIsNotTruthy(true), false);
-    assertEquals(checkIsNotTruthy([]), false);
-    assertEquals(checkIsNotTruthy({}), false);
-  });
+	await t.step("should return false for truthy values", () => {
+		assertEquals(check_is_not_truthy(1), false);
+		assertEquals(check_is_not_truthy("string"), false);
+		assertEquals(check_is_not_truthy(true), false);
+		assertEquals(check_is_not_truthy([]), false);
+		assertEquals(check_is_not_truthy({}), false);
+	});
 
-  await t.step("should exclude truthy types", () => {
-    type Value = string | number | true | null | undefined | false;
-    const value = {} as Value;
-    if (checkIsNotTruthy(value)) {
-      assertType<IsExact<typeof value, null | undefined | false>>(true);
-    }
-  });
+	await t.step("should exclude truthy types", () => {
+		type Value = string | number | true | null | undefined | false;
+		const value = {} as Value;
+		if (check_is_not_truthy(value)) {
+			assertType<IsExact<typeof value, null | undefined | false>>(true);
+		}
+	});
 });

--- a/packages/nullish/README.md
+++ b/packages/nullish/README.md
@@ -38,60 +38,60 @@ bunx jsr add @checker/nullish
 
 ## Functions
 
-### `checkIsNull`
+### `check_is_null`
 
 Checks if the given value is strictly `null`.
 
 ```ts
-checkIsNull(null); // true
-checkIsNull(undefined); // false
+check_is_null(null); // true
+check_is_null(undefined); // false
 ```
 
-### `checkIsNotNull`
+### `check_is_not_null`
 
 Checks if the given value is not strictly `null`.
 
 ```ts
-checkIsNotNull(undefined); // true
-checkIsNotNull(null); // false
+check_is_not_null(undefined); // true
+check_is_not_null(null); // false
 ```
 
-### `checkIsUndefined`
+### `check_is_undefined`
 
 Checks if the given value is strictly `undefined`.
 
 ```ts
-checkIsUndefined(undefined); // true
-checkIsUndefined(null); // false
+check_is_undefined(undefined); // true
+check_is_undefined(null); // false
 ```
 
-### `checkIsNotUndefined`
+### `check_is_not_undefined`
 
 Checks if the given value is not strictly `undefined`.
 
 ```ts
-checkIsNotUndefined(null); // true
-checkIsNotUndefined(undefined); // false
+check_is_not_undefined(null); // true
+check_is_not_undefined(undefined); // false
 ```
 
-### `checkIsNullish`
+### `check_is_nullish`
 
 Checks if the given value is nullish (either `null` or `undefined`).
 
 ```ts
-checkIsNullish(null); // true
-checkIsNullish(undefined); // true
-checkIsNullish(0); // false
+check_is_nullish(null); // true
+check_is_nullish(undefined); // true
+check_is_nullish(0); // false
 ```
 
-### `checkIsNotNullish`
+### `check_is_not_nullish`
 
 Checks if the given value is not nullish (neither `null` nor `undefined`).
 
 ```ts
-checkIsNotNullish(0); // true
-checkIsNotNullish(null); // false
-checkIsNotNullish(undefined); // false
+check_is_not_nullish(0); // true
+check_is_not_nullish(null); // false
+check_is_not_nullish(undefined); // false
 ```
 
 ## License

--- a/packages/nullish/mod.ts
+++ b/packages/nullish/mod.ts
@@ -1,20 +1,20 @@
 import type { Nullish } from "./src/types.ts";
 import { check_is_not_null, check_is_null } from "./src/checkNull/main.ts";
 import {
-	check_is_not_undefined,
-	check_is_undefined,
+  check_is_not_undefined,
+  check_is_undefined,
 } from "./src/checkUndefined/main.ts";
 import {
-	check_is_not_nullish,
-	check_is_nullish,
+  check_is_not_nullish,
+  check_is_nullish,
 } from "./src/checkNullish/main.ts";
 
 export {
-	check_is_not_null,
-	check_is_not_nullish,
-	check_is_not_undefined,
-	check_is_null,
-	check_is_nullish,
-	check_is_undefined,
-	type Nullish,
+  check_is_not_null,
+  check_is_not_nullish,
+  check_is_not_undefined,
+  check_is_null,
+  check_is_nullish,
+  check_is_undefined,
+  type Nullish,
 };

--- a/packages/nullish/mod.ts
+++ b/packages/nullish/mod.ts
@@ -1,17 +1,20 @@
 import type { Nullish } from "./src/types.ts";
-import { checkIsNotNull, checkIsNull } from "./src/checkNull/main.ts";
+import { check_is_not_null, check_is_null } from "./src/checkNull/main.ts";
 import {
-  checkIsNotUndefined,
-  checkIsUndefined,
+	check_is_not_undefined,
+	check_is_undefined,
 } from "./src/checkUndefined/main.ts";
-import { checkIsNotNullish, checkIsNullish } from "./src/checkNullish/main.ts";
+import {
+	check_is_not_nullish,
+	check_is_nullish,
+} from "./src/checkNullish/main.ts";
 
 export {
-  checkIsNotNull,
-  checkIsNotNullish,
-  checkIsNotUndefined,
-  checkIsNull,
-  checkIsNullish,
-  checkIsUndefined,
-  type Nullish,
+	check_is_not_null,
+	check_is_not_nullish,
+	check_is_not_undefined,
+	check_is_null,
+	check_is_nullish,
+	check_is_undefined,
+	type Nullish,
 };

--- a/packages/nullish/src/checkNull/main.ts
+++ b/packages/nullish/src/checkNull/main.ts
@@ -6,32 +6,32 @@
  *
  * @example
  * // Returns true
- * checkIsNull(null); // The value is strictly null
+ * check_is_null(null); // The value is strictly null
  *
  * @example
  * // Returns false
- * checkIsNull(undefined); // The value is not null
+ * check_is_null(undefined); // The value is not null
  */
-export const checkIsNull = (value: unknown): value is null => {
-  return value === null;
+export const check_is_null = (value: unknown): value is null => {
+	return value === null;
 };
 
 /**
  * Checks if the given value is not strictly `null`.
  *
- * This is the inverse of `checkIsNull`.
+ * This is the inverse of `check_is_null`.
  *
  * @param {T} value - The value to check.
  * @returns {value is Exclude<T, null>} True if the value is not strictly `null`, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotNull(undefined); // The value is not null
+ * check_is_not_null(undefined); // The value is not null
  *
  * @example
  * // Returns false
- * checkIsNotNull(null); // The value is strictly null
+ * check_is_not_null(null); // The value is strictly null
  */
-export const checkIsNotNull = <T>(value: T): value is Exclude<T, null> => {
-  return !checkIsNull(value);
+export const check_is_not_null = <T>(value: T): value is Exclude<T, null> => {
+	return !check_is_null(value);
 };

--- a/packages/nullish/src/checkNull/main.ts
+++ b/packages/nullish/src/checkNull/main.ts
@@ -13,7 +13,7 @@
  * check_is_null(undefined); // The value is not null
  */
 export const check_is_null = (value: unknown): value is null => {
-	return value === null;
+  return value === null;
 };
 
 /**
@@ -33,5 +33,5 @@ export const check_is_null = (value: unknown): value is null => {
  * check_is_not_null(null); // The value is strictly null
  */
 export const check_is_not_null = <T>(value: T): value is Exclude<T, null> => {
-	return !check_is_null(value);
+  return !check_is_null(value);
 };

--- a/packages/nullish/src/checkNull/test.ts
+++ b/packages/nullish/src/checkNull/test.ts
@@ -1,46 +1,46 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkIsNotNull, checkIsNull } from "./main.ts";
+import { check_is_not_null, check_is_null } from "./main.ts";
 
-Deno.test("checkIsNull", async (t) => {
-  await t.step("should return true for null", () => {
-    assertEquals(checkIsNull(null), true);
-  });
+Deno.test("check_is_null", async (t) => {
+	await t.step("should return true for null", () => {
+		assertEquals(check_is_null(null), true);
+	});
 
-  await t.step("should return false for non-null values", () => {
-    assertEquals(checkIsNull(undefined), false);
-    assertEquals(checkIsNull(0), false);
-    assertEquals(checkIsNull(""), false);
-    assertEquals(checkIsNull(false), false);
-    assertEquals(checkIsNull({}), false);
-  });
+	await t.step("should return false for non-null values", () => {
+		assertEquals(check_is_null(undefined), false);
+		assertEquals(check_is_null(0), false);
+		assertEquals(check_is_null(""), false);
+		assertEquals(check_is_null(false), false);
+		assertEquals(check_is_null({}), false);
+	});
 
-  await t.step("should narrow null type", () => {
-    type Value = string | null;
-    const value = {} as Value;
-    if (checkIsNull(value)) {
-      assertType<IsExact<typeof value, null>>(true);
-    }
-  });
+	await t.step("should narrow null type", () => {
+		type Value = string | null;
+		const value = {} as Value;
+		if (check_is_null(value)) {
+			assertType<IsExact<typeof value, null>>(true);
+		}
+	});
 });
 
-Deno.test("checkIsNotNull", async (t) => {
-  await t.step("should return true for non-null values", () => {
-    assertEquals(checkIsNotNull(undefined), true);
-    assertEquals(checkIsNotNull(0), true);
-    assertEquals(checkIsNotNull(""), true);
-    assertEquals(checkIsNotNull(false), true);
-    assertEquals(checkIsNotNull({}), true);
-  });
+Deno.test("check_is_not_null", async (t) => {
+	await t.step("should return true for non-null values", () => {
+		assertEquals(check_is_not_null(undefined), true);
+		assertEquals(check_is_not_null(0), true);
+		assertEquals(check_is_not_null(""), true);
+		assertEquals(check_is_not_null(false), true);
+		assertEquals(check_is_not_null({}), true);
+	});
 
-  await t.step("should return false for null", () => {
-    assertEquals(checkIsNotNull(null), false);
-  });
+	await t.step("should return false for null", () => {
+		assertEquals(check_is_not_null(null), false);
+	});
 
-  await t.step("should exclude null type", () => {
-    type Value = string | null;
-    const value = {} as Value;
-    if (checkIsNotNull(value)) {
-      assertType<IsExact<typeof value, string>>(true);
-    }
-  });
+	await t.step("should exclude null type", () => {
+		type Value = string | null;
+		const value = {} as Value;
+		if (check_is_not_null(value)) {
+			assertType<IsExact<typeof value, string>>(true);
+		}
+	});
 });

--- a/packages/nullish/src/checkNull/test.ts
+++ b/packages/nullish/src/checkNull/test.ts
@@ -2,45 +2,45 @@ import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import { check_is_not_null, check_is_null } from "./main.ts";
 
 Deno.test("check_is_null", async (t) => {
-	await t.step("should return true for null", () => {
-		assertEquals(check_is_null(null), true);
-	});
+  await t.step("should return true for null", () => {
+    assertEquals(check_is_null(null), true);
+  });
 
-	await t.step("should return false for non-null values", () => {
-		assertEquals(check_is_null(undefined), false);
-		assertEquals(check_is_null(0), false);
-		assertEquals(check_is_null(""), false);
-		assertEquals(check_is_null(false), false);
-		assertEquals(check_is_null({}), false);
-	});
+  await t.step("should return false for non-null values", () => {
+    assertEquals(check_is_null(undefined), false);
+    assertEquals(check_is_null(0), false);
+    assertEquals(check_is_null(""), false);
+    assertEquals(check_is_null(false), false);
+    assertEquals(check_is_null({}), false);
+  });
 
-	await t.step("should narrow null type", () => {
-		type Value = string | null;
-		const value = {} as Value;
-		if (check_is_null(value)) {
-			assertType<IsExact<typeof value, null>>(true);
-		}
-	});
+  await t.step("should narrow null type", () => {
+    type Value = string | null;
+    const value = {} as Value;
+    if (check_is_null(value)) {
+      assertType<IsExact<typeof value, null>>(true);
+    }
+  });
 });
 
 Deno.test("check_is_not_null", async (t) => {
-	await t.step("should return true for non-null values", () => {
-		assertEquals(check_is_not_null(undefined), true);
-		assertEquals(check_is_not_null(0), true);
-		assertEquals(check_is_not_null(""), true);
-		assertEquals(check_is_not_null(false), true);
-		assertEquals(check_is_not_null({}), true);
-	});
+  await t.step("should return true for non-null values", () => {
+    assertEquals(check_is_not_null(undefined), true);
+    assertEquals(check_is_not_null(0), true);
+    assertEquals(check_is_not_null(""), true);
+    assertEquals(check_is_not_null(false), true);
+    assertEquals(check_is_not_null({}), true);
+  });
 
-	await t.step("should return false for null", () => {
-		assertEquals(check_is_not_null(null), false);
-	});
+  await t.step("should return false for null", () => {
+    assertEquals(check_is_not_null(null), false);
+  });
 
-	await t.step("should exclude null type", () => {
-		type Value = string | null;
-		const value = {} as Value;
-		if (check_is_not_null(value)) {
-			assertType<IsExact<typeof value, string>>(true);
-		}
-	});
+  await t.step("should exclude null type", () => {
+    type Value = string | null;
+    const value = {} as Value;
+    if (check_is_not_null(value)) {
+      assertType<IsExact<typeof value, string>>(true);
+    }
+  });
 });

--- a/packages/nullish/src/checkNullish/main.ts
+++ b/packages/nullish/src/checkNullish/main.ts
@@ -21,7 +21,7 @@ import { check_is_undefined } from "../checkUndefined/main.ts";
  * check_is_nullish(0); // The value is not nullish, just falsy
  */
 export const check_is_nullish = <T>(value: T): value is Extract<T, Nullish> => {
-	return check_is_null(value) || check_is_undefined(value);
+  return check_is_null(value) || check_is_undefined(value);
 };
 
 /**
@@ -45,7 +45,7 @@ export const check_is_nullish = <T>(value: T): value is Extract<T, Nullish> => {
  * check_is_not_nullish(undefined); // The value is undefined
  */
 export const check_is_not_nullish = <T>(
-	value: T
+  value: T,
 ): value is Exclude<T, Nullish> => {
-	return !check_is_nullish(value);
+  return !check_is_nullish(value);
 };

--- a/packages/nullish/src/checkNullish/main.ts
+++ b/packages/nullish/src/checkNullish/main.ts
@@ -1,6 +1,6 @@
 import type { Nullish } from "../types.ts";
-import { checkIsNull } from "../checkNull/main.ts";
-import { checkIsUndefined } from "../checkUndefined/main.ts";
+import { check_is_null } from "../checkNull/main.ts";
+import { check_is_undefined } from "../checkUndefined/main.ts";
 
 /**
  * Checks if the given value is nullish (either `null` or `undefined`).
@@ -10,42 +10,42 @@ import { checkIsUndefined } from "../checkUndefined/main.ts";
  *
  * @example
  * // Returns true
- * checkIsNullish(null); // The value is null
+ * check_is_nullish(null); // The value is null
  *
  * @example
  * // Returns true
- * checkIsNullish(undefined); // The value is undefined
+ * check_is_nullish(undefined); // The value is undefined
  *
  * @example
  * // Returns false
- * checkIsNullish(0); // The value is not nullish, just falsy
+ * check_is_nullish(0); // The value is not nullish, just falsy
  */
-export const checkIsNullish = <T>(value: T): value is Extract<T, Nullish> => {
-  return checkIsNull(value) || checkIsUndefined(value);
+export const check_is_nullish = <T>(value: T): value is Extract<T, Nullish> => {
+	return check_is_null(value) || check_is_undefined(value);
 };
 
 /**
  * Checks if the given value is not nullish (neither `null` nor `undefined`).
  *
- * This is the inverse of `checkIsNullish`.
+ * This is the inverse of `check_is_nullish`.
  *
  * @param {T} value - The value to check.
  * @returns {value is Exclude<T, Nullish>} True if the value is neither `null` nor `undefined`, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotNullish(0); // The value is not nullish, even though it's falsy
+ * check_is_not_nullish(0); // The value is not nullish, even though it's falsy
  *
  * @example
  * // Returns false
- * checkIsNotNullish(null); // The value is null
+ * check_is_not_nullish(null); // The value is null
  *
  * @example
  * // Returns false
- * checkIsNotNullish(undefined); // The value is undefined
+ * check_is_not_nullish(undefined); // The value is undefined
  */
-export const checkIsNotNullish = <T>(
-  value: T,
+export const check_is_not_nullish = <T>(
+	value: T
 ): value is Exclude<T, Nullish> => {
-  return !checkIsNullish(value);
+	return !check_is_nullish(value);
 };

--- a/packages/nullish/src/checkNullish/test.ts
+++ b/packages/nullish/src/checkNullish/test.ts
@@ -2,45 +2,45 @@ import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import { check_is_not_nullish, check_is_nullish } from "./main.ts";
 
 Deno.test("checkIsNullish", async (t) => {
-	await t.step("should return true for nullish values", () => {
-		assertEquals(check_is_nullish(null), true);
-		assertEquals(check_is_nullish(undefined), true);
-	});
+  await t.step("should return true for nullish values", () => {
+    assertEquals(check_is_nullish(null), true);
+    assertEquals(check_is_nullish(undefined), true);
+  });
 
-	await t.step("should return false for non-nullish values", () => {
-		assertEquals(check_is_nullish("string"), false);
-		assertEquals(check_is_nullish(123), false);
-		assertEquals(check_is_nullish([]), false);
-		assertEquals(check_is_nullish({}), false);
-	});
+  await t.step("should return false for non-nullish values", () => {
+    assertEquals(check_is_nullish("string"), false);
+    assertEquals(check_is_nullish(123), false);
+    assertEquals(check_is_nullish([]), false);
+    assertEquals(check_is_nullish({}), false);
+  });
 
-	await t.step("should narrow nullish types", () => {
-		type Value = string | null | undefined;
-		const value = {} as Value;
-		if (check_is_nullish(value)) {
-			assertType<IsExact<typeof value, null | undefined>>(true);
-		}
-	});
+  await t.step("should narrow nullish types", () => {
+    type Value = string | null | undefined;
+    const value = {} as Value;
+    if (check_is_nullish(value)) {
+      assertType<IsExact<typeof value, null | undefined>>(true);
+    }
+  });
 });
 
 Deno.test("checkIsNotNullish", async (t) => {
-	await t.step("should return true for non-nullish values", () => {
-		assertEquals(check_is_not_nullish("string"), true);
-		assertEquals(check_is_not_nullish(123), true);
-		assertEquals(check_is_not_nullish([]), true);
-		assertEquals(check_is_not_nullish({}), true);
-	});
+  await t.step("should return true for non-nullish values", () => {
+    assertEquals(check_is_not_nullish("string"), true);
+    assertEquals(check_is_not_nullish(123), true);
+    assertEquals(check_is_not_nullish([]), true);
+    assertEquals(check_is_not_nullish({}), true);
+  });
 
-	await t.step("should return false for nullish values", () => {
-		assertEquals(check_is_not_nullish(null), false);
-		assertEquals(check_is_not_nullish(undefined), false);
-	});
+  await t.step("should return false for nullish values", () => {
+    assertEquals(check_is_not_nullish(null), false);
+    assertEquals(check_is_not_nullish(undefined), false);
+  });
 
-	await t.step("should exclude nullish types", () => {
-		type Value = string | null | undefined;
-		const value = {} as Value;
-		if (check_is_not_nullish(value)) {
-			assertType<IsExact<typeof value, string>>(true);
-		}
-	});
+  await t.step("should exclude nullish types", () => {
+    type Value = string | null | undefined;
+    const value = {} as Value;
+    if (check_is_not_nullish(value)) {
+      assertType<IsExact<typeof value, string>>(true);
+    }
+  });
 });

--- a/packages/nullish/src/checkNullish/test.ts
+++ b/packages/nullish/src/checkNullish/test.ts
@@ -1,46 +1,46 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkIsNotNullish, checkIsNullish } from "./main.ts";
+import { check_is_not_nullish, check_is_nullish } from "./main.ts";
 
 Deno.test("checkIsNullish", async (t) => {
-  await t.step("should return true for nullish values", () => {
-    assertEquals(checkIsNullish(null), true);
-    assertEquals(checkIsNullish(undefined), true);
-  });
+	await t.step("should return true for nullish values", () => {
+		assertEquals(check_is_nullish(null), true);
+		assertEquals(check_is_nullish(undefined), true);
+	});
 
-  await t.step("should return false for non-nullish values", () => {
-    assertEquals(checkIsNullish("string"), false);
-    assertEquals(checkIsNullish(123), false);
-    assertEquals(checkIsNullish([]), false);
-    assertEquals(checkIsNullish({}), false);
-  });
+	await t.step("should return false for non-nullish values", () => {
+		assertEquals(check_is_nullish("string"), false);
+		assertEquals(check_is_nullish(123), false);
+		assertEquals(check_is_nullish([]), false);
+		assertEquals(check_is_nullish({}), false);
+	});
 
-  await t.step("should narrow nullish types", () => {
-    type Value = string | null | undefined;
-    const value = {} as Value;
-    if (checkIsNullish(value)) {
-      assertType<IsExact<typeof value, null | undefined>>(true);
-    }
-  });
+	await t.step("should narrow nullish types", () => {
+		type Value = string | null | undefined;
+		const value = {} as Value;
+		if (check_is_nullish(value)) {
+			assertType<IsExact<typeof value, null | undefined>>(true);
+		}
+	});
 });
 
 Deno.test("checkIsNotNullish", async (t) => {
-  await t.step("should return true for non-nullish values", () => {
-    assertEquals(checkIsNotNullish("string"), true);
-    assertEquals(checkIsNotNullish(123), true);
-    assertEquals(checkIsNotNullish([]), true);
-    assertEquals(checkIsNotNullish({}), true);
-  });
+	await t.step("should return true for non-nullish values", () => {
+		assertEquals(check_is_not_nullish("string"), true);
+		assertEquals(check_is_not_nullish(123), true);
+		assertEquals(check_is_not_nullish([]), true);
+		assertEquals(check_is_not_nullish({}), true);
+	});
 
-  await t.step("should return false for nullish values", () => {
-    assertEquals(checkIsNotNullish(null), false);
-    assertEquals(checkIsNotNullish(undefined), false);
-  });
+	await t.step("should return false for nullish values", () => {
+		assertEquals(check_is_not_nullish(null), false);
+		assertEquals(check_is_not_nullish(undefined), false);
+	});
 
-  await t.step("should exclude nullish types", () => {
-    type Value = string | null | undefined;
-    const value = {} as Value;
-    if (checkIsNotNullish(value)) {
-      assertType<IsExact<typeof value, string>>(true);
-    }
-  });
+	await t.step("should exclude nullish types", () => {
+		type Value = string | null | undefined;
+		const value = {} as Value;
+		if (check_is_not_nullish(value)) {
+			assertType<IsExact<typeof value, string>>(true);
+		}
+	});
 });

--- a/packages/nullish/src/checkUndefined/main.ts
+++ b/packages/nullish/src/checkUndefined/main.ts
@@ -6,34 +6,34 @@
  *
  * @example
  * // Returns true
- * checkIsUndefined(undefined); // The value is strictly undefined
+ * check_is_undefined(undefined); // The value is strictly undefined
  *
  * @example
  * // Returns false
- * checkIsUndefined(null); // The value is not undefined, but it's null
+ * check_is_undefined(null); // The value is not undefined, but it's null
  */
-export const checkIsUndefined = (value: unknown): value is undefined => {
-  return value === undefined;
+export const check_is_undefined = (value: unknown): value is undefined => {
+	return value === undefined;
 };
 
 /**
  * Checks if the given value is not strictly `undefined`.
  *
- * This is the inverse of `checkIsUndefined`.
+ * This is the inverse of `check_is_undefined`.
  *
  * @param {T} value - The value to check.
  * @returns {value is Exclude<T, undefined>} True if the value is not strictly `undefined`, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotUndefined(null); // The value is not undefined, it's null
+ * check_is_not_undefined(null); // The value is not undefined, it's null
  *
  * @example
  * // Returns false
- * checkIsNotUndefined(undefined); // The value is strictly undefined
+ * check_is_not_undefined(undefined); // The value is strictly undefined
  */
-export const checkIsNotUndefined = <T>(
-  value: T,
+export const check_is_not_undefined = <T>(
+	value: T
 ): value is Exclude<T, undefined> => {
-  return !checkIsUndefined(value);
+	return !check_is_undefined(value);
 };

--- a/packages/nullish/src/checkUndefined/main.ts
+++ b/packages/nullish/src/checkUndefined/main.ts
@@ -13,7 +13,7 @@
  * check_is_undefined(null); // The value is not undefined, but it's null
  */
 export const check_is_undefined = (value: unknown): value is undefined => {
-	return value === undefined;
+  return value === undefined;
 };
 
 /**
@@ -33,7 +33,7 @@ export const check_is_undefined = (value: unknown): value is undefined => {
  * check_is_not_undefined(undefined); // The value is strictly undefined
  */
 export const check_is_not_undefined = <T>(
-	value: T
+  value: T,
 ): value is Exclude<T, undefined> => {
-	return !check_is_undefined(value);
+  return !check_is_undefined(value);
 };

--- a/packages/nullish/src/checkUndefined/test.ts
+++ b/packages/nullish/src/checkUndefined/test.ts
@@ -1,48 +1,48 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkIsNotUndefined, checkIsUndefined } from "./main.ts";
+import { check_is_not_undefined, check_is_undefined } from "./main.ts";
 
-Deno.test("checkIsUndefined", async (t) => {
-  await t.step("should return true for undefined", () => {
-    assertEquals(checkIsUndefined(undefined), true);
-  });
+Deno.test("check_is_undefined", async (t) => {
+	await t.step("should return true for undefined", () => {
+		assertEquals(check_is_undefined(undefined), true);
+	});
 
-  await t.step("should return false for non-undefined values", () => {
-    assertEquals(checkIsUndefined(null), false);
-    assertEquals(checkIsUndefined(0), false);
-    assertEquals(checkIsUndefined(""), false);
-    assertEquals(checkIsUndefined(false), false);
-    assertEquals(checkIsUndefined({}), false);
-    assertEquals(checkIsUndefined(0n), false);
-  });
+	await t.step("should return false for non-undefined values", () => {
+		assertEquals(check_is_undefined(null), false);
+		assertEquals(check_is_undefined(0), false);
+		assertEquals(check_is_undefined(""), false);
+		assertEquals(check_is_undefined(false), false);
+		assertEquals(check_is_undefined({}), false);
+		assertEquals(check_is_undefined(0n), false);
+	});
 
-  await t.step("should narrow undefined type", () => {
-    type Value = string | null | undefined;
-    const value = {} as Value;
-    if (checkIsUndefined(value)) {
-      assertType<IsExact<typeof value, undefined>>(true);
-    }
-  });
+	await t.step("should narrow undefined type", () => {
+		type Value = string | null | undefined;
+		const value = {} as Value;
+		if (check_is_undefined(value)) {
+			assertType<IsExact<typeof value, undefined>>(true);
+		}
+	});
 });
 
-Deno.test("checkIsNotUndefined", async (t) => {
-  await t.step("should return true for non-undefined values", () => {
-    assertEquals(checkIsNotUndefined(null), true);
-    assertEquals(checkIsNotUndefined(0), true);
-    assertEquals(checkIsNotUndefined(""), true);
-    assertEquals(checkIsNotUndefined(false), true);
-    assertEquals(checkIsNotUndefined({}), true);
-    assertEquals(checkIsNotUndefined(0n), true);
-  });
+Deno.test("check_is_not_undefined", async (t) => {
+	await t.step("should return true for non-undefined values", () => {
+		assertEquals(check_is_not_undefined(null), true);
+		assertEquals(check_is_not_undefined(0), true);
+		assertEquals(check_is_not_undefined(""), true);
+		assertEquals(check_is_not_undefined(false), true);
+		assertEquals(check_is_not_undefined({}), true);
+		assertEquals(check_is_not_undefined(0n), true);
+	});
 
-  await t.step("should return false for undefined", () => {
-    assertEquals(checkIsNotUndefined(undefined), false);
-  });
+	await t.step("should return false for undefined", () => {
+		assertEquals(check_is_not_undefined(undefined), false);
+	});
 
-  await t.step("should exclude undefined type", () => {
-    type Value = string | null | undefined;
-    const value = {} as Value;
-    if (checkIsNotUndefined(value)) {
-      assertType<IsExact<typeof value, string | null>>(true);
-    }
-  });
+	await t.step("should exclude undefined type", () => {
+		type Value = string | null | undefined;
+		const value = {} as Value;
+		if (check_is_not_undefined(value)) {
+			assertType<IsExact<typeof value, string | null>>(true);
+		}
+	});
 });

--- a/packages/nullish/src/checkUndefined/test.ts
+++ b/packages/nullish/src/checkUndefined/test.ts
@@ -2,47 +2,47 @@ import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import { check_is_not_undefined, check_is_undefined } from "./main.ts";
 
 Deno.test("check_is_undefined", async (t) => {
-	await t.step("should return true for undefined", () => {
-		assertEquals(check_is_undefined(undefined), true);
-	});
+  await t.step("should return true for undefined", () => {
+    assertEquals(check_is_undefined(undefined), true);
+  });
 
-	await t.step("should return false for non-undefined values", () => {
-		assertEquals(check_is_undefined(null), false);
-		assertEquals(check_is_undefined(0), false);
-		assertEquals(check_is_undefined(""), false);
-		assertEquals(check_is_undefined(false), false);
-		assertEquals(check_is_undefined({}), false);
-		assertEquals(check_is_undefined(0n), false);
-	});
+  await t.step("should return false for non-undefined values", () => {
+    assertEquals(check_is_undefined(null), false);
+    assertEquals(check_is_undefined(0), false);
+    assertEquals(check_is_undefined(""), false);
+    assertEquals(check_is_undefined(false), false);
+    assertEquals(check_is_undefined({}), false);
+    assertEquals(check_is_undefined(0n), false);
+  });
 
-	await t.step("should narrow undefined type", () => {
-		type Value = string | null | undefined;
-		const value = {} as Value;
-		if (check_is_undefined(value)) {
-			assertType<IsExact<typeof value, undefined>>(true);
-		}
-	});
+  await t.step("should narrow undefined type", () => {
+    type Value = string | null | undefined;
+    const value = {} as Value;
+    if (check_is_undefined(value)) {
+      assertType<IsExact<typeof value, undefined>>(true);
+    }
+  });
 });
 
 Deno.test("check_is_not_undefined", async (t) => {
-	await t.step("should return true for non-undefined values", () => {
-		assertEquals(check_is_not_undefined(null), true);
-		assertEquals(check_is_not_undefined(0), true);
-		assertEquals(check_is_not_undefined(""), true);
-		assertEquals(check_is_not_undefined(false), true);
-		assertEquals(check_is_not_undefined({}), true);
-		assertEquals(check_is_not_undefined(0n), true);
-	});
+  await t.step("should return true for non-undefined values", () => {
+    assertEquals(check_is_not_undefined(null), true);
+    assertEquals(check_is_not_undefined(0), true);
+    assertEquals(check_is_not_undefined(""), true);
+    assertEquals(check_is_not_undefined(false), true);
+    assertEquals(check_is_not_undefined({}), true);
+    assertEquals(check_is_not_undefined(0n), true);
+  });
 
-	await t.step("should return false for undefined", () => {
-		assertEquals(check_is_not_undefined(undefined), false);
-	});
+  await t.step("should return false for undefined", () => {
+    assertEquals(check_is_not_undefined(undefined), false);
+  });
 
-	await t.step("should exclude undefined type", () => {
-		type Value = string | null | undefined;
-		const value = {} as Value;
-		if (check_is_not_undefined(value)) {
-			assertType<IsExact<typeof value, string | null>>(true);
-		}
-	});
+  await t.step("should exclude undefined type", () => {
+    type Value = string | null | undefined;
+    const value = {} as Value;
+    if (check_is_not_undefined(value)) {
+      assertType<IsExact<typeof value, string | null>>(true);
+    }
+  });
 });

--- a/packages/number/README.md
+++ b/packages/number/README.md
@@ -227,8 +227,8 @@ check_is_not_greater_than_or_equal(10, 5); // false
 
 Checks if the given value is Infinity.
 
-If you want to know if a string is Infinity, use the `check_is_infinity_string()`
-function.
+If you want to know if a string is Infinity, use the
+`check_is_infinity_string()` function.
 
 ```ts
 check_is_infinity(Infinity); // true

--- a/packages/number/README.md
+++ b/packages/number/README.md
@@ -41,497 +41,497 @@ bunx jsr add @checker/number
 
 ## Functions
 
-### `checkIsCleanlyDivisible`
+### `check_is_cleanly_disible`
 
 Checks if a given number is cleanly divisible by a divisor.
 
 ```ts
-checkIsCleanDisible(10, 2); // 10 % 2 = 0
-checkIsCleanDivible(10, 3); // 10 % 3 = 1
+check_is_cleanly_disible(10, 2); // 10 % 2 = 0
+check_is_cleanly_disible(10, 3); // 10 % 3 = 1
 ```
 
-### `checkIsNotCleanlyDivisible`
+### `check_is_not_cleanly_disible`
 
 Checks if a given number is not cleanly divisible by a divisor.
 
 ```ts
-checkIsNotCleanDisible(10, 3); // true, 10 % 3 = 1
-checkIsNotCleanDisible(10, 2); // false, 10 % 2 = 0
+check_is_not_cleanly_disible(10, 3); // true, 10 % 3 = 1
+check_is_not_cleanly_disible(10, 2); // false, 10 % 2 = 0
 ```
 
-### `checkIsCubeRoot`
+### `check_is_cube_root`
 
 Checks if a given number is the cube root of a target number.
 
 ```ts
-checkIsCubeRoot(3, 27); // true, 3 * 3 * 3 = 27
-checkIsCubeRoot(2, 27); // false, 2 * 2 * 2 = 8 ≠ 27
+check_is_cube_root(3, 27); // true, 3 * 3 * 3 = 27
+check_is_cube_root(2, 27); // false, 2 * 2 * 2 = 8 ≠ 27
 ```
 
-### `checkIsNotCubeRoot`
+### `check_is_not_cube_root`
 
 Checks if a given number is not the cube root of a target number.
 
 ```ts
-checkIsNotCubeRoot(2, 27); // true, 2 * 2 * 2 = 8 ≠ 27
-checkIsNotCubeRoot(3, 27); // false, 3 * 3 * 3 = 27
+check_is_not_cube_root(2, 27); // true, 2 * 2 * 2 = 8 ≠ 27
+check_is_not_cube_root(3, 27); // false, 3 * 3 * 3 = 27
 ```
 
-### `checkIsDivisor`
+### `check_is_divisor`
 
 Checks if the given number is a divisor of the target number.
 
 ```ts
-checkIsDivisor(3, 9);
+check_is_divisor(3, 9);
 // true, 9 % 3 = 0 => 3 is a divisor of 9
 
-checkIsDivisor(2, 9);
+check_is_divisor(2, 9);
 // false, 9 % 2 = 1 => 2 is not a divisor of 9
 ```
 
-### `checkIsNotDivisor`
+### `check_is_not_divisor`
 
 Checks if the given number is not a divisor of the target number.
 
 ```ts
-checkIsNotDivisor(2, 9); // true
-checkIsNotDivisor(3, 9); // false
+check_is_not_divisor(2, 9); // true
+check_is_not_divisor(3, 9); // false
 ```
 
-### `checkIsEven`
+### `check_is_even`
 
 Checks if a given number is even.
 
 ```ts
-checkIsEven(4); // true
-checkIsEven(3); // false
+check_is_even(4); // true
+check_is_even(3); // false
 ```
 
-### `checkIsNotEven`
+### `check_is_not_even`
 
 Checks if a given number is not even (odd).
 
 ```ts
-checkIsNotEven(3); // false
-checkIsNotEven(4); // true
+check_is_not_even(3); // false
+check_is_not_even(4); // true
 ```
 
-### `checkIsFibonacci`
+### `check_is_fibonacci`
 
 Checks if a given number is a Fibonacci number.
 
 ```ts
-checkIsFibonacci(3); // true
-checkIsFibonacci(5); // true
+check_is_fibonacci(3); // true
+check_is_fibonacci(5); // true
 
-checkIsFibonacci(4); //false
-checkIsFibonacci(6); // false
+check_is_fibonacci(4); //false
+check_is_fibonacci(6); // false
 ```
 
-### `checkIsNotFibonacci`
+### `check_is_not_fibonacci`
 
 Checks if a given number is not a Fibonacci number.
 
 ```ts
-checkIsNotFibonacci(4); // true
-checkIsNotFibonacci(6); // true
+check_is_not_fibonacci(4); // true
+check_is_not_fibonacci(6); // true
 
-checkIsNotFibonacci(3); // false
-checkIsNotFibonacci(5); // false
+check_is_not_fibonacci(3); // false
+check_is_not_fibonacci(5); // false
 ```
 
-### `checkIsFloat`
+### `check_is_float`
 
 Checks if the given number is a floating-point number.
 
 ```ts
-checkIsFloat(1.2); // true
+check_is_float(1.2); // true
 
-checkIsFloat(1); // false
-checkIsFloat(1.0); // 1.0 % 1 = 0 => false
+check_is_float(1); // false
+check_is_float(1.0); // 1.0 % 1 = 0 => false
 ```
 
-### `checkIsNotFloat`
+### `check_is_not_float`
 
 Checks if the given number is not a floating-point number.
 
 ```ts
-checkIsNotFloat(1); // true
-checkIsNotFloat(1.0); // true
+check_is_not_float(1); // true
+check_is_not_float(1.0); // true
 
-checkIsNotFloat(1.2); // false
+check_is_not_float(1.2); // false
 ```
 
-### `checkIsGeometricSequence`
+### `check_is_geometric_sequence`
 
 Checks if the given array of numbers forms a geometric sequence with the
 specified ratio.
 
 ```ts
-checkIsGeometricSequence([2, 4, 8], 2); // true
-checkIsGeometricSequence([2, 4, 9], 2); // false
+check_is_geometric_sequence([2, 4, 8], 2); // true
+check_is_geometric_sequence([2, 4, 9], 2); // false
 ```
 
-### `checkIsNotGeometricSequence`
+### `check_is_not_geometric_sequence`
 
 Checks if the given array of numbers does not form a geometric sequence with the
 specified ratio.
 
 ```ts
-checkIsNotGeometricSequence([2, 4, 9], 2); // false
-checkIsNotGeometricSequence([2, 4, 8], 2); // true
+check_is_not_geometric_sequence([2, 4, 9], 2); // false
+check_is_not_geometric_sequence([2, 4, 8], 2); // true
 ```
 
-### `checkIsGreaterThan`
+### `check_is_greater_than`
 
 Checks if the given number is greater than a specified threshold.
 
 ```ts
-checkIsGreaterThan(10, 5); // true, 10 is greater than 5
-checkIsGreaterThan(10, 15); // false, 10 is not greater than 15
+check_is_greater_than(10, 5); // true, 10 is greater than 5
+check_is_greater_than(10, 15); // false, 10 is not greater than 15
 ```
 
-### `checkIsNotGreaterThan`
+### `check_is_not_greater_than`
 
 Checks if the given number is not greater than a specified threshold.
 
 ```ts
-checkIsGreaterThan(10, 15); // true, 10 is not greater than 15
-checkIsGreterThan(10, 10); // false
-checkIsGreaterThan(10, 5); // false, 10 is greater than 5
+check_is_not_greater_than(10, 15); // true, 10 is not greater than 15
+check_is_not_greater_than(10, 10); // false
+check_is_not_greater_than(10, 5); // false, 10 is greater than 5
 ```
 
-### `checkIsGreaterThanOrEqual`
+### `check_is_greater_than_or_equal`
 
 Checks if a number is greater than or equal to a given threshold.
 
 ```ts
-checkIsGreaterThanOrEqual(10, 10); // true, 10 is equal 10
-checkIsGreaterThanOrEqual(10, 5); // true, 10 is greater than 5
+check_is_greater_than_or_equal(10, 10); // true, 10 is equal 10
+check_is_greater_than_or_equal(10, 5); // true, 10 is greater than 5
 
-checkIsGreaterThanOrEqual(10, 15); // false, 10 is not greater than 15
+check_is_greater_than_or_equal(10, 15); // false, 10 is not greater than 15
 ```
 
-### `checkIsNotGreaterThanOrEqual`
+### `check_is_not_greater_than_or_equal`
 
 Checks if a number is not greater than or equal to a given threshold.
 
 ```ts
-checkIsNotGreaterThanOrEqual(10, 15); // true
+check_is_not_greater_than_or_equal(10, 15); // true
 
-checkIsNotGreaterThanOrEqual(10, 10); // false
-checkIsGreaterThanOrEqual(10, 5); // false
+check_is_not_greater_than_or_equal(10, 10); // false
+check_is_not_greater_than_or_equal(10, 5); // false
 ```
 
-### `checkIsInfiniy`
+### `check_is_infinity`
 
 Checks if the given value is Infinity.
 
-If you want to know if a string is Infinity, use the `checkIsInifinityString()`
+If you want to know if a string is Infinity, use the `check_is_infinity_string()`
 function.
 
 ```ts
-checkIsInfinity(Infinity); // true
-checkIsInfinity(-Infinity); // true
+check_is_infinity(Infinity); // true
+check_is_infinity(-Infinity); // true
 
-checkIsInfinity("hello"); // false
-checkIsInifinity(123); // false
+check_is_infinity("hello"); // false
+check_is_infinity(123); // false
 ```
 
-### `checkIsNotInfinity`
+### `check_is_not_infinity`
 
 Checks if the given value is not Infinity.
 
 ```ts
-checkIsNotInfinity("hello"); // true
-checkIsNotInifinity(123); // true
+check_is_not_infinity("hello"); // true
+check_is_not_infinity(123); // true
 
-checkIsNotInfinity(Infinity); // false
-checkIsNotInfinity(-Infinity); // false
+check_is_not_infinity(Infinity); // false
+check_is_not_infinity(-Infinity); // false
 ```
 
-### `checkIsInterger`
+### `check_is_integer`
 
 Checks if the given number is an integer.
 
 ```ts
-checkIsInteger(1); // true
-checkIsInteger(1.1); // false
+check_is_integer(1); // true
+check_is_integer(1.1); // false
 ```
 
-### `checkIsNotInteger`
+### `check_is_not_integer`
 
 Checks if the given number is not an integer.
 
 ```ts
-checkIsNotInteger(1.1); // true
-checkIsNotInteger(1); // false
+check_is_not_integer(1.1); // true
+check_is_not_integer(1); // false
 ```
 
-### `checkIsLessThan`
+### `check_is_less_than`
 
 Checks if a number is less than a specified threshold.
 
 ```ts
-checkIsLessThan(5, 10); // true, 5 is less than 10
-checkIsLessThan(15, 10); // false, 15 is not less than 10
+check_is_less_than(5, 10); // true, 5 is less than 10
+check_is_less_than(15, 10); // false, 15 is not less than 10
 ```
 
-### `checkIsNotLessThan`
+### `check_is_not_less_than`
 
 Checks if a number is not less than a specified threshold.
 
 ```ts
-checkIsNotLessThan(15, 10); // true
-checkIsNotLessThan(5, 10); // false
+check_is_not_less_than(15, 10); // true
+check_is_not_less_than(5, 10); // false
 ```
 
-### `checkIsLessThanOrEqual`
+### `check_is_less_than_or_equal`
 
 Checks if the given number is less than or equal to the specified threshold.
 
 ```ts
-checkIsLessTHanOrEqual(10, 10); // true
-checkIsLessThanOrEqual(15, 10); // true
+check_is_less_than_or_equal(10, 10); // true
+check_is_less_than_or_equal(15, 10); // true
 
-checkIsLessThanOrEqual(5, 10); // false
+check_is_less_than_or_equal(5, 10); // false
 ```
 
-### `checkIsNotLessThanOrEqual`
+### `check_is_not_less_than_or_equal`
 
 Checks if the given number is not less than or equal to the specified threshold.
 
 ```ts
-checkIsNotLessThanOrEqual(5, 10); // true
+check_is_not_less_than_or_equal(5, 10); // true
 
 checkIsLessTHanOrEqual(10, 10); // true
-checkIsNotLessThanOrEqual(15, 5); // false
+check_is_not_less_than_or_equal(15, 5); // false
 ```
 
-### `checkIsLogarithm`
+### `check_is_logarithm`
 
 Checks if a given number matches the logarithm of a target with a specified
 base.
 
 ```ts
-checkIsLogarithm(4, 2, 16); // log2(16) = 4
-checkIsLogarithm(4, 2, 8); // log2(8) = 3 ≠ 4
+check_is_logarithm(4, 2, 16); // log2(16) = 4
+check_is_logarithm(4, 2, 8); // log2(8) = 3 ≠ 4
 ```
 
-### `checkIsNotLogarithm`
+### `check_is_not_logarithm`
 
 Checks if a given number does not match the logarithm of a target with a
 specified base.
 
 ```ts
-checkIsNotLogarithm(4, 2, 8); // true
-checkIsNotLogarithm(4, 2, 16); // false
+check_is_not_logarithm(4, 2, 8); // true
+check_is_not_logarithm(4, 2, 16); // false
 ```
 
-### `checkIsNegative`
+### `check_is_negative`
 
 Checks if a given number is negative.
 
 ```ts
-checkIsNegative(-1); // true
-checkIsNegative(1); // false
+check_is_negative(-1); // true
+check_is_negative(1); // false
 ```
 
-### `checkIsNotNegative`
+### check_is_not_negative
 
 Checks if a given number is not negative.
 
 ```ts
-checkIsNotNegative(1); // true
-checkIsNegative(-1); // true
+check_is_not_negative(1); // true
+check_is_not_negative(-1); // true
 ```
 
-### `checkIsNumber`
+### `check_is_number`
 
 Checks if the given value is of type `number`.
 
 ```ts
-checkIsNumber(1); // true
-checkIsNumber("string"); // false
+check_is_number(1); // true
+check_is_number("string"); // false
 ```
 
-### `checkIsNotNumber`
+### `check_is_not_number`
 
 Checks if the given value is not of type `number`.
 
 ```ts
-checkIsNotNumber("string"); // true
-checkIsNotNumber(1); // false
+check_is_not_number("string"); // true
+check_is_not_number(1); // false
 ```
 
-### `checkIsOdd`
+### `check_is_odd`
 
 Checks if a given number is odd.
 
 ```ts
-checkIsOdd(3); // true
-checkIsOdd(-3); // true
+check_is_odd(3); // true
+check_is_odd(-3); // true
 
-checkIsOdd(2); // false
-checkIsOdd(-2); // false
+check_is_odd(2); // false
+check_is_odd(-2); // false
 ```
 
-### `checkIsNotOdd`
+### `check_is_not_odd`
 
 Checks if a given number is not odd.
 
 ```ts
-checkIsNotOdd(2); // true
-checkIsNotOdd(-2); // true
+check_is_not_odd(2); // true
+check_is_not_odd(-2); // true
 
-checkIsOdd(3); // false
-checkIsOdd(-3); // false
+check_is_not_odd(3); // false
+check_is_not_odd(-3); // false
 ```
 
-### `checkIsPerfectNumber`
+### `check_is_perfect_number`
 
 Checks if a given number is a perfect number.
 
 ```ts
-checkIsPerfectNumber(28); // true, 1 + 2 + 4 + 7 + 14 = 28
-checkIsPerfectNumber(12); // false, 1 + 2 + 3 + 4 + 6 = 16
+check_is_perfect_number(28); // true, 1 + 2 + 4 + 7 + 14 = 28
+check_is_perfect_number(12); // false, 1 + 2 + 3 + 4 + 6 = 16
 ```
 
-### `checkIsNotPerfectNumber`
+### `check_is_not_perfect_number`
 
 Checks if a given number is not a perfect number.
 
 ```ts
-checkIsPerfectNumber(12); // true
-checkIsPerfectNumber(28); // false
+check_is_not_perfect_number(12); // true
+check_is_not_perfect_number(28); // false
 ```
 
-### `checkIsPerfectSquare`
+### `check_is_perfect_square`
 
 Checks if a given number is a perfect square.
 
 ```ts
-checkIsPerfectSquare(16); // true, 4 * 4 = 16
-checkIsPerfectSquare(8); // false, 2 * 2 = 4 ≠ 8
+check_is_perfect_square(16); // true, 4 * 4 = 16
+check_is_perfect_square(8); // false, 2 * 2 = 4 ≠ 8
 ```
 
-### `checkIsNotPerfectSquare`
+### `check_is_not_perfect_square`
 
 Checks if a given number is not a perfect square.
 
 ```ts
-checkIsNotPerfectSquare(8); // true
-checkIsNotPerfectSquare(16); // false
+check_is_not_perfect_square(8); // true
+check_is_not_perfect_square(16); // false
 ```
 
-### `checkIsPositive`
+### `check_is_positive`
 
 Checks if a given number is positive.
 
 ```ts
-checkIsPositive(1); // true
+check_is_positive(1); // true
 
-checkIsPositive(0); // false
-checkIsPositive(-1); // false
+check_is_positive(0); // false
+check_is_positive(-1); // false
 ```
 
-### `checkIsNotPositive`
+### `check_is_not_positive`
 
 Checks if a given number is not positive.
 
 ```ts
-checkIsNotPositive(0); // true
-checkIsNotPositive(-1); // true
+check_is_not_positive(0); // true
+check_is_not_positive(-1); // true
 
-checkIsNotPositive(1); // false
+check_is_not_positive(1); // false
 ```
 
-### `checkIsPower`
+### `check_is_power`
 
 Checks if a given number is a power of a specified base.
 
 ```ts
-checkIsPowerOf(8, 2); // true, 8 is 2^3, so it's a power of 2
-checkIsPower(10, 2); // false, 10 is not a power of 2
+check_is_power(8, 2); // true, 8 is 2^3, so it's a power of 2
+check_is_power(10, 2); // false, 10 is not a power of 2
 ```
 
-### `checkIsNotPower`
+### `check_is_not_power`
 
 Checks if a given number is not a power of a specified base.
 
 ```ts
-checkIsNotPower(10, 2); // true
-checkIsNotPower(8, 2); // false
+check_is_not_power(10, 2); // true
+check_is_not_power(8, 2); // false
 ```
 
-### `checkIsPrime`
+### `check_is_prime`
 
 Checks if a given number is a prime number.
 
 ```ts
-checkIsPrime(7); // true
-checkisPrime(10); // false, 10 is divisible by 2 and 5
+check_is_prime(7); // true
+check_is_prime(10); // false, 10 is divisible by 2 and 5
 ```
 
-### `checkIsNotPrime`
+### `check_is_not_prime`
 
 Checks if a given number is not a prime number.
 
 ```ts
-checkIsNotPrime(10); // true
-checkIsNotPrime(7); // false
+check_is_not_prime(10); // true
+check_is_not_prime(7); // false
 ```
 
-### `checkIsSquareRoot`
+### `check_is_square_root`
 
 Checks if a given number is the square root of the target number.
 
 ```ts
-checkIsSquareRootOf(3, 9); // true, 3 * 3 = 9
-checkIsSquareRootOf(4, 20); // false, 4 * 4 =16
+check_is_square_root(3, 9); // true, 3 * 3 = 9
+check_is_square_root(4, 20); // false, 4 * 4 =16
 ```
 
-### `checkIsNotSquareRoot`
+### `check_is_not_sequare_root`
 
 Checks if a given number is not the square root of the target number.
 
 ```ts
-checkIsNotSquareRootOf(4, 20); // true
-checkIsNotSquareRootOf(3, 9); // false, 3 * 3 = 9
+check_is_not_sequare_root(4, 20); // true
+check_is_not_sequare_root(3, 9); // false, 3 * 3 = 9
 ```
 
-### `checkIsWithinRange`
+### `check_within_range`
 
 Checks if a given number is within a specified range, inclusive.
 
 ```ts
-checkIsWithinRange(5, 1, 10); // true, 5 is within the range [1, 10]
-checkIsWithinRange(15, 1, 10); // false, 15 is not within the range [1, 10]
+check_within_range(5, 1, 10); // true, 5 is within the range [1, 10]
+check_within_range(15, 1, 10); // false, 15 is not within the range [1, 10]
 ```
 
-### `checkIsNotWithinRange`
+### `check_is_not_within_range`
 
 Checks if a given number is not within a specified range.
 
 ```ts
-checkIsNotWithinRange(15, 1, 10); //
-checkIsNotWithinRange(5, 1, 10);
+check_is_not_within_range(15, 1, 10); //
+check_is_not_within_range(5, 1, 10);
 ```
 
-### `checkIsZero`
+### `check_is_zero`
 
 Checks if the given number is zero.
 
 ```ts
-checkIsZero(0); // true
-checkIsZero(5); // false
+check_is_zero(0); // true
+check_is_zero(5); // false
 ```
 
-### `checkIsNotZero`
+### `check_is_not_zero`
 
 Checks if the given number is not zero.
 
 ```ts
-checkIsNotZero(5); // true
-checkIsNotZero(0); // false
+check_is_not_zero(5); // true
+check_is_not_zero(0); // false
 ```

--- a/packages/number/mod.ts
+++ b/packages/number/mod.ts
@@ -1,135 +1,135 @@
 import {
-	check_is_cleanly_disible,
-	check_is_not_cleanly_disible,
+  check_is_cleanly_disible,
+  check_is_not_cleanly_disible,
 } from "./src/checkCleanlyDivisible/main.ts";
 import {
-	check_is_cube_root,
-	check_is_not_cube_root,
+  check_is_cube_root,
+  check_is_not_cube_root,
 } from "./src/checkCubeRoot/main.ts";
 import {
-	check_is_divisor,
-	check_is_not_divisor,
+  check_is_divisor,
+  check_is_not_divisor,
 } from "./src/checkDivisor/main.ts";
 import { check_is_even, check_is_not_even } from "./src/checkEven/main.ts";
 import {
-	check_is_fibonacci,
-	check_is_not_fibonacci,
+  check_is_fibonacci,
+  check_is_not_fibonacci,
 } from "./src/checkFibonacci/main.ts";
 import { check_is_float, check_is_not_float } from "./src/checkFloat/main.ts";
 import {
-	check_is_geometric_sequence,
-	check_is_not_geometric_sequence,
+  check_is_geometric_sequence,
+  check_is_not_geometric_sequence,
 } from "./src/checkGeometricSequence/main.ts";
 import {
-	check_is_greater_than,
-	check_is_not_greater_than,
+  check_is_greater_than,
+  check_is_not_greater_than,
 } from "./src/checkGreaterThan/main.ts";
 import {
-	check_is_infinity,
-	check_is_not_infinity,
+  check_is_infinity,
+  check_is_not_infinity,
 } from "./src/checkInfinity/main.ts";
 import {
-	check_is_logarithm,
-	check_is_not_logarithm,
+  check_is_logarithm,
+  check_is_not_logarithm,
 } from "./src/checkLogarithm/main.ts";
 import { check_is_not_power, check_is_power } from "./src/checkPower/main.ts";
 import {
-	check_is_not_square_root,
-	check_is_square_root,
+  check_is_not_square_root,
+  check_is_square_root,
 } from "./src/checkSquareRoot/main.ts";
 import {
-	check_is_not_number,
-	check_is_number,
+  check_is_not_number,
+  check_is_number,
 } from "./src/checkNumber/main.ts";
 import {
-	check_is_not_positive,
-	check_is_positive,
+  check_is_not_positive,
+  check_is_positive,
 } from "./src/checkPositive/main.ts";
 import {
-	check_is_negative,
-	check_is_not_negative,
+  check_is_negative,
+  check_is_not_negative,
 } from "./src/checkNegative/main.ts";
 import { check_is_not_zero, check_is_zero } from "./src/checkZero/main.ts";
 import {
-	check_is_integer,
-	check_is_not_integer,
+  check_is_integer,
+  check_is_not_integer,
 } from "./src/checkInteger/main.ts";
 import { check_is_not_odd, check_is_odd } from "./src/checkOdd/main.ts";
 import { check_is_not_prime, check_is_prime } from "./src/checkPrime/main.ts";
 import {
-	check_is_less_than,
-	check_is_not_less_than,
+  check_is_less_than,
+  check_is_not_less_than,
 } from "./src/checkLessThan/main.ts";
 import {
-	check_is_greater_than_or_equal,
-	check_is_not_greater_than_or_equal,
+  check_is_greater_than_or_equal,
+  check_is_not_greater_than_or_equal,
 } from "./src/checkGreaterThanOrEqual/main.ts";
 import {
-	check_is_less_than_or_equal,
-	check_is_not_less_than_or_equal,
+  check_is_less_than_or_equal,
+  check_is_not_less_than_or_equal,
 } from "./src/checkLessThanOrEqual/main.ts";
 import {
-	check_is_not_within_range,
-	check_is_within_range,
+  check_is_not_within_range,
+  check_is_within_range,
 } from "./src/checkWithinRange/main.ts";
 import {
-	check_is_not_perfect_number,
-	check_is_perfect_number,
+  check_is_not_perfect_number,
+  check_is_perfect_number,
 } from "./src/checkPerfectNumber/main.ts";
 import {
-	check_is_not_perfect_square,
-	check_is_perfect_square,
+  check_is_not_perfect_square,
+  check_is_perfect_square,
 } from "./src/checkPerfectSquare/main.ts";
 
 export {
-	check_is_cleanly_disible,
-	check_is_cube_root,
-	check_is_divisor,
-	check_is_even,
-	check_is_fibonacci,
-	check_is_float,
-	check_is_geometric_sequence,
-	check_is_greater_than,
-	check_is_greater_than_or_equal,
-	check_is_infinity,
-	check_is_integer,
-	check_is_less_than,
-	check_is_less_than_or_equal,
-	check_is_logarithm,
-	check_is_negative,
-	check_is_not_cleanly_disible,
-	check_is_not_cube_root,
-	check_is_not_divisor,
-	check_is_not_even,
-	check_is_not_fibonacci,
-	check_is_not_float,
-	check_is_not_geometric_sequence,
-	check_is_not_greater_than,
-	check_is_not_greater_than_or_equal,
-	check_is_not_infinity,
-	check_is_not_integer,
-	check_is_not_less_than,
-	check_is_not_less_than_or_equal,
-	check_is_not_logarithm,
-	check_is_not_negative,
-	check_is_not_number,
-	check_is_not_odd,
-	check_is_not_perfect_number,
-	check_is_not_perfect_square,
-	check_is_not_positive,
-	check_is_not_power,
-	check_is_not_prime,
-	check_is_not_square_root,
-	check_is_not_within_range,
-	check_is_not_zero,
-	check_is_number,
-	check_is_odd,
-	check_is_perfect_number,
-	check_is_perfect_square,
-	check_is_positive,
-	check_is_power,
-	check_is_prime,
-	check_is_square_root,
-	check_is_within_range,
-	check_is_zero,
+  check_is_cleanly_disible,
+  check_is_cube_root,
+  check_is_divisor,
+  check_is_even,
+  check_is_fibonacci,
+  check_is_float,
+  check_is_geometric_sequence,
+  check_is_greater_than,
+  check_is_greater_than_or_equal,
+  check_is_infinity,
+  check_is_integer,
+  check_is_less_than,
+  check_is_less_than_or_equal,
+  check_is_logarithm,
+  check_is_negative,
+  check_is_not_cleanly_disible,
+  check_is_not_cube_root,
+  check_is_not_divisor,
+  check_is_not_even,
+  check_is_not_fibonacci,
+  check_is_not_float,
+  check_is_not_geometric_sequence,
+  check_is_not_greater_than,
+  check_is_not_greater_than_or_equal,
+  check_is_not_infinity,
+  check_is_not_integer,
+  check_is_not_less_than,
+  check_is_not_less_than_or_equal,
+  check_is_not_logarithm,
+  check_is_not_negative,
+  check_is_not_number,
+  check_is_not_odd,
+  check_is_not_perfect_number,
+  check_is_not_perfect_square,
+  check_is_not_positive,
+  check_is_not_power,
+  check_is_not_prime,
+  check_is_not_square_root,
+  check_is_not_within_range,
+  check_is_not_zero,
+  check_is_number,
+  check_is_odd,
+  check_is_perfect_number,
+  check_is_perfect_square,
+  check_is_positive,
+  check_is_power,
+  check_is_prime,
+  check_is_square_root,
+  check_is_within_range,
+  check_is_zero,
 };

--- a/packages/number/mod.ts
+++ b/packages/number/mod.ts
@@ -1,126 +1,135 @@
 import {
-  checkIsCleanlyDivisible,
-  checkIsNotCleanlyDivisible,
+	check_is_cleanly_disible,
+	check_is_not_cleanly_disible,
 } from "./src/checkCleanlyDivisible/main.ts";
 import {
-  checkIsCubeRoot,
-  checkIsNotCubeRoot,
+	check_is_cube_root,
+	check_is_not_cube_root,
 } from "./src/checkCubeRoot/main.ts";
-import { checkIsDivisor, checkIsNotDivisor } from "./src/checkDivisor/main.ts";
-import { checkIsEven, checkIsNotEven } from "./src/checkEven/main.ts";
 import {
-  checkIsFibonacci,
-  checkIsNotFibonacci,
+	check_is_divisor,
+	check_is_not_divisor,
+} from "./src/checkDivisor/main.ts";
+import { check_is_even, check_is_not_even } from "./src/checkEven/main.ts";
+import {
+	check_is_fibonacci,
+	check_is_not_fibonacci,
 } from "./src/checkFibonacci/main.ts";
-import { checkIsFloat, checkIsNotFloat } from "./src/checkFloat/main.ts";
+import { check_is_float, check_is_not_float } from "./src/checkFloat/main.ts";
 import {
-  checkIsGeometricSequence,
-  checkIsNotGeometricSequence,
+	check_is_geometric_sequence,
+	check_is_not_geometric_sequence,
 } from "./src/checkGeometricSequence/main.ts";
 import {
-  checkIsGreaterThan,
-  checkIsNotGreaterThan,
+	check_is_greater_than,
+	check_is_not_greater_than,
 } from "./src/checkGreaterThan/main.ts";
 import {
-  checkIsInfinity,
-  checkIsNotInfinity,
+	check_is_infinity,
+	check_is_not_infinity,
 } from "./src/checkInfinity/main.ts";
 import {
-  checkIsLogarithm,
-  checkIsNotLogarithm,
+	check_is_logarithm,
+	check_is_not_logarithm,
 } from "./src/checkLogarithm/main.ts";
-import { checkIsNotPower, checkIsPower } from "./src/checkPower/main.ts";
+import { check_is_not_power, check_is_power } from "./src/checkPower/main.ts";
 import {
-  checkIsNotSquareRoot,
-  checkIsSquareRoot,
+	check_is_not_square_root,
+	check_is_square_root,
 } from "./src/checkSquareRoot/main.ts";
-import { checkIsNotNumber, checkIsNumber } from "./src/checkNumber/main.ts";
 import {
-  checkIsNotPositive,
-  checkIsPositive,
+	check_is_not_number,
+	check_is_number,
+} from "./src/checkNumber/main.ts";
+import {
+	check_is_not_positive,
+	check_is_positive,
 } from "./src/checkPositive/main.ts";
 import {
-  checkIsNegative,
-  checkIsNotNegative,
+	check_is_negative,
+	check_is_not_negative,
 } from "./src/checkNegative/main.ts";
-import { checkIsNotZero, checkIsZero } from "./src/checkZero/main.ts";
-import { checkIsInteger, checkIsNotInteger } from "./src/checkInteger/main.ts";
-import { checkIsNotOdd, checkIsOdd } from "./src/checkOdd/main.ts";
-import { checkIsNotPrime, checkIsPrime } from "./src/checkPrime/main.ts";
+import { check_is_not_zero, check_is_zero } from "./src/checkZero/main.ts";
 import {
-  checkIsLessThan,
-  checkIsNotLessThan,
+	check_is_integer,
+	check_is_not_integer,
+} from "./src/checkInteger/main.ts";
+import { check_is_not_odd, check_is_odd } from "./src/checkOdd/main.ts";
+import { check_is_not_prime, check_is_prime } from "./src/checkPrime/main.ts";
+import {
+	check_is_less_than,
+	check_is_not_less_than,
 } from "./src/checkLessThan/main.ts";
 import {
-  checkIsGreaterThanOrEqual,
-  checkIsNotGreaterThanOrEqual,
+	check_is_greater_than_or_equal,
+	check_is_not_greater_than_or_equal,
 } from "./src/checkGreaterThanOrEqual/main.ts";
 import {
-  checkIsLessThanOrEqual,
-  checkIsNotLessThanOrEqual,
+	check_is_less_than_or_equal,
+	check_is_not_less_than_or_equal,
 } from "./src/checkLessThanOrEqual/main.ts";
 import {
-  checkIsNotWithinRange,
-  checkIsWithinRange,
+	check_is_not_within_range,
+	check_is_within_range,
 } from "./src/checkWithinRange/main.ts";
 import {
-  checkIsNotPerfectNumber,
-  checkIsPerfectNumber,
+	check_is_not_perfect_number,
+	check_is_perfect_number,
 } from "./src/checkPerfectNumber/main.ts";
 import {
-  checkIsNotPerfectSquare,
-  checkIsPerfectSquare,
+	check_is_not_perfect_square,
+	check_is_perfect_square,
 } from "./src/checkPerfectSquare/main.ts";
 
 export {
-  checkIsCleanlyDivisible,
-  checkIsCubeRoot,
-  checkIsDivisor,
-  checkIsEven,
-  checkIsFibonacci,
-  checkIsFloat,
-  checkIsGeometricSequence,
-  checkIsGreaterThan,
-  checkIsGreaterThanOrEqual,
-  checkIsInfinity,
-  checkIsInteger,
-  checkIsLessThan,
-  checkIsLessThanOrEqual,
-  checkIsLogarithm,
-  checkIsNegative,
-  checkIsNotCleanlyDivisible,
-  checkIsNotCubeRoot,
-  checkIsNotDivisor,
-  checkIsNotEven,
-  checkIsNotFibonacci,
-  checkIsNotFloat,
-  checkIsNotGeometricSequence,
-  checkIsNotGreaterThan,
-  checkIsNotGreaterThanOrEqual,
-  checkIsNotInfinity,
-  checkIsNotInteger,
-  checkIsNotLessThan,
-  checkIsNotLessThanOrEqual,
-  checkIsNotLogarithm,
-  checkIsNotNegative,
-  checkIsNotNumber,
-  checkIsNotOdd,
-  checkIsNotPerfectNumber,
-  checkIsNotPerfectSquare,
-  checkIsNotPositive,
-  checkIsNotPower,
-  checkIsNotPrime,
-  checkIsNotSquareRoot,
-  checkIsNotWithinRange,
-  checkIsNotZero,
-  checkIsNumber,
-  checkIsOdd,
-  checkIsPerfectNumber,
-  checkIsPerfectSquare,
-  checkIsPositive,
-  checkIsPower,
-  checkIsPrime,
-  checkIsSquareRoot,
-  checkIsWithinRange,
-  checkIsZero,
+	check_is_cleanly_disible,
+	check_is_cube_root,
+	check_is_divisor,
+	check_is_even,
+	check_is_fibonacci,
+	check_is_float,
+	check_is_geometric_sequence,
+	check_is_greater_than,
+	check_is_greater_than_or_equal,
+	check_is_infinity,
+	check_is_integer,
+	check_is_less_than,
+	check_is_less_than_or_equal,
+	check_is_logarithm,
+	check_is_negative,
+	check_is_not_cleanly_disible,
+	check_is_not_cube_root,
+	check_is_not_divisor,
+	check_is_not_even,
+	check_is_not_fibonacci,
+	check_is_not_float,
+	check_is_not_geometric_sequence,
+	check_is_not_greater_than,
+	check_is_not_greater_than_or_equal,
+	check_is_not_infinity,
+	check_is_not_integer,
+	check_is_not_less_than,
+	check_is_not_less_than_or_equal,
+	check_is_not_logarithm,
+	check_is_not_negative,
+	check_is_not_number,
+	check_is_not_odd,
+	check_is_not_perfect_number,
+	check_is_not_perfect_square,
+	check_is_not_positive,
+	check_is_not_power,
+	check_is_not_prime,
+	check_is_not_square_root,
+	check_is_not_within_range,
+	check_is_not_zero,
+	check_is_number,
+	check_is_odd,
+	check_is_perfect_number,
+	check_is_perfect_square,
+	check_is_positive,
+	check_is_power,
+	check_is_prime,
+	check_is_square_root,
+	check_is_within_range,
+	check_is_zero,
 };

--- a/packages/number/src/checkCleanlyDivisible/main.ts
+++ b/packages/number/src/checkCleanlyDivisible/main.ts
@@ -9,23 +9,23 @@
  *
  * @example
  * // Returns true
- * checkIsCleanlyDivisible(10, 2); // 10 is cleanly divisible by 2
+ * check_is_cleanly_disible(10, 2); // 10 is cleanly divisible by 2
  *
  * @example
  * // Returns false
- * checkIsCleanlyDivisible(10, 3); // 10 is not cleanly divisible by 3
+ * check_is_cleanly_disible(10, 3); // 10 is not cleanly divisible by 3
  */
-export const checkIsCleanlyDivisible = (
-  num: number,
-  divisor: number,
+export const check_is_cleanly_disible = (
+	num: number,
+	divisor: number
 ): boolean => {
-  return num % divisor === 0;
+	return num % divisor === 0;
 };
 
 /**
  * Checks if a given number is not cleanly divisible by a divisor.
  *
- * This is the inverse of `checkIsCleanlyDivisible`.
+ * This is the inverse of `check_is_cleanly_disible`.
  *
  * @param {number} num - The number to check.
  * @param {number} divisor - The divisor to check against.
@@ -33,15 +33,15 @@ export const checkIsCleanlyDivisible = (
  *
  * @example
  * // Returns true
- * checkIsNotCleanlyDivisible(10, 3); // 10 is not cleanly divisible by 3
+ * check_is_not_cleanly_disible(10, 3); // 10 is not cleanly divisible by 3
  *
  * @example
  * // Returns false
- * checkIsNotCleanlyDivisible(10, 2); // 10 is cleanly divisible by 2
+ * check_is_not_cleanly_disible(10, 2); // 10 is cleanly divisible by 2
  */
-export const checkIsNotCleanlyDivisible = (
-  num: number,
-  divisor: number,
+export const check_is_not_cleanly_disible = (
+	num: number,
+	divisor: number
 ): boolean => {
-  return !checkIsCleanlyDivisible(num, divisor);
+	return !check_is_cleanly_disible(num, divisor);
 };

--- a/packages/number/src/checkCleanlyDivisible/main.ts
+++ b/packages/number/src/checkCleanlyDivisible/main.ts
@@ -16,10 +16,10 @@
  * check_is_cleanly_disible(10, 3); // 10 is not cleanly divisible by 3
  */
 export const check_is_cleanly_disible = (
-	num: number,
-	divisor: number
+  num: number,
+  divisor: number,
 ): boolean => {
-	return num % divisor === 0;
+  return num % divisor === 0;
 };
 
 /**
@@ -40,8 +40,8 @@ export const check_is_cleanly_disible = (
  * check_is_not_cleanly_disible(10, 2); // 10 is cleanly divisible by 2
  */
 export const check_is_not_cleanly_disible = (
-	num: number,
-	divisor: number
+  num: number,
+  divisor: number,
 ): boolean => {
-	return !check_is_cleanly_disible(num, divisor);
+  return !check_is_cleanly_disible(num, divisor);
 };

--- a/packages/number/src/checkCleanlyDivisible/test.ts
+++ b/packages/number/src/checkCleanlyDivisible/test.ts
@@ -1,53 +1,53 @@
 import { assertEquals } from "../../deps.ts";
 import {
-	check_is_cleanly_disible,
-	check_is_not_cleanly_disible,
+  check_is_cleanly_disible,
+  check_is_not_cleanly_disible,
 } from "./main.ts";
 
 Deno.test("check_is_cleanly_disible", async (t) => {
-	await t.step(
-		"should return true for numbers divisible by the divisor",
-		() => {
-			assertEquals(check_is_cleanly_disible(10, 2), true);
-			assertEquals(check_is_cleanly_disible(15, 3), true);
-			assertEquals(check_is_cleanly_disible(100, 10), true);
-			assertEquals(check_is_cleanly_disible(0, 1), true); // Zero is divisible by any non-zero number
-			assertEquals(check_is_cleanly_disible(-10, 5), true); // Negative number divisible
-		}
-	);
+  await t.step(
+    "should return true for numbers divisible by the divisor",
+    () => {
+      assertEquals(check_is_cleanly_disible(10, 2), true);
+      assertEquals(check_is_cleanly_disible(15, 3), true);
+      assertEquals(check_is_cleanly_disible(100, 10), true);
+      assertEquals(check_is_cleanly_disible(0, 1), true); // Zero is divisible by any non-zero number
+      assertEquals(check_is_cleanly_disible(-10, 5), true); // Negative number divisible
+    },
+  );
 
-	await t.step(
-		"should return false for numbers not divisible by the divisor",
-		() => {
-			assertEquals(check_is_cleanly_disible(10, 3), false);
-			assertEquals(check_is_cleanly_disible(14, 5), false);
-			assertEquals(check_is_cleanly_disible(100, 6), false);
-			assertEquals(check_is_cleanly_disible(7, 2), false);
-			assertEquals(check_is_cleanly_disible(-9, 4), false); // Negative number not divisible
-		}
-	);
+  await t.step(
+    "should return false for numbers not divisible by the divisor",
+    () => {
+      assertEquals(check_is_cleanly_disible(10, 3), false);
+      assertEquals(check_is_cleanly_disible(14, 5), false);
+      assertEquals(check_is_cleanly_disible(100, 6), false);
+      assertEquals(check_is_cleanly_disible(7, 2), false);
+      assertEquals(check_is_cleanly_disible(-9, 4), false); // Negative number not divisible
+    },
+  );
 });
 
 Deno.test("check_is_not_cleanly_disible", async (t) => {
-	await t.step(
-		"should return true for numbers not divisible by the divisor",
-		() => {
-			assertEquals(check_is_not_cleanly_disible(10, 3), true);
-			assertEquals(check_is_not_cleanly_disible(14, 5), true);
-			assertEquals(check_is_not_cleanly_disible(100, 6), true);
-			assertEquals(check_is_not_cleanly_disible(7, 2), true);
-			assertEquals(check_is_not_cleanly_disible(-9, 4), true); // Negative number not divisible
-		}
-	);
+  await t.step(
+    "should return true for numbers not divisible by the divisor",
+    () => {
+      assertEquals(check_is_not_cleanly_disible(10, 3), true);
+      assertEquals(check_is_not_cleanly_disible(14, 5), true);
+      assertEquals(check_is_not_cleanly_disible(100, 6), true);
+      assertEquals(check_is_not_cleanly_disible(7, 2), true);
+      assertEquals(check_is_not_cleanly_disible(-9, 4), true); // Negative number not divisible
+    },
+  );
 
-	await t.step(
-		"should return false for numbers divisible by the divisor",
-		() => {
-			assertEquals(check_is_not_cleanly_disible(10, 2), false);
-			assertEquals(check_is_not_cleanly_disible(15, 3), false);
-			assertEquals(check_is_not_cleanly_disible(100, 10), false);
-			assertEquals(check_is_not_cleanly_disible(0, 1), false); // Zero is divisible by any non-zero number
-			assertEquals(check_is_not_cleanly_disible(-10, 5), false); // Negative number divisible
-		}
-	);
+  await t.step(
+    "should return false for numbers divisible by the divisor",
+    () => {
+      assertEquals(check_is_not_cleanly_disible(10, 2), false);
+      assertEquals(check_is_not_cleanly_disible(15, 3), false);
+      assertEquals(check_is_not_cleanly_disible(100, 10), false);
+      assertEquals(check_is_not_cleanly_disible(0, 1), false); // Zero is divisible by any non-zero number
+      assertEquals(check_is_not_cleanly_disible(-10, 5), false); // Negative number divisible
+    },
+  );
 });

--- a/packages/number/src/checkCleanlyDivisible/test.ts
+++ b/packages/number/src/checkCleanlyDivisible/test.ts
@@ -1,50 +1,53 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsCleanlyDivisible, checkIsNotCleanlyDivisible } from "./main.ts";
+import {
+	check_is_cleanly_disible,
+	check_is_not_cleanly_disible,
+} from "./main.ts";
 
-Deno.test("checkIsDivisibleBy", async (t) => {
-  await t.step(
-    "should return true for numbers divisible by the divisor",
-    () => {
-      assertEquals(checkIsCleanlyDivisible(10, 2), true);
-      assertEquals(checkIsCleanlyDivisible(15, 3), true);
-      assertEquals(checkIsCleanlyDivisible(100, 10), true);
-      assertEquals(checkIsCleanlyDivisible(0, 1), true); // Zero is divisible by any non-zero number
-      assertEquals(checkIsCleanlyDivisible(-10, 5), true); // Negative number divisible
-    },
-  );
+Deno.test("check_is_cleanly_disible", async (t) => {
+	await t.step(
+		"should return true for numbers divisible by the divisor",
+		() => {
+			assertEquals(check_is_cleanly_disible(10, 2), true);
+			assertEquals(check_is_cleanly_disible(15, 3), true);
+			assertEquals(check_is_cleanly_disible(100, 10), true);
+			assertEquals(check_is_cleanly_disible(0, 1), true); // Zero is divisible by any non-zero number
+			assertEquals(check_is_cleanly_disible(-10, 5), true); // Negative number divisible
+		}
+	);
 
-  await t.step(
-    "should return false for numbers not divisible by the divisor",
-    () => {
-      assertEquals(checkIsCleanlyDivisible(10, 3), false);
-      assertEquals(checkIsCleanlyDivisible(14, 5), false);
-      assertEquals(checkIsCleanlyDivisible(100, 6), false);
-      assertEquals(checkIsCleanlyDivisible(7, 2), false);
-      assertEquals(checkIsCleanlyDivisible(-9, 4), false); // Negative number not divisible
-    },
-  );
+	await t.step(
+		"should return false for numbers not divisible by the divisor",
+		() => {
+			assertEquals(check_is_cleanly_disible(10, 3), false);
+			assertEquals(check_is_cleanly_disible(14, 5), false);
+			assertEquals(check_is_cleanly_disible(100, 6), false);
+			assertEquals(check_is_cleanly_disible(7, 2), false);
+			assertEquals(check_is_cleanly_disible(-9, 4), false); // Negative number not divisible
+		}
+	);
 });
 
-Deno.test("checkIsNotDivisibleBy", async (t) => {
-  await t.step(
-    "should return true for numbers not divisible by the divisor",
-    () => {
-      assertEquals(checkIsNotCleanlyDivisible(10, 3), true);
-      assertEquals(checkIsNotCleanlyDivisible(14, 5), true);
-      assertEquals(checkIsNotCleanlyDivisible(100, 6), true);
-      assertEquals(checkIsNotCleanlyDivisible(7, 2), true);
-      assertEquals(checkIsNotCleanlyDivisible(-9, 4), true); // Negative number not divisible
-    },
-  );
+Deno.test("check_is_not_cleanly_disible", async (t) => {
+	await t.step(
+		"should return true for numbers not divisible by the divisor",
+		() => {
+			assertEquals(check_is_not_cleanly_disible(10, 3), true);
+			assertEquals(check_is_not_cleanly_disible(14, 5), true);
+			assertEquals(check_is_not_cleanly_disible(100, 6), true);
+			assertEquals(check_is_not_cleanly_disible(7, 2), true);
+			assertEquals(check_is_not_cleanly_disible(-9, 4), true); // Negative number not divisible
+		}
+	);
 
-  await t.step(
-    "should return false for numbers divisible by the divisor",
-    () => {
-      assertEquals(checkIsNotCleanlyDivisible(10, 2), false);
-      assertEquals(checkIsNotCleanlyDivisible(15, 3), false);
-      assertEquals(checkIsNotCleanlyDivisible(100, 10), false);
-      assertEquals(checkIsNotCleanlyDivisible(0, 1), false); // Zero is divisible by any non-zero number
-      assertEquals(checkIsNotCleanlyDivisible(-10, 5), false); // Negative number divisible
-    },
-  );
+	await t.step(
+		"should return false for numbers divisible by the divisor",
+		() => {
+			assertEquals(check_is_not_cleanly_disible(10, 2), false);
+			assertEquals(check_is_not_cleanly_disible(15, 3), false);
+			assertEquals(check_is_not_cleanly_disible(100, 10), false);
+			assertEquals(check_is_not_cleanly_disible(0, 1), false); // Zero is divisible by any non-zero number
+			assertEquals(check_is_not_cleanly_disible(-10, 5), false); // Negative number divisible
+		}
+	);
 });

--- a/packages/number/src/checkCubeRoot/main.ts
+++ b/packages/number/src/checkCubeRoot/main.ts
@@ -7,20 +7,20 @@
  *
  * @example
  * // Returns true
- * checkIsCubeRoot(3, 27); // 3 is the cube root of 27
+ * check_is_cube_root(3, 27); // 3 is the cube root of 27
  *
  * @example
  * // Returns false
- * checkIsCubeRoot(2, 27); // 2 is not the cube root of 27
+ * check_is_cube_root(2, 27); // 2 is not the cube root of 27
  */
-export const checkIsCubeRoot = (num: number, target: number): boolean => {
-  return num === Math.cbrt(target);
+export const check_is_cube_root = (num: number, target: number): boolean => {
+	return num === Math.cbrt(target);
 };
 
 /**
  * Checks if a given number is not the cube root of a target number.
  *
- * This is the inverse of `checkIsCubeRoot`.
+ * This is the inverse of `check_is_cube_root`.
  *
  * @param {number} num - The number to check.
  * @param {number} target - The target number to check against.
@@ -28,12 +28,15 @@ export const checkIsCubeRoot = (num: number, target: number): boolean => {
  *
  * @example
  * // Returns true
- * checkIsNotCubeRoot(2, 27); // 2 is not the cube root of 27
+ * check_is_not_cube_root(2, 27); // 2 is not the cube root of 27
  *
  * @example
  * // Returns false
- * checkIsNotCubeRoot(3, 27); // 3 is the cube root of 27
+ * check_is_not_cube_root(3, 27); // 3 is the cube root of 27
  */
-export const checkIsNotCubeRoot = (num: number, target: number): boolean => {
-  return !checkIsCubeRoot(num, target);
+export const check_is_not_cube_root = (
+	num: number,
+	target: number
+): boolean => {
+	return !check_is_cube_root(num, target);
 };

--- a/packages/number/src/checkCubeRoot/main.ts
+++ b/packages/number/src/checkCubeRoot/main.ts
@@ -14,7 +14,7 @@
  * check_is_cube_root(2, 27); // 2 is not the cube root of 27
  */
 export const check_is_cube_root = (num: number, target: number): boolean => {
-	return num === Math.cbrt(target);
+  return num === Math.cbrt(target);
 };
 
 /**
@@ -35,8 +35,8 @@ export const check_is_cube_root = (num: number, target: number): boolean => {
  * check_is_not_cube_root(3, 27); // 3 is the cube root of 27
  */
 export const check_is_not_cube_root = (
-	num: number,
-	target: number
+  num: number,
+  target: number,
 ): boolean => {
-	return !check_is_cube_root(num, target);
+  return !check_is_cube_root(num, target);
 };

--- a/packages/number/src/checkCubeRoot/test.ts
+++ b/packages/number/src/checkCubeRoot/test.ts
@@ -1,50 +1,50 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsCubeRoot, checkIsNotCubeRoot } from "./main.ts";
+import { check_is_cube_root, check_is_not_cube_root } from "./main.ts";
 
 Deno.test("checkIsCubeRootOf", async (t) => {
-  await t.step(
-    "should return true if the number is the cube root of the target",
-    () => {
-      assertEquals(checkIsCubeRoot(3, 27), true); // 3 is the cube root of 27
-      assertEquals(checkIsCubeRoot(2, 8), true); // 2 is the cube root of 8
-      assertEquals(checkIsCubeRoot(-2, -8), true); // -2 is the cube root of -8
-      assertEquals(checkIsCubeRoot(0, 0), true); // 0 is the cube root of 0
-      assertEquals(checkIsCubeRoot(1, 1), true); // 1 is the cube root of 1
-    },
-  );
+	await t.step(
+		"should return true if the number is the cube root of the target",
+		() => {
+			assertEquals(check_is_cube_root(3, 27), true); // 3 is the cube root of 27
+			assertEquals(check_is_cube_root(2, 8), true); // 2 is the cube root of 8
+			assertEquals(check_is_cube_root(-2, -8), true); // -2 is the cube root of -8
+			assertEquals(check_is_cube_root(0, 0), true); // 0 is the cube root of 0
+			assertEquals(check_is_cube_root(1, 1), true); // 1 is the cube root of 1
+		}
+	);
 
-  await t.step(
-    "should return false if the number is not the cube root of the target",
-    () => {
-      assertEquals(checkIsCubeRoot(4, 27), false); // 4 is not the cube root of 27
-      assertEquals(checkIsCubeRoot(2, 9), false); // 2 is not the cube root of 9
-      assertEquals(checkIsCubeRoot(-3, -8), false); // -3 is not the cube root of -8
-      assertEquals(checkIsCubeRoot(1, 0), false); // 1 is not the cube root of 0
-      assertEquals(checkIsCubeRoot(0, 1), false); // 0 is not the cube root of 1
-    },
-  );
+	await t.step(
+		"should return false if the number is not the cube root of the target",
+		() => {
+			assertEquals(check_is_cube_root(4, 27), false); // 4 is not the cube root of 27
+			assertEquals(check_is_cube_root(2, 9), false); // 2 is not the cube root of 9
+			assertEquals(check_is_cube_root(-3, -8), false); // -3 is not the cube root of -8
+			assertEquals(check_is_cube_root(1, 0), false); // 1 is not the cube root of 0
+			assertEquals(check_is_cube_root(0, 1), false); // 0 is not the cube root of 1
+		}
+	);
 });
 
 Deno.test("checkIsNotCubeRootOf", async (t) => {
-  await t.step(
-    "should return true if the number is not the cube root of the target",
-    () => {
-      assertEquals(checkIsNotCubeRoot(4, 27), true); // 4 is not the cube root of 27
-      assertEquals(checkIsNotCubeRoot(2, 9), true); // 2 is not the cube root of 9
-      assertEquals(checkIsNotCubeRoot(-3, -8), true); // -3 is not the cube root of -8
-      assertEquals(checkIsNotCubeRoot(1, 0), true); // 1 is not the cube root of 0
-      assertEquals(checkIsNotCubeRoot(0, 1), true); // 0 is not the cube root of 1
-    },
-  );
+	await t.step(
+		"should return true if the number is not the cube root of the target",
+		() => {
+			assertEquals(check_is_not_cube_root(4, 27), true); // 4 is not the cube root of 27
+			assertEquals(check_is_not_cube_root(2, 9), true); // 2 is not the cube root of 9
+			assertEquals(check_is_not_cube_root(-3, -8), true); // -3 is not the cube root of -8
+			assertEquals(check_is_not_cube_root(1, 0), true); // 1 is not the cube root of 0
+			assertEquals(check_is_not_cube_root(0, 1), true); // 0 is not the cube root of 1
+		}
+	);
 
-  await t.step(
-    "should return false if the number is the cube root of the target",
-    () => {
-      assertEquals(checkIsNotCubeRoot(3, 27), false); // 3 is the cube root of 27
-      assertEquals(checkIsNotCubeRoot(2, 8), false); // 2 is the cube root of 8
-      assertEquals(checkIsNotCubeRoot(-2, -8), false); // -2 is the cube root of -8
-      assertEquals(checkIsNotCubeRoot(0, 0), false); // 0 is the cube root of 0
-      assertEquals(checkIsNotCubeRoot(1, 1), false); // 1 is the cube root of 1
-    },
-  );
+	await t.step(
+		"should return false if the number is the cube root of the target",
+		() => {
+			assertEquals(check_is_not_cube_root(3, 27), false); // 3 is the cube root of 27
+			assertEquals(check_is_not_cube_root(2, 8), false); // 2 is the cube root of 8
+			assertEquals(check_is_not_cube_root(-2, -8), false); // -2 is the cube root of -8
+			assertEquals(check_is_not_cube_root(0, 0), false); // 0 is the cube root of 0
+			assertEquals(check_is_not_cube_root(1, 1), false); // 1 is the cube root of 1
+		}
+	);
 });

--- a/packages/number/src/checkCubeRoot/test.ts
+++ b/packages/number/src/checkCubeRoot/test.ts
@@ -2,49 +2,49 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_cube_root, check_is_not_cube_root } from "./main.ts";
 
 Deno.test("checkIsCubeRootOf", async (t) => {
-	await t.step(
-		"should return true if the number is the cube root of the target",
-		() => {
-			assertEquals(check_is_cube_root(3, 27), true); // 3 is the cube root of 27
-			assertEquals(check_is_cube_root(2, 8), true); // 2 is the cube root of 8
-			assertEquals(check_is_cube_root(-2, -8), true); // -2 is the cube root of -8
-			assertEquals(check_is_cube_root(0, 0), true); // 0 is the cube root of 0
-			assertEquals(check_is_cube_root(1, 1), true); // 1 is the cube root of 1
-		}
-	);
+  await t.step(
+    "should return true if the number is the cube root of the target",
+    () => {
+      assertEquals(check_is_cube_root(3, 27), true); // 3 is the cube root of 27
+      assertEquals(check_is_cube_root(2, 8), true); // 2 is the cube root of 8
+      assertEquals(check_is_cube_root(-2, -8), true); // -2 is the cube root of -8
+      assertEquals(check_is_cube_root(0, 0), true); // 0 is the cube root of 0
+      assertEquals(check_is_cube_root(1, 1), true); // 1 is the cube root of 1
+    },
+  );
 
-	await t.step(
-		"should return false if the number is not the cube root of the target",
-		() => {
-			assertEquals(check_is_cube_root(4, 27), false); // 4 is not the cube root of 27
-			assertEquals(check_is_cube_root(2, 9), false); // 2 is not the cube root of 9
-			assertEquals(check_is_cube_root(-3, -8), false); // -3 is not the cube root of -8
-			assertEquals(check_is_cube_root(1, 0), false); // 1 is not the cube root of 0
-			assertEquals(check_is_cube_root(0, 1), false); // 0 is not the cube root of 1
-		}
-	);
+  await t.step(
+    "should return false if the number is not the cube root of the target",
+    () => {
+      assertEquals(check_is_cube_root(4, 27), false); // 4 is not the cube root of 27
+      assertEquals(check_is_cube_root(2, 9), false); // 2 is not the cube root of 9
+      assertEquals(check_is_cube_root(-3, -8), false); // -3 is not the cube root of -8
+      assertEquals(check_is_cube_root(1, 0), false); // 1 is not the cube root of 0
+      assertEquals(check_is_cube_root(0, 1), false); // 0 is not the cube root of 1
+    },
+  );
 });
 
 Deno.test("checkIsNotCubeRootOf", async (t) => {
-	await t.step(
-		"should return true if the number is not the cube root of the target",
-		() => {
-			assertEquals(check_is_not_cube_root(4, 27), true); // 4 is not the cube root of 27
-			assertEquals(check_is_not_cube_root(2, 9), true); // 2 is not the cube root of 9
-			assertEquals(check_is_not_cube_root(-3, -8), true); // -3 is not the cube root of -8
-			assertEquals(check_is_not_cube_root(1, 0), true); // 1 is not the cube root of 0
-			assertEquals(check_is_not_cube_root(0, 1), true); // 0 is not the cube root of 1
-		}
-	);
+  await t.step(
+    "should return true if the number is not the cube root of the target",
+    () => {
+      assertEquals(check_is_not_cube_root(4, 27), true); // 4 is not the cube root of 27
+      assertEquals(check_is_not_cube_root(2, 9), true); // 2 is not the cube root of 9
+      assertEquals(check_is_not_cube_root(-3, -8), true); // -3 is not the cube root of -8
+      assertEquals(check_is_not_cube_root(1, 0), true); // 1 is not the cube root of 0
+      assertEquals(check_is_not_cube_root(0, 1), true); // 0 is not the cube root of 1
+    },
+  );
 
-	await t.step(
-		"should return false if the number is the cube root of the target",
-		() => {
-			assertEquals(check_is_not_cube_root(3, 27), false); // 3 is the cube root of 27
-			assertEquals(check_is_not_cube_root(2, 8), false); // 2 is the cube root of 8
-			assertEquals(check_is_not_cube_root(-2, -8), false); // -2 is the cube root of -8
-			assertEquals(check_is_not_cube_root(0, 0), false); // 0 is the cube root of 0
-			assertEquals(check_is_not_cube_root(1, 1), false); // 1 is the cube root of 1
-		}
-	);
+  await t.step(
+    "should return false if the number is the cube root of the target",
+    () => {
+      assertEquals(check_is_not_cube_root(3, 27), false); // 3 is the cube root of 27
+      assertEquals(check_is_not_cube_root(2, 8), false); // 2 is the cube root of 8
+      assertEquals(check_is_not_cube_root(-2, -8), false); // -2 is the cube root of -8
+      assertEquals(check_is_not_cube_root(0, 0), false); // 0 is the cube root of 0
+      assertEquals(check_is_not_cube_root(1, 1), false); // 1 is the cube root of 1
+    },
+  );
 });

--- a/packages/number/src/checkDivisor/main.ts
+++ b/packages/number/src/checkDivisor/main.ts
@@ -7,20 +7,20 @@
  *
  * @example
  * // Returns true
- * checkIsDivisor(3, 9); // 3 is a divisor of 9
+ * check_is_divisor(3, 9); // 3 is a divisor of 9
  *
  * @example
  * // Returns false
- * checkIsDivisor(2, 9); // 2 is not a divisor of 9
+ * check_is_divisor(2, 9); // 2 is not a divisor of 9
  */
-export const checkIsDivisor = (num: number, target: number): boolean => {
-  return target % num === 0;
+export const check_is_divisor = (num: number, target: number): boolean => {
+	return target % num === 0;
 };
 
 /**
  * Checks if the given number is not a divisor of the target number.
  *
- * This is the inverse of `checkIsDivisor`.
+ * This is the inverse of `check_is_divisor`.
  *
  * @param {number} num - The number to check as not being a divisor.
  * @param {number} target - The target number to be divided.
@@ -28,12 +28,12 @@ export const checkIsDivisor = (num: number, target: number): boolean => {
  *
  * @example
  * // Returns true
- * checkIsNotDivisor(2, 9); // 2 is not a divisor of 9
+ * check_is_not_divisor(2, 9); // 2 is not a divisor of 9
  *
  * @example
  * // Returns false
- * checkIsNotDivisor(3, 9); // 3 is a divisor of 9
+ * check_is_not_divisor(3, 9); // 3 is a divisor of 9
  */
-export const checkIsNotDivisor = (num: number, target: number): boolean => {
-  return !checkIsDivisor(num, target);
+export const check_is_not_divisor = (num: number, target: number): boolean => {
+	return !check_is_divisor(num, target);
 };

--- a/packages/number/src/checkDivisor/main.ts
+++ b/packages/number/src/checkDivisor/main.ts
@@ -14,7 +14,7 @@
  * check_is_divisor(2, 9); // 2 is not a divisor of 9
  */
 export const check_is_divisor = (num: number, target: number): boolean => {
-	return target % num === 0;
+  return target % num === 0;
 };
 
 /**
@@ -35,5 +35,5 @@ export const check_is_divisor = (num: number, target: number): boolean => {
  * check_is_not_divisor(3, 9); // 3 is a divisor of 9
  */
 export const check_is_not_divisor = (num: number, target: number): boolean => {
-	return !check_is_divisor(num, target);
+  return !check_is_divisor(num, target);
 };

--- a/packages/number/src/checkDivisor/test.ts
+++ b/packages/number/src/checkDivisor/test.ts
@@ -1,41 +1,41 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsDivisor, checkIsNotDivisor } from "./main.ts";
+import { check_is_divisor, check_is_not_divisor } from "./main.ts";
 
-Deno.test("checkIsDivisorOf", async (t) => {
-  await t.step("should return true when num is a divisor of target", () => {
-    assertEquals(checkIsDivisor(1, 10), true);
-    assertEquals(checkIsDivisor(2, 10), true);
-    assertEquals(checkIsDivisor(5, 10), true);
-    assertEquals(checkIsDivisor(10, 100), true);
-    assertEquals(checkIsDivisor(-2, 10), true);
-  });
+Deno.test("check_is_divisor", async (t) => {
+	await t.step("should return true when num is a divisor of target", () => {
+		assertEquals(check_is_divisor(1, 10), true);
+		assertEquals(check_is_divisor(2, 10), true);
+		assertEquals(check_is_divisor(5, 10), true);
+		assertEquals(check_is_divisor(10, 100), true);
+		assertEquals(check_is_divisor(-2, 10), true);
+	});
 
-  await t.step(
-    "should return false when num is not a divisor of target",
-    () => {
-      assertEquals(checkIsDivisor(3, 10), false);
-      assertEquals(checkIsDivisor(7, 10), false);
-      assertEquals(checkIsDivisor(11, 10), false);
-      assertEquals(checkIsDivisor(4, 10), false);
-      assertEquals(checkIsDivisor(-3, 10), false);
-    },
-  );
+	await t.step(
+		"should return false when num is not a divisor of target",
+		() => {
+			assertEquals(check_is_divisor(3, 10), false);
+			assertEquals(check_is_divisor(7, 10), false);
+			assertEquals(check_is_divisor(11, 10), false);
+			assertEquals(check_is_divisor(4, 10), false);
+			assertEquals(check_is_divisor(-3, 10), false);
+		}
+	);
 });
 
-Deno.test("checkIsNotDivisorOf", async (t) => {
-  await t.step("should return true when num is not a divisor of target", () => {
-    assertEquals(checkIsNotDivisor(3, 10), true);
-    assertEquals(checkIsNotDivisor(7, 10), true);
-    assertEquals(checkIsNotDivisor(11, 10), true);
-    assertEquals(checkIsNotDivisor(4, 10), true);
-    assertEquals(checkIsNotDivisor(-3, 10), true);
-  });
+Deno.test("check_is_not_divisor", async (t) => {
+	await t.step("should return true when num is not a divisor of target", () => {
+		assertEquals(check_is_not_divisor(3, 10), true);
+		assertEquals(check_is_not_divisor(7, 10), true);
+		assertEquals(check_is_not_divisor(11, 10), true);
+		assertEquals(check_is_not_divisor(4, 10), true);
+		assertEquals(check_is_not_divisor(-3, 10), true);
+	});
 
-  await t.step("should return false when num is a divisor of target", () => {
-    assertEquals(checkIsNotDivisor(1, 10), false);
-    assertEquals(checkIsNotDivisor(2, 10), false);
-    assertEquals(checkIsNotDivisor(5, 10), false);
-    assertEquals(checkIsNotDivisor(10, 100), false);
-    assertEquals(checkIsNotDivisor(-2, 10), false);
-  });
+	await t.step("should return false when num is a divisor of target", () => {
+		assertEquals(check_is_not_divisor(1, 10), false);
+		assertEquals(check_is_not_divisor(2, 10), false);
+		assertEquals(check_is_not_divisor(5, 10), false);
+		assertEquals(check_is_not_divisor(10, 100), false);
+		assertEquals(check_is_not_divisor(-2, 10), false);
+	});
 });

--- a/packages/number/src/checkDivisor/test.ts
+++ b/packages/number/src/checkDivisor/test.ts
@@ -2,40 +2,40 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_divisor, check_is_not_divisor } from "./main.ts";
 
 Deno.test("check_is_divisor", async (t) => {
-	await t.step("should return true when num is a divisor of target", () => {
-		assertEquals(check_is_divisor(1, 10), true);
-		assertEquals(check_is_divisor(2, 10), true);
-		assertEquals(check_is_divisor(5, 10), true);
-		assertEquals(check_is_divisor(10, 100), true);
-		assertEquals(check_is_divisor(-2, 10), true);
-	});
+  await t.step("should return true when num is a divisor of target", () => {
+    assertEquals(check_is_divisor(1, 10), true);
+    assertEquals(check_is_divisor(2, 10), true);
+    assertEquals(check_is_divisor(5, 10), true);
+    assertEquals(check_is_divisor(10, 100), true);
+    assertEquals(check_is_divisor(-2, 10), true);
+  });
 
-	await t.step(
-		"should return false when num is not a divisor of target",
-		() => {
-			assertEquals(check_is_divisor(3, 10), false);
-			assertEquals(check_is_divisor(7, 10), false);
-			assertEquals(check_is_divisor(11, 10), false);
-			assertEquals(check_is_divisor(4, 10), false);
-			assertEquals(check_is_divisor(-3, 10), false);
-		}
-	);
+  await t.step(
+    "should return false when num is not a divisor of target",
+    () => {
+      assertEquals(check_is_divisor(3, 10), false);
+      assertEquals(check_is_divisor(7, 10), false);
+      assertEquals(check_is_divisor(11, 10), false);
+      assertEquals(check_is_divisor(4, 10), false);
+      assertEquals(check_is_divisor(-3, 10), false);
+    },
+  );
 });
 
 Deno.test("check_is_not_divisor", async (t) => {
-	await t.step("should return true when num is not a divisor of target", () => {
-		assertEquals(check_is_not_divisor(3, 10), true);
-		assertEquals(check_is_not_divisor(7, 10), true);
-		assertEquals(check_is_not_divisor(11, 10), true);
-		assertEquals(check_is_not_divisor(4, 10), true);
-		assertEquals(check_is_not_divisor(-3, 10), true);
-	});
+  await t.step("should return true when num is not a divisor of target", () => {
+    assertEquals(check_is_not_divisor(3, 10), true);
+    assertEquals(check_is_not_divisor(7, 10), true);
+    assertEquals(check_is_not_divisor(11, 10), true);
+    assertEquals(check_is_not_divisor(4, 10), true);
+    assertEquals(check_is_not_divisor(-3, 10), true);
+  });
 
-	await t.step("should return false when num is a divisor of target", () => {
-		assertEquals(check_is_not_divisor(1, 10), false);
-		assertEquals(check_is_not_divisor(2, 10), false);
-		assertEquals(check_is_not_divisor(5, 10), false);
-		assertEquals(check_is_not_divisor(10, 100), false);
-		assertEquals(check_is_not_divisor(-2, 10), false);
-	});
+  await t.step("should return false when num is a divisor of target", () => {
+    assertEquals(check_is_not_divisor(1, 10), false);
+    assertEquals(check_is_not_divisor(2, 10), false);
+    assertEquals(check_is_not_divisor(5, 10), false);
+    assertEquals(check_is_not_divisor(10, 100), false);
+    assertEquals(check_is_not_divisor(-2, 10), false);
+  });
 });

--- a/packages/number/src/checkEven/main.ts
+++ b/packages/number/src/checkEven/main.ts
@@ -8,32 +8,32 @@
  *
  * @example
  * // Returns true
- * checkIsEven(4); // 4 is an even number
+ * check_is_even(4); // 4 is an even number
  *
  * @example
  * // Returns false
- * checkIsEven(7); // 7 is not an even number
+ * check_is_even(7); // 7 is not an even number
  */
-export const checkIsEven = (num: number): boolean => {
-  return num % 2 === 0;
+export const check_is_even = (num: number): boolean => {
+	return num % 2 === 0;
 };
 
 /**
  * Checks if a given number is not even (odd).
  *
- * This is the inverse of `checkIsEven`.
+ * This is the inverse of `check_is_even`.
  *
  * @param {number} num - The number to check.
  * @returns {boolean} True if the number is not even (odd), otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotEven(7); // 7 is not an even number (it's odd)
+ * check_is_not_even(7); // 7 is not an even number (it's odd)
  *
  * @example
  * // Returns false
- * checkIsNotEven(4); // 4 is an even number
+ * check_is_not_even(4); // 4 is an even number
  */
-export const checkIsNotEven = (num: number): boolean => {
-  return !checkIsEven(num);
+export const check_is_not_even = (num: number): boolean => {
+	return !check_is_even(num);
 };

--- a/packages/number/src/checkEven/main.ts
+++ b/packages/number/src/checkEven/main.ts
@@ -15,7 +15,7 @@
  * check_is_even(7); // 7 is not an even number
  */
 export const check_is_even = (num: number): boolean => {
-	return num % 2 === 0;
+  return num % 2 === 0;
 };
 
 /**
@@ -35,5 +35,5 @@ export const check_is_even = (num: number): boolean => {
  * check_is_not_even(4); // 4 is an even number
  */
 export const check_is_not_even = (num: number): boolean => {
-	return !check_is_even(num);
+  return !check_is_even(num);
 };

--- a/packages/number/src/checkEven/test.ts
+++ b/packages/number/src/checkEven/test.ts
@@ -1,41 +1,41 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsEven, checkIsNotEven } from "./main.ts";
+import { check_is_even, check_is_not_even } from "./main.ts";
 
-Deno.test("checkIsEven", async (t) => {
-  await t.step("should return true for even numbers", () => {
-    assertEquals(checkIsEven(2), true);
-    assertEquals(checkIsEven(0), true);
-    assertEquals(checkIsEven(-4), true);
-    assertEquals(checkIsEven(42), true);
-  });
+Deno.test("check_is_even", async (t) => {
+	await t.step("should return true for even numbers", () => {
+		assertEquals(check_is_even(2), true);
+		assertEquals(check_is_even(0), true);
+		assertEquals(check_is_even(-4), true);
+		assertEquals(check_is_even(42), true);
+	});
 
-  await t.step("should return false for odd numbers", () => {
-    assertEquals(checkIsEven(1), false);
-    assertEquals(checkIsEven(-3), false);
-    assertEquals(checkIsEven(99), false);
-  });
+	await t.step("should return false for odd numbers", () => {
+		assertEquals(check_is_even(1), false);
+		assertEquals(check_is_even(-3), false);
+		assertEquals(check_is_even(99), false);
+	});
 
-  await t.step("should return false for non-integer numbers", () => {
-    assertEquals(checkIsEven(1.5), false);
-    assertEquals(checkIsEven(3.14), false);
-  });
+	await t.step("should return false for non-integer numbers", () => {
+		assertEquals(check_is_even(1.5), false);
+		assertEquals(check_is_even(3.14), false);
+	});
 });
 
-Deno.test("checkIsNotEven", async (t) => {
-  await t.step("should return true for odd numbers", () => {
-    assertEquals(checkIsNotEven(1), true);
-    assertEquals(checkIsNotEven(-3), true);
-    assertEquals(checkIsNotEven(99), true);
-  });
+Deno.test("check_is_not_even", async (t) => {
+	await t.step("should return true for odd numbers", () => {
+		assertEquals(check_is_not_even(1), true);
+		assertEquals(check_is_not_even(-3), true);
+		assertEquals(check_is_not_even(99), true);
+	});
 
-  await t.step("should return false for even numbers", () => {
-    assertEquals(checkIsNotEven(2), false);
-    assertEquals(checkIsNotEven(0), false);
-    assertEquals(checkIsNotEven(-4), false);
-  });
+	await t.step("should return false for even numbers", () => {
+		assertEquals(check_is_not_even(2), false);
+		assertEquals(check_is_not_even(0), false);
+		assertEquals(check_is_not_even(-4), false);
+	});
 
-  await t.step("should return true for non-integer numbers", () => {
-    assertEquals(checkIsNotEven(1.5), true);
-    assertEquals(checkIsNotEven(3.14), true);
-  });
+	await t.step("should return true for non-integer numbers", () => {
+		assertEquals(check_is_not_even(1.5), true);
+		assertEquals(check_is_not_even(3.14), true);
+	});
 });

--- a/packages/number/src/checkEven/test.ts
+++ b/packages/number/src/checkEven/test.ts
@@ -2,40 +2,40 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_even, check_is_not_even } from "./main.ts";
 
 Deno.test("check_is_even", async (t) => {
-	await t.step("should return true for even numbers", () => {
-		assertEquals(check_is_even(2), true);
-		assertEquals(check_is_even(0), true);
-		assertEquals(check_is_even(-4), true);
-		assertEquals(check_is_even(42), true);
-	});
+  await t.step("should return true for even numbers", () => {
+    assertEquals(check_is_even(2), true);
+    assertEquals(check_is_even(0), true);
+    assertEquals(check_is_even(-4), true);
+    assertEquals(check_is_even(42), true);
+  });
 
-	await t.step("should return false for odd numbers", () => {
-		assertEquals(check_is_even(1), false);
-		assertEquals(check_is_even(-3), false);
-		assertEquals(check_is_even(99), false);
-	});
+  await t.step("should return false for odd numbers", () => {
+    assertEquals(check_is_even(1), false);
+    assertEquals(check_is_even(-3), false);
+    assertEquals(check_is_even(99), false);
+  });
 
-	await t.step("should return false for non-integer numbers", () => {
-		assertEquals(check_is_even(1.5), false);
-		assertEquals(check_is_even(3.14), false);
-	});
+  await t.step("should return false for non-integer numbers", () => {
+    assertEquals(check_is_even(1.5), false);
+    assertEquals(check_is_even(3.14), false);
+  });
 });
 
 Deno.test("check_is_not_even", async (t) => {
-	await t.step("should return true for odd numbers", () => {
-		assertEquals(check_is_not_even(1), true);
-		assertEquals(check_is_not_even(-3), true);
-		assertEquals(check_is_not_even(99), true);
-	});
+  await t.step("should return true for odd numbers", () => {
+    assertEquals(check_is_not_even(1), true);
+    assertEquals(check_is_not_even(-3), true);
+    assertEquals(check_is_not_even(99), true);
+  });
 
-	await t.step("should return false for even numbers", () => {
-		assertEquals(check_is_not_even(2), false);
-		assertEquals(check_is_not_even(0), false);
-		assertEquals(check_is_not_even(-4), false);
-	});
+  await t.step("should return false for even numbers", () => {
+    assertEquals(check_is_not_even(2), false);
+    assertEquals(check_is_not_even(0), false);
+    assertEquals(check_is_not_even(-4), false);
+  });
 
-	await t.step("should return true for non-integer numbers", () => {
-		assertEquals(check_is_not_even(1.5), true);
-		assertEquals(check_is_not_even(3.14), true);
-	});
+  await t.step("should return true for non-integer numbers", () => {
+    assertEquals(check_is_not_even(1.5), true);
+    assertEquals(check_is_not_even(3.14), true);
+  });
 });

--- a/packages/number/src/checkFibonacci/main.ts
+++ b/packages/number/src/checkFibonacci/main.ts
@@ -18,10 +18,10 @@ import { check_is_perfect_square } from "../checkPerfectSquare/main.ts";
  * check_is_fibonacci(10); // 10 is not a Fibonacci number
  */
 export const check_is_fibonacci = (num: number): boolean => {
-	return (
-		check_is_perfect_square(5 * num * num + 4) ||
-		check_is_perfect_square(5 * num * num - 4)
-	);
+  return (
+    check_is_perfect_square(5 * num * num + 4) ||
+    check_is_perfect_square(5 * num * num - 4)
+  );
 };
 
 /**
@@ -41,5 +41,5 @@ export const check_is_fibonacci = (num: number): boolean => {
  * check_is_not_fibonacci(8); // 8 is a Fibonacci number
  */
 export const check_is_not_fibonacci = (num: number): boolean => {
-	return !check_is_fibonacci(num);
+  return !check_is_fibonacci(num);
 };

--- a/packages/number/src/checkFibonacci/main.ts
+++ b/packages/number/src/checkFibonacci/main.ts
@@ -1,4 +1,4 @@
-import { checkIsPerfectSquare } from "../checkPerfectSquare/main.ts";
+import { check_is_perfect_square } from "../checkPerfectSquare/main.ts";
 
 /**
  * Checks if a given number is a Fibonacci number.
@@ -11,35 +11,35 @@ import { checkIsPerfectSquare } from "../checkPerfectSquare/main.ts";
  *
  * @example
  * // Returns true
- * checkIsFibonacci(8); // 8 is a Fibonacci number
+ * check_is_fibonacci(8); // 8 is a Fibonacci number
  *
  * @example
  * // Returns false
- * checkIsFibonacci(10); // 10 is not a Fibonacci number
+ * check_is_fibonacci(10); // 10 is not a Fibonacci number
  */
-export const checkIsFibonacci = (num: number): boolean => {
-  return (
-    checkIsPerfectSquare(5 * num * num + 4) ||
-    checkIsPerfectSquare(5 * num * num - 4)
-  );
+export const check_is_fibonacci = (num: number): boolean => {
+	return (
+		check_is_perfect_square(5 * num * num + 4) ||
+		check_is_perfect_square(5 * num * num - 4)
+	);
 };
 
 /**
  * Checks if a given number is not a Fibonacci number.
  *
- * This is the inverse of `checkIsFibonacci`.
+ * This is the inverse of `check_is_fibonacci`.
  *
  * @param {number} num - The number to check.
  * @returns {boolean} True if the number is not a Fibonacci number, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotFibonacci(10); // 10 is not a Fibonacci number
+ * check_is_not_fibonacci(10); // 10 is not a Fibonacci number
  *
  * @example
  * // Returns false
- * checkIsNotFibonacci(8); // 8 is a Fibonacci number
+ * check_is_not_fibonacci(8); // 8 is a Fibonacci number
  */
-export const checkIsNotFibonacci = (num: number): boolean => {
-  return !checkIsFibonacci(num);
+export const check_is_not_fibonacci = (num: number): boolean => {
+	return !check_is_fibonacci(num);
 };

--- a/packages/number/src/checkFibonacci/test.ts
+++ b/packages/number/src/checkFibonacci/test.ts
@@ -2,51 +2,51 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_fibonacci, check_is_not_fibonacci } from "./main.ts";
 
 Deno.test("check_is_fibonacci", async (t) => {
-	await t.step("should return true for Fibonacci numbers", () => {
-		assertEquals(check_is_fibonacci(0), true);
-		assertEquals(check_is_fibonacci(1), true);
-		assertEquals(check_is_fibonacci(2), true);
-		assertEquals(check_is_fibonacci(3), true);
-		assertEquals(check_is_fibonacci(5), true);
-		assertEquals(check_is_fibonacci(8), true);
-		assertEquals(check_is_fibonacci(13), true);
-		assertEquals(check_is_fibonacci(21), true);
-		assertEquals(check_is_fibonacci(34), true);
-		assertEquals(check_is_fibonacci(55), true);
-	});
+  await t.step("should return true for Fibonacci numbers", () => {
+    assertEquals(check_is_fibonacci(0), true);
+    assertEquals(check_is_fibonacci(1), true);
+    assertEquals(check_is_fibonacci(2), true);
+    assertEquals(check_is_fibonacci(3), true);
+    assertEquals(check_is_fibonacci(5), true);
+    assertEquals(check_is_fibonacci(8), true);
+    assertEquals(check_is_fibonacci(13), true);
+    assertEquals(check_is_fibonacci(21), true);
+    assertEquals(check_is_fibonacci(34), true);
+    assertEquals(check_is_fibonacci(55), true);
+  });
 
-	await t.step("should return false for non-Fibonacci numbers", () => {
-		assertEquals(check_is_fibonacci(4), false);
-		assertEquals(check_is_fibonacci(6), false);
-		assertEquals(check_is_fibonacci(7), false);
-		assertEquals(check_is_fibonacci(9), false);
-		assertEquals(check_is_fibonacci(10), false);
-		assertEquals(check_is_fibonacci(14), false);
-		assertEquals(check_is_fibonacci(22), false);
-	});
+  await t.step("should return false for non-Fibonacci numbers", () => {
+    assertEquals(check_is_fibonacci(4), false);
+    assertEquals(check_is_fibonacci(6), false);
+    assertEquals(check_is_fibonacci(7), false);
+    assertEquals(check_is_fibonacci(9), false);
+    assertEquals(check_is_fibonacci(10), false);
+    assertEquals(check_is_fibonacci(14), false);
+    assertEquals(check_is_fibonacci(22), false);
+  });
 });
 
 Deno.test("check_is_not_fibonacci", async (t) => {
-	await t.step("should return true for non-Fibonacci numbers", () => {
-		assertEquals(check_is_not_fibonacci(4), true);
-		assertEquals(check_is_not_fibonacci(6), true);
-		assertEquals(check_is_not_fibonacci(7), true);
-		assertEquals(check_is_not_fibonacci(9), true);
-		assertEquals(check_is_not_fibonacci(10), true);
-		assertEquals(check_is_not_fibonacci(14), true);
-		assertEquals(check_is_not_fibonacci(22), true);
-	});
+  await t.step("should return true for non-Fibonacci numbers", () => {
+    assertEquals(check_is_not_fibonacci(4), true);
+    assertEquals(check_is_not_fibonacci(6), true);
+    assertEquals(check_is_not_fibonacci(7), true);
+    assertEquals(check_is_not_fibonacci(9), true);
+    assertEquals(check_is_not_fibonacci(10), true);
+    assertEquals(check_is_not_fibonacci(14), true);
+    assertEquals(check_is_not_fibonacci(22), true);
+  });
 
-	await t.step("should return false for Fibonacci numbers", () => {
-		assertEquals(check_is_not_fibonacci(0), false);
-		assertEquals(check_is_not_fibonacci(1), false);
-		assertEquals(check_is_not_fibonacci(2), false);
-		assertEquals(check_is_not_fibonacci(3), false);
-		assertEquals(check_is_not_fibonacci(5), false);
-		assertEquals(check_is_not_fibonacci(8), false);
-		assertEquals(check_is_not_fibonacci(13), false);
-		assertEquals(check_is_not_fibonacci(21), false);
-		assertEquals(check_is_not_fibonacci(34), false);
-		assertEquals(check_is_not_fibonacci(55), false);
-	});
+  await t.step("should return false for Fibonacci numbers", () => {
+    assertEquals(check_is_not_fibonacci(0), false);
+    assertEquals(check_is_not_fibonacci(1), false);
+    assertEquals(check_is_not_fibonacci(2), false);
+    assertEquals(check_is_not_fibonacci(3), false);
+    assertEquals(check_is_not_fibonacci(5), false);
+    assertEquals(check_is_not_fibonacci(8), false);
+    assertEquals(check_is_not_fibonacci(13), false);
+    assertEquals(check_is_not_fibonacci(21), false);
+    assertEquals(check_is_not_fibonacci(34), false);
+    assertEquals(check_is_not_fibonacci(55), false);
+  });
 });

--- a/packages/number/src/checkFibonacci/test.ts
+++ b/packages/number/src/checkFibonacci/test.ts
@@ -1,52 +1,52 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsFibonacci, checkIsNotFibonacci } from "./main.ts";
+import { check_is_fibonacci, check_is_not_fibonacci } from "./main.ts";
 
-Deno.test("checkIsFibonacci", async (t) => {
-  await t.step("should return true for Fibonacci numbers", () => {
-    assertEquals(checkIsFibonacci(0), true);
-    assertEquals(checkIsFibonacci(1), true);
-    assertEquals(checkIsFibonacci(2), true);
-    assertEquals(checkIsFibonacci(3), true);
-    assertEquals(checkIsFibonacci(5), true);
-    assertEquals(checkIsFibonacci(8), true);
-    assertEquals(checkIsFibonacci(13), true);
-    assertEquals(checkIsFibonacci(21), true);
-    assertEquals(checkIsFibonacci(34), true);
-    assertEquals(checkIsFibonacci(55), true);
-  });
+Deno.test("check_is_fibonacci", async (t) => {
+	await t.step("should return true for Fibonacci numbers", () => {
+		assertEquals(check_is_fibonacci(0), true);
+		assertEquals(check_is_fibonacci(1), true);
+		assertEquals(check_is_fibonacci(2), true);
+		assertEquals(check_is_fibonacci(3), true);
+		assertEquals(check_is_fibonacci(5), true);
+		assertEquals(check_is_fibonacci(8), true);
+		assertEquals(check_is_fibonacci(13), true);
+		assertEquals(check_is_fibonacci(21), true);
+		assertEquals(check_is_fibonacci(34), true);
+		assertEquals(check_is_fibonacci(55), true);
+	});
 
-  await t.step("should return false for non-Fibonacci numbers", () => {
-    assertEquals(checkIsFibonacci(4), false);
-    assertEquals(checkIsFibonacci(6), false);
-    assertEquals(checkIsFibonacci(7), false);
-    assertEquals(checkIsFibonacci(9), false);
-    assertEquals(checkIsFibonacci(10), false);
-    assertEquals(checkIsFibonacci(14), false);
-    assertEquals(checkIsFibonacci(22), false);
-  });
+	await t.step("should return false for non-Fibonacci numbers", () => {
+		assertEquals(check_is_fibonacci(4), false);
+		assertEquals(check_is_fibonacci(6), false);
+		assertEquals(check_is_fibonacci(7), false);
+		assertEquals(check_is_fibonacci(9), false);
+		assertEquals(check_is_fibonacci(10), false);
+		assertEquals(check_is_fibonacci(14), false);
+		assertEquals(check_is_fibonacci(22), false);
+	});
 });
 
-Deno.test("checkIsNotFibonacci", async (t) => {
-  await t.step("should return true for non-Fibonacci numbers", () => {
-    assertEquals(checkIsNotFibonacci(4), true);
-    assertEquals(checkIsNotFibonacci(6), true);
-    assertEquals(checkIsNotFibonacci(7), true);
-    assertEquals(checkIsNotFibonacci(9), true);
-    assertEquals(checkIsNotFibonacci(10), true);
-    assertEquals(checkIsNotFibonacci(14), true);
-    assertEquals(checkIsNotFibonacci(22), true);
-  });
+Deno.test("check_is_not_fibonacci", async (t) => {
+	await t.step("should return true for non-Fibonacci numbers", () => {
+		assertEquals(check_is_not_fibonacci(4), true);
+		assertEquals(check_is_not_fibonacci(6), true);
+		assertEquals(check_is_not_fibonacci(7), true);
+		assertEquals(check_is_not_fibonacci(9), true);
+		assertEquals(check_is_not_fibonacci(10), true);
+		assertEquals(check_is_not_fibonacci(14), true);
+		assertEquals(check_is_not_fibonacci(22), true);
+	});
 
-  await t.step("should return false for Fibonacci numbers", () => {
-    assertEquals(checkIsNotFibonacci(0), false);
-    assertEquals(checkIsNotFibonacci(1), false);
-    assertEquals(checkIsNotFibonacci(2), false);
-    assertEquals(checkIsNotFibonacci(3), false);
-    assertEquals(checkIsNotFibonacci(5), false);
-    assertEquals(checkIsNotFibonacci(8), false);
-    assertEquals(checkIsNotFibonacci(13), false);
-    assertEquals(checkIsNotFibonacci(21), false);
-    assertEquals(checkIsNotFibonacci(34), false);
-    assertEquals(checkIsNotFibonacci(55), false);
-  });
+	await t.step("should return false for Fibonacci numbers", () => {
+		assertEquals(check_is_not_fibonacci(0), false);
+		assertEquals(check_is_not_fibonacci(1), false);
+		assertEquals(check_is_not_fibonacci(2), false);
+		assertEquals(check_is_not_fibonacci(3), false);
+		assertEquals(check_is_not_fibonacci(5), false);
+		assertEquals(check_is_not_fibonacci(8), false);
+		assertEquals(check_is_not_fibonacci(13), false);
+		assertEquals(check_is_not_fibonacci(21), false);
+		assertEquals(check_is_not_fibonacci(34), false);
+		assertEquals(check_is_not_fibonacci(55), false);
+	});
 });

--- a/packages/number/src/checkFloat/main.ts
+++ b/packages/number/src/checkFloat/main.ts
@@ -13,7 +13,7 @@
  * check_is_float(4); // 4 is an integer, not a floating-point number
  */
 export const check_is_float = (num: number): boolean => {
-	return num % 1 !== 0;
+  return num % 1 !== 0;
 };
 
 /**
@@ -33,5 +33,5 @@ export const check_is_float = (num: number): boolean => {
  * check_is_not_float(4.5); // 4.5 is a floating-point number
  */
 export const check_is_not_float = (num: number): boolean => {
-	return !check_is_float(num);
+  return !check_is_float(num);
 };

--- a/packages/number/src/checkFloat/main.ts
+++ b/packages/number/src/checkFloat/main.ts
@@ -6,32 +6,32 @@
  *
  * @example
  * // Returns true
- * checkIsFloat(4.5); // 4.5 is a floating-point number
+ * check_is_float(4.5); // 4.5 is a floating-point number
  *
  * @example
  * // Returns false
- * checkIsFloat(4); // 4 is an integer, not a floating-point number
+ * check_is_float(4); // 4 is an integer, not a floating-point number
  */
-export const checkIsFloat = (num: number): boolean => {
-  return num % 1 !== 0;
+export const check_is_float = (num: number): boolean => {
+	return num % 1 !== 0;
 };
 
 /**
  * Checks if the given number is not a floating-point number (i.e., it is an integer).
  *
- * This is the inverse of `checkIsFloat`.
+ * This is the inverse of `check_is_float`.
  *
  * @param {number} num - The number to check.
  * @returns {boolean} True if the number is not a floating-point number, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotFloat(4); // 4 is an integer
+ * check_is_not_float(4); // 4 is an integer
  *
  * @example
  * // Returns false
- * checkIsNotFloat(4.5); // 4.5 is a floating-point number
+ * check_is_not_float(4.5); // 4.5 is a floating-point number
  */
-export const checkIsNotFloat = (num: number): boolean => {
-  return !checkIsFloat(num);
+export const check_is_not_float = (num: number): boolean => {
+	return !check_is_float(num);
 };

--- a/packages/number/src/checkFloat/test.ts
+++ b/packages/number/src/checkFloat/test.ts
@@ -2,27 +2,27 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_float, check_is_not_float } from "./main.ts";
 
 Deno.test("check_is_float", async (t) => {
-	await t.step("should return true for float numbers", () => {
-		assertEquals(check_is_float(3.14), true);
-		assertEquals(check_is_float(-2.71), true);
-	});
+  await t.step("should return true for float numbers", () => {
+    assertEquals(check_is_float(3.14), true);
+    assertEquals(check_is_float(-2.71), true);
+  });
 
-	await t.step("should return false for integers", () => {
-		assertEquals(check_is_float(1), false);
-		assertEquals(check_is_float(0), false);
-		assertEquals(check_is_float(-1), false);
-	});
+  await t.step("should return false for integers", () => {
+    assertEquals(check_is_float(1), false);
+    assertEquals(check_is_float(0), false);
+    assertEquals(check_is_float(-1), false);
+  });
 });
 
 Deno.test("check_is_not_float", async (t) => {
-	await t.step("should return true for non-float numbers (integers)", () => {
-		assertEquals(check_is_not_float(1), true);
-		assertEquals(check_is_not_float(0), true);
-		assertEquals(check_is_not_float(-1), true);
-	});
+  await t.step("should return true for non-float numbers (integers)", () => {
+    assertEquals(check_is_not_float(1), true);
+    assertEquals(check_is_not_float(0), true);
+    assertEquals(check_is_not_float(-1), true);
+  });
 
-	await t.step("should return false for float numbers", () => {
-		assertEquals(check_is_not_float(3.14), false);
-		assertEquals(check_is_not_float(-2.71), false);
-	});
+  await t.step("should return false for float numbers", () => {
+    assertEquals(check_is_not_float(3.14), false);
+    assertEquals(check_is_not_float(-2.71), false);
+  });
 });

--- a/packages/number/src/checkFloat/test.ts
+++ b/packages/number/src/checkFloat/test.ts
@@ -1,28 +1,28 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsFloat, checkIsNotFloat } from "./main.ts";
+import { check_is_float, check_is_not_float } from "./main.ts";
 
-Deno.test("checkIsFloat", async (t) => {
-  await t.step("should return true for float numbers", () => {
-    assertEquals(checkIsFloat(3.14), true);
-    assertEquals(checkIsFloat(-2.71), true);
-  });
+Deno.test("check_is_float", async (t) => {
+	await t.step("should return true for float numbers", () => {
+		assertEquals(check_is_float(3.14), true);
+		assertEquals(check_is_float(-2.71), true);
+	});
 
-  await t.step("should return false for integers", () => {
-    assertEquals(checkIsFloat(1), false);
-    assertEquals(checkIsFloat(0), false);
-    assertEquals(checkIsFloat(-1), false);
-  });
+	await t.step("should return false for integers", () => {
+		assertEquals(check_is_float(1), false);
+		assertEquals(check_is_float(0), false);
+		assertEquals(check_is_float(-1), false);
+	});
 });
 
-Deno.test("checkIsNotFloat", async (t) => {
-  await t.step("should return true for non-float numbers (integers)", () => {
-    assertEquals(checkIsNotFloat(1), true);
-    assertEquals(checkIsNotFloat(0), true);
-    assertEquals(checkIsNotFloat(-1), true);
-  });
+Deno.test("check_is_not_float", async (t) => {
+	await t.step("should return true for non-float numbers (integers)", () => {
+		assertEquals(check_is_not_float(1), true);
+		assertEquals(check_is_not_float(0), true);
+		assertEquals(check_is_not_float(-1), true);
+	});
 
-  await t.step("should return false for float numbers", () => {
-    assertEquals(checkIsNotFloat(3.14), false);
-    assertEquals(checkIsNotFloat(-2.71), false);
-  });
+	await t.step("should return false for float numbers", () => {
+		assertEquals(check_is_not_float(3.14), false);
+		assertEquals(check_is_not_float(-2.71), false);
+	});
 });

--- a/packages/number/src/checkGeometricSequence/main.ts
+++ b/packages/number/src/checkGeometricSequence/main.ts
@@ -19,17 +19,17 @@ import { Constants } from "../constants.ts";
  * check_is_geometric_sequence([2, 4, 9], 2); // The sequence [2, 4, 9] does not have a common ratio of 2
  */
 export const check_is_geometric_sequence = (
-	nums: number[],
-	ratio: number
+  nums: number[],
+  ratio: number,
 ): boolean => {
-	if (nums.length < 2) return false;
-	for (let i = 1; i < nums.length; i++) {
-		// Small differences are acceptable
-		if (Math.abs(nums[i] / nums[i - 1] - ratio) > Constants.TOLERANCE) {
-			return false;
-		}
-	}
-	return true;
+  if (nums.length < 2) return false;
+  for (let i = 1; i < nums.length; i++) {
+    // Small differences are acceptable
+    if (Math.abs(nums[i] / nums[i - 1] - ratio) > Constants.TOLERANCE) {
+      return false;
+    }
+  }
+  return true;
 };
 
 /**
@@ -50,8 +50,8 @@ export const check_is_geometric_sequence = (
  * check_is_not_geometric_sequence([2, 4, 8], 2); // The sequence [2, 4, 8] has a common ratio of 2
  */
 export const check_is_not_geometric_sequence = (
-	nums: number[],
-	ratio: number
+  nums: number[],
+  ratio: number,
 ): boolean => {
-	return !check_is_geometric_sequence(nums, ratio);
+  return !check_is_geometric_sequence(nums, ratio);
 };

--- a/packages/number/src/checkGeometricSequence/main.ts
+++ b/packages/number/src/checkGeometricSequence/main.ts
@@ -12,30 +12,30 @@ import { Constants } from "../constants.ts";
  *
  * @example
  * // Returns true
- * checkIsGeometricSequence([2, 4, 8], 2); // The sequence [2, 4, 8] has a common ratio of 2
+ * check_is_geometric_sequence([2, 4, 8], 2); // The sequence [2, 4, 8] has a common ratio of 2
  *
  * @example
  * // Returns false
- * checkIsGeometricSequence([2, 4, 9], 2); // The sequence [2, 4, 9] does not have a common ratio of 2
+ * check_is_geometric_sequence([2, 4, 9], 2); // The sequence [2, 4, 9] does not have a common ratio of 2
  */
-export const checkIsGeometricSequence = (
-  nums: number[],
-  ratio: number,
+export const check_is_geometric_sequence = (
+	nums: number[],
+	ratio: number
 ): boolean => {
-  if (nums.length < 2) return false;
-  for (let i = 1; i < nums.length; i++) {
-    // Small differences are acceptable
-    if (Math.abs(nums[i] / nums[i - 1] - ratio) > Constants.TOLERANCE) {
-      return false;
-    }
-  }
-  return true;
+	if (nums.length < 2) return false;
+	for (let i = 1; i < nums.length; i++) {
+		// Small differences are acceptable
+		if (Math.abs(nums[i] / nums[i - 1] - ratio) > Constants.TOLERANCE) {
+			return false;
+		}
+	}
+	return true;
 };
 
 /**
  * Checks if the given array of numbers does not form a geometric sequence with the specified ratio.
  *
- * This is the inverse of `checkIsGeometricSequence`.
+ * This is the inverse of `check_is_geometric_sequence`.
  *
  * @param {number[]} nums - The array of numbers to check.
  * @param {number} ratio - The common ratio that should not match.
@@ -43,15 +43,15 @@ export const checkIsGeometricSequence = (
  *
  * @example
  * // Returns true
- * checkIsNotGeometricSequence([2, 4, 9], 2); // The sequence [2, 4, 9] does not have a common ratio of 2
+ * check_is_not_geometric_sequence([2, 4, 9], 2); // The sequence [2, 4, 9] does not have a common ratio of 2
  *
  * @example
  * // Returns false
- * checkIsNotGeometricSequence([2, 4, 8], 2); // The sequence [2, 4, 8] has a common ratio of 2
+ * check_is_not_geometric_sequence([2, 4, 8], 2); // The sequence [2, 4, 8] has a common ratio of 2
  */
-export const checkIsNotGeometricSequence = (
-  nums: number[],
-  ratio: number,
+export const check_is_not_geometric_sequence = (
+	nums: number[],
+	ratio: number
 ): boolean => {
-  return !checkIsGeometricSequence(nums, ratio);
+	return !check_is_geometric_sequence(nums, ratio);
 };

--- a/packages/number/src/checkGeometricSequence/test.ts
+++ b/packages/number/src/checkGeometricSequence/test.ts
@@ -1,50 +1,56 @@
 import { assertEquals } from "../../deps.ts";
 import {
-  checkIsGeometricSequence,
-  checkIsNotGeometricSequence,
+	check_is_geometric_sequence,
+	check_is_not_geometric_sequence,
 } from "./main.ts";
 
 Deno.test("checkIsGeometricSequence", async (t) => {
-  await t.step("should return true for valid geometric sequences", () => {
-    assertEquals(checkIsGeometricSequence([2, 4, 8, 16], 2), true); // ratio of 2
-    assertEquals(checkIsGeometricSequence([3, 9, 27], 3), true); // ratio of 3
-    assertEquals(checkIsGeometricSequence([5, 25, 125], 5), true); // ratio of 5
-    assertEquals(checkIsGeometricSequence([1, 0.1, 0.01, 0.001], 0.1), true); // ratio of 0.1
-  });
+	await t.step("should return true for valid geometric sequences", () => {
+		assertEquals(check_is_geometric_sequence([2, 4, 8, 16], 2), true); // ratio of 2
+		assertEquals(check_is_geometric_sequence([3, 9, 27], 3), true); // ratio of 3
+		assertEquals(check_is_geometric_sequence([5, 25, 125], 5), true); // ratio of 5
+		assertEquals(check_is_geometric_sequence([1, 0.1, 0.01, 0.001], 0.1), true); // ratio of 0.1
+	});
 
-  await t.step("should return false for invalid geometric sequences", () => {
-    assertEquals(checkIsGeometricSequence([2, 4, 9, 16], 2), false); // 9 does not fit the ratio of 2
-    assertEquals(checkIsGeometricSequence([3, 9, 28], 3), false); // 28 does not fit the ratio of 3
-    assertEquals(checkIsGeometricSequence([5, 20, 125], 5), false); // 20 does not fit the ratio of 5
-    assertEquals(checkIsGeometricSequence([1, 0.2, 0.01, 0.001], 0.1), false); // 0.2 does not fit the ratio of 0.1
-  });
+	await t.step("should return false for invalid geometric sequences", () => {
+		assertEquals(check_is_geometric_sequence([2, 4, 9, 16], 2), false); // 9 does not fit the ratio of 2
+		assertEquals(check_is_geometric_sequence([3, 9, 28], 3), false); // 28 does not fit the ratio of 3
+		assertEquals(check_is_geometric_sequence([5, 20, 125], 5), false); // 20 does not fit the ratio of 5
+		assertEquals(
+			check_is_geometric_sequence([1, 0.2, 0.01, 0.001], 0.1),
+			false
+		); // 0.2 does not fit the ratio of 0.1
+	});
 
-  await t.step(
-    "should return false for sequences with less than 2 numbers",
-    () => {
-      assertEquals(checkIsGeometricSequence([1], 2), false); // single element
-      assertEquals(checkIsGeometricSequence([], 2), false); // empty array
-    },
-  );
+	await t.step(
+		"should return false for sequences with less than 2 numbers",
+		() => {
+			assertEquals(check_is_geometric_sequence([1], 2), false); // single element
+			assertEquals(check_is_geometric_sequence([], 2), false); // empty array
+		}
+	);
 });
 
 Deno.test("checkIsNotGeometricSequence", async (t) => {
-  await t.step("should return true for invalid geometric sequences", () => {
-    assertEquals(checkIsNotGeometricSequence([2, 4, 9, 16], 2), true); // 9 does not fit the ratio of 2
-    assertEquals(checkIsNotGeometricSequence([3, 9, 28], 3), true); // 28 does not fit the ratio of 3
-    assertEquals(checkIsNotGeometricSequence([5, 20, 125], 5), true); // 20 does not fit the ratio of 5
-    assertEquals(checkIsNotGeometricSequence([1, 0.2, 0.01, 0.001], 0.1), true); // 0.2 does not fit the ratio of 0.1
-    assertEquals(checkIsNotGeometricSequence([1], 2), true); // single element
-    assertEquals(checkIsNotGeometricSequence([], 2), true); // empty array
-  });
+	await t.step("should return true for invalid geometric sequences", () => {
+		assertEquals(check_is_not_geometric_sequence([2, 4, 9, 16], 2), true); // 9 does not fit the ratio of 2
+		assertEquals(check_is_not_geometric_sequence([3, 9, 28], 3), true); // 28 does not fit the ratio of 3
+		assertEquals(check_is_not_geometric_sequence([5, 20, 125], 5), true); // 20 does not fit the ratio of 5
+		assertEquals(
+			check_is_not_geometric_sequence([1, 0.2, 0.01, 0.001], 0.1),
+			true
+		); // 0.2 does not fit the ratio of 0.1
+		assertEquals(check_is_not_geometric_sequence([1], 2), true); // single element
+		assertEquals(check_is_not_geometric_sequence([], 2), true); // empty array
+	});
 
-  await t.step("should return false for valid geometric sequences", () => {
-    assertEquals(checkIsNotGeometricSequence([2, 4, 8, 16], 2), false); // ratio of 2
-    assertEquals(checkIsNotGeometricSequence([3, 9, 27], 3), false); // ratio of 3
-    assertEquals(checkIsNotGeometricSequence([5, 25, 125], 5), false); // ratio of 5
-    assertEquals(
-      checkIsNotGeometricSequence([1, 0.1, 0.01, 0.001], 0.1),
-      false,
-    ); // ratio of 0.1
-  });
+	await t.step("should return false for valid geometric sequences", () => {
+		assertEquals(check_is_not_geometric_sequence([2, 4, 8, 16], 2), false); // ratio of 2
+		assertEquals(check_is_not_geometric_sequence([3, 9, 27], 3), false); // ratio of 3
+		assertEquals(check_is_not_geometric_sequence([5, 25, 125], 5), false); // ratio of 5
+		assertEquals(
+			check_is_not_geometric_sequence([1, 0.1, 0.01, 0.001], 0.1),
+			false
+		); // ratio of 0.1
+	});
 });

--- a/packages/number/src/checkGeometricSequence/test.ts
+++ b/packages/number/src/checkGeometricSequence/test.ts
@@ -1,56 +1,56 @@
 import { assertEquals } from "../../deps.ts";
 import {
-	check_is_geometric_sequence,
-	check_is_not_geometric_sequence,
+  check_is_geometric_sequence,
+  check_is_not_geometric_sequence,
 } from "./main.ts";
 
 Deno.test("checkIsGeometricSequence", async (t) => {
-	await t.step("should return true for valid geometric sequences", () => {
-		assertEquals(check_is_geometric_sequence([2, 4, 8, 16], 2), true); // ratio of 2
-		assertEquals(check_is_geometric_sequence([3, 9, 27], 3), true); // ratio of 3
-		assertEquals(check_is_geometric_sequence([5, 25, 125], 5), true); // ratio of 5
-		assertEquals(check_is_geometric_sequence([1, 0.1, 0.01, 0.001], 0.1), true); // ratio of 0.1
-	});
+  await t.step("should return true for valid geometric sequences", () => {
+    assertEquals(check_is_geometric_sequence([2, 4, 8, 16], 2), true); // ratio of 2
+    assertEquals(check_is_geometric_sequence([3, 9, 27], 3), true); // ratio of 3
+    assertEquals(check_is_geometric_sequence([5, 25, 125], 5), true); // ratio of 5
+    assertEquals(check_is_geometric_sequence([1, 0.1, 0.01, 0.001], 0.1), true); // ratio of 0.1
+  });
 
-	await t.step("should return false for invalid geometric sequences", () => {
-		assertEquals(check_is_geometric_sequence([2, 4, 9, 16], 2), false); // 9 does not fit the ratio of 2
-		assertEquals(check_is_geometric_sequence([3, 9, 28], 3), false); // 28 does not fit the ratio of 3
-		assertEquals(check_is_geometric_sequence([5, 20, 125], 5), false); // 20 does not fit the ratio of 5
-		assertEquals(
-			check_is_geometric_sequence([1, 0.2, 0.01, 0.001], 0.1),
-			false
-		); // 0.2 does not fit the ratio of 0.1
-	});
+  await t.step("should return false for invalid geometric sequences", () => {
+    assertEquals(check_is_geometric_sequence([2, 4, 9, 16], 2), false); // 9 does not fit the ratio of 2
+    assertEquals(check_is_geometric_sequence([3, 9, 28], 3), false); // 28 does not fit the ratio of 3
+    assertEquals(check_is_geometric_sequence([5, 20, 125], 5), false); // 20 does not fit the ratio of 5
+    assertEquals(
+      check_is_geometric_sequence([1, 0.2, 0.01, 0.001], 0.1),
+      false,
+    ); // 0.2 does not fit the ratio of 0.1
+  });
 
-	await t.step(
-		"should return false for sequences with less than 2 numbers",
-		() => {
-			assertEquals(check_is_geometric_sequence([1], 2), false); // single element
-			assertEquals(check_is_geometric_sequence([], 2), false); // empty array
-		}
-	);
+  await t.step(
+    "should return false for sequences with less than 2 numbers",
+    () => {
+      assertEquals(check_is_geometric_sequence([1], 2), false); // single element
+      assertEquals(check_is_geometric_sequence([], 2), false); // empty array
+    },
+  );
 });
 
 Deno.test("checkIsNotGeometricSequence", async (t) => {
-	await t.step("should return true for invalid geometric sequences", () => {
-		assertEquals(check_is_not_geometric_sequence([2, 4, 9, 16], 2), true); // 9 does not fit the ratio of 2
-		assertEquals(check_is_not_geometric_sequence([3, 9, 28], 3), true); // 28 does not fit the ratio of 3
-		assertEquals(check_is_not_geometric_sequence([5, 20, 125], 5), true); // 20 does not fit the ratio of 5
-		assertEquals(
-			check_is_not_geometric_sequence([1, 0.2, 0.01, 0.001], 0.1),
-			true
-		); // 0.2 does not fit the ratio of 0.1
-		assertEquals(check_is_not_geometric_sequence([1], 2), true); // single element
-		assertEquals(check_is_not_geometric_sequence([], 2), true); // empty array
-	});
+  await t.step("should return true for invalid geometric sequences", () => {
+    assertEquals(check_is_not_geometric_sequence([2, 4, 9, 16], 2), true); // 9 does not fit the ratio of 2
+    assertEquals(check_is_not_geometric_sequence([3, 9, 28], 3), true); // 28 does not fit the ratio of 3
+    assertEquals(check_is_not_geometric_sequence([5, 20, 125], 5), true); // 20 does not fit the ratio of 5
+    assertEquals(
+      check_is_not_geometric_sequence([1, 0.2, 0.01, 0.001], 0.1),
+      true,
+    ); // 0.2 does not fit the ratio of 0.1
+    assertEquals(check_is_not_geometric_sequence([1], 2), true); // single element
+    assertEquals(check_is_not_geometric_sequence([], 2), true); // empty array
+  });
 
-	await t.step("should return false for valid geometric sequences", () => {
-		assertEquals(check_is_not_geometric_sequence([2, 4, 8, 16], 2), false); // ratio of 2
-		assertEquals(check_is_not_geometric_sequence([3, 9, 27], 3), false); // ratio of 3
-		assertEquals(check_is_not_geometric_sequence([5, 25, 125], 5), false); // ratio of 5
-		assertEquals(
-			check_is_not_geometric_sequence([1, 0.1, 0.01, 0.001], 0.1),
-			false
-		); // ratio of 0.1
-	});
+  await t.step("should return false for valid geometric sequences", () => {
+    assertEquals(check_is_not_geometric_sequence([2, 4, 8, 16], 2), false); // ratio of 2
+    assertEquals(check_is_not_geometric_sequence([3, 9, 27], 3), false); // ratio of 3
+    assertEquals(check_is_not_geometric_sequence([5, 25, 125], 5), false); // ratio of 5
+    assertEquals(
+      check_is_not_geometric_sequence([1, 0.1, 0.01, 0.001], 0.1),
+      false,
+    ); // ratio of 0.1
+  });
 });

--- a/packages/number/src/checkGreaterThan/main.ts
+++ b/packages/number/src/checkGreaterThan/main.ts
@@ -7,20 +7,23 @@
  *
  * @example
  * // Returns true
- * checkIsGreaterThan(10, 5); // 10 is greater than 5
+ * check_is_greater_than(10, 5); // 10 is greater than 5
  *
  * @example
  * // Returns false
- * checkIsGreaterThan(3, 5); // 3 is not greater than 5
+ * check_is_greater_than(3, 5); // 3 is not greater than 5
  */
-export const checkIsGreaterThan = (num: number, threshold: number): boolean => {
-  return num > threshold;
+export const check_is_greater_than = (
+	num: number,
+	threshold: number
+): boolean => {
+	return num > threshold;
 };
 
 /**
  * Checks if the given number is not greater than a specified threshold.
  *
- * This is the inverse of `checkIsGreaterThan`.
+ * This is the inverse of `check_is_greater_than`.
  *
  * @param {number} num - The number to check.
  * @param {number} threshold - The threshold to compare against.
@@ -28,15 +31,15 @@ export const checkIsGreaterThan = (num: number, threshold: number): boolean => {
  *
  * @example
  * // Returns true
- * checkIsNotGreaterThan(3, 5); // 3 is not greater than 5
+ * check_is_not_greater_than(3, 5); // 3 is not greater than 5
  *
  * @example
  * // Returns false
- * checkIsNotGreaterThan(10, 5); // 10 is greater than 5
+ * check_is_not_greater_than(10, 5); // 10 is greater than 5
  */
-export const checkIsNotGreaterThan = (
-  num: number,
-  threshold: number,
+export const check_is_not_greater_than = (
+	num: number,
+	threshold: number
 ): boolean => {
-  return !checkIsGreaterThan(num, threshold);
+	return !check_is_greater_than(num, threshold);
 };

--- a/packages/number/src/checkGreaterThan/main.ts
+++ b/packages/number/src/checkGreaterThan/main.ts
@@ -14,10 +14,10 @@
  * check_is_greater_than(3, 5); // 3 is not greater than 5
  */
 export const check_is_greater_than = (
-	num: number,
-	threshold: number
+  num: number,
+  threshold: number,
 ): boolean => {
-	return num > threshold;
+  return num > threshold;
 };
 
 /**
@@ -38,8 +38,8 @@ export const check_is_greater_than = (
  * check_is_not_greater_than(10, 5); // 10 is greater than 5
  */
 export const check_is_not_greater_than = (
-	num: number,
-	threshold: number
+  num: number,
+  threshold: number,
 ): boolean => {
-	return !check_is_greater_than(num, threshold);
+  return !check_is_greater_than(num, threshold);
 };

--- a/packages/number/src/checkGreaterThan/test.ts
+++ b/packages/number/src/checkGreaterThan/test.ts
@@ -2,37 +2,37 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_greater_than, check_is_not_greater_than } from "./main.ts";
 
 Deno.test("check_is_greater_than", async (t) => {
-	await t.step("should return true when num is greater than threshold", () => {
-		assertEquals(check_is_greater_than(10, 5), true);
-		assertEquals(check_is_greater_than(0, -1), true);
-		assertEquals(check_is_greater_than(100, 99), true);
-	});
+  await t.step("should return true when num is greater than threshold", () => {
+    assertEquals(check_is_greater_than(10, 5), true);
+    assertEquals(check_is_greater_than(0, -1), true);
+    assertEquals(check_is_greater_than(100, 99), true);
+  });
 
-	await t.step(
-		"should return false when num is not greater than threshold",
-		() => {
-			assertEquals(check_is_greater_than(5, 10), false);
-			assertEquals(check_is_greater_than(0, 0), false); // equal values
-			assertEquals(check_is_greater_than(-1, 0), false);
-			assertEquals(check_is_greater_than(-10, -5), false);
-		}
-	);
+  await t.step(
+    "should return false when num is not greater than threshold",
+    () => {
+      assertEquals(check_is_greater_than(5, 10), false);
+      assertEquals(check_is_greater_than(0, 0), false); // equal values
+      assertEquals(check_is_greater_than(-1, 0), false);
+      assertEquals(check_is_greater_than(-10, -5), false);
+    },
+  );
 });
 
 Deno.test("check_is_not_greater_than", async (t) => {
-	await t.step(
-		"should return true when num is not greater than threshold",
-		() => {
-			assertEquals(check_is_not_greater_than(5, 10), true);
-			assertEquals(check_is_not_greater_than(0, 0), true); // equal values
-			assertEquals(check_is_not_greater_than(-1, 0), true);
-			assertEquals(check_is_not_greater_than(-10, -5), true);
-		}
-	);
+  await t.step(
+    "should return true when num is not greater than threshold",
+    () => {
+      assertEquals(check_is_not_greater_than(5, 10), true);
+      assertEquals(check_is_not_greater_than(0, 0), true); // equal values
+      assertEquals(check_is_not_greater_than(-1, 0), true);
+      assertEquals(check_is_not_greater_than(-10, -5), true);
+    },
+  );
 
-	await t.step("should return false when num is greater than threshold", () => {
-		assertEquals(check_is_not_greater_than(10, 5), false);
-		assertEquals(check_is_not_greater_than(0, -1), false);
-		assertEquals(check_is_not_greater_than(100, 99), false);
-	});
+  await t.step("should return false when num is greater than threshold", () => {
+    assertEquals(check_is_not_greater_than(10, 5), false);
+    assertEquals(check_is_not_greater_than(0, -1), false);
+    assertEquals(check_is_not_greater_than(100, 99), false);
+  });
 });

--- a/packages/number/src/checkGreaterThan/test.ts
+++ b/packages/number/src/checkGreaterThan/test.ts
@@ -1,38 +1,38 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsGreaterThan, checkIsNotGreaterThan } from "./main.ts";
+import { check_is_greater_than, check_is_not_greater_than } from "./main.ts";
 
-Deno.test("checkIsGreaterThan", async (t) => {
-  await t.step("should return true when num is greater than threshold", () => {
-    assertEquals(checkIsGreaterThan(10, 5), true);
-    assertEquals(checkIsGreaterThan(0, -1), true);
-    assertEquals(checkIsGreaterThan(100, 99), true);
-  });
+Deno.test("check_is_greater_than", async (t) => {
+	await t.step("should return true when num is greater than threshold", () => {
+		assertEquals(check_is_greater_than(10, 5), true);
+		assertEquals(check_is_greater_than(0, -1), true);
+		assertEquals(check_is_greater_than(100, 99), true);
+	});
 
-  await t.step(
-    "should return false when num is not greater than threshold",
-    () => {
-      assertEquals(checkIsGreaterThan(5, 10), false);
-      assertEquals(checkIsGreaterThan(0, 0), false); // equal values
-      assertEquals(checkIsGreaterThan(-1, 0), false);
-      assertEquals(checkIsGreaterThan(-10, -5), false);
-    },
-  );
+	await t.step(
+		"should return false when num is not greater than threshold",
+		() => {
+			assertEquals(check_is_greater_than(5, 10), false);
+			assertEquals(check_is_greater_than(0, 0), false); // equal values
+			assertEquals(check_is_greater_than(-1, 0), false);
+			assertEquals(check_is_greater_than(-10, -5), false);
+		}
+	);
 });
 
-Deno.test("checkIsNotGreaterThan", async (t) => {
-  await t.step(
-    "should return true when num is not greater than threshold",
-    () => {
-      assertEquals(checkIsNotGreaterThan(5, 10), true);
-      assertEquals(checkIsNotGreaterThan(0, 0), true); // equal values
-      assertEquals(checkIsNotGreaterThan(-1, 0), true);
-      assertEquals(checkIsNotGreaterThan(-10, -5), true);
-    },
-  );
+Deno.test("check_is_not_greater_than", async (t) => {
+	await t.step(
+		"should return true when num is not greater than threshold",
+		() => {
+			assertEquals(check_is_not_greater_than(5, 10), true);
+			assertEquals(check_is_not_greater_than(0, 0), true); // equal values
+			assertEquals(check_is_not_greater_than(-1, 0), true);
+			assertEquals(check_is_not_greater_than(-10, -5), true);
+		}
+	);
 
-  await t.step("should return false when num is greater than threshold", () => {
-    assertEquals(checkIsNotGreaterThan(10, 5), false);
-    assertEquals(checkIsNotGreaterThan(0, -1), false);
-    assertEquals(checkIsNotGreaterThan(100, 99), false);
-  });
+	await t.step("should return false when num is greater than threshold", () => {
+		assertEquals(check_is_not_greater_than(10, 5), false);
+		assertEquals(check_is_not_greater_than(0, -1), false);
+		assertEquals(check_is_not_greater_than(100, 99), false);
+	});
 });

--- a/packages/number/src/checkGreaterThanOrEqual/main.ts
+++ b/packages/number/src/checkGreaterThanOrEqual/main.ts
@@ -7,23 +7,23 @@
  *
  * @example
  * // Returns true
- * checkIsGreaterThanOrEqual(10, 5); // 10 is greater than or equal to 5
+ * check_is_greater_than_or_equal(10, 5); // 10 is greater than or equal to 5
  *
  * @example
  * // Returns false
- * checkIsGreaterThanOrEqual(3, 5); // 3 is not greater than or equal to 5
+ * check_is_greater_than_or_equal(3, 5); // 3 is not greater than or equal to 5
  */
-export const checkIsGreaterThanOrEqual = (
-  num: number,
-  threshold: number,
+export const check_is_greater_than_or_equal = (
+	num: number,
+	threshold: number
 ): boolean => {
-  return num >= threshold;
+	return num >= threshold;
 };
 
 /**
  * Checks if a number is not greater than or equal to a given threshold.
  *
- * This is the inverse of `checkIsGreaterThanOrEqual`.
+ * This is the inverse of `check_is_greater_than_or_equal`.
  *
  * @param {number} num - The number to check.
  * @param {number} threshold - The threshold to compare against.
@@ -31,15 +31,15 @@ export const checkIsGreaterThanOrEqual = (
  *
  * @example
  * // Returns true
- * checkIsNotGreaterThanOrEqual(3, 5); // 3 is not greater than or equal to 5
+ * check_is_not_greater_than_or_equal(3, 5); // 3 is not greater than or equal to 5
  *
  * @example
  * // Returns false
- * checkIsNotGreaterThanOrEqual(10, 5); // 10 is greater than or equal to 5
+ * check_is_not_greater_than_or_equal(10, 5); // 10 is greater than or equal to 5
  */
-export const checkIsNotGreaterThanOrEqual = (
-  num: number,
-  threshold: number,
+export const check_is_not_greater_than_or_equal = (
+	num: number,
+	threshold: number
 ): boolean => {
-  return !checkIsGreaterThanOrEqual(num, threshold);
+	return !check_is_greater_than_or_equal(num, threshold);
 };

--- a/packages/number/src/checkGreaterThanOrEqual/main.ts
+++ b/packages/number/src/checkGreaterThanOrEqual/main.ts
@@ -14,10 +14,10 @@
  * check_is_greater_than_or_equal(3, 5); // 3 is not greater than or equal to 5
  */
 export const check_is_greater_than_or_equal = (
-	num: number,
-	threshold: number
+  num: number,
+  threshold: number,
 ): boolean => {
-	return num >= threshold;
+  return num >= threshold;
 };
 
 /**
@@ -38,8 +38,8 @@ export const check_is_greater_than_or_equal = (
  * check_is_not_greater_than_or_equal(10, 5); // 10 is greater than or equal to 5
  */
 export const check_is_not_greater_than_or_equal = (
-	num: number,
-	threshold: number
+  num: number,
+  threshold: number,
 ): boolean => {
-	return !check_is_greater_than_or_equal(num, threshold);
+  return !check_is_greater_than_or_equal(num, threshold);
 };

--- a/packages/number/src/checkGreaterThanOrEqual/test.ts
+++ b/packages/number/src/checkGreaterThanOrEqual/test.ts
@@ -1,42 +1,42 @@
 import { assertEquals } from "../../deps.ts";
 import {
-  checkIsGreaterThanOrEqual,
-  checkIsNotGreaterThanOrEqual,
+	check_is_greater_than_or_equal,
+	check_is_not_greater_than_or_equal,
 } from "./main.ts";
 
 Deno.test("checkIsGreaterThanOrEqual", async (t) => {
-  await t.step("should return true when num is greater than threshold", () => {
-    assertEquals(checkIsGreaterThanOrEqual(10, 5), true);
-    assertEquals(checkIsGreaterThanOrEqual(100, 99), true);
-    assertEquals(checkIsGreaterThanOrEqual(-1, -5), true);
-  });
+	await t.step("should return true when num is greater than threshold", () => {
+		assertEquals(check_is_greater_than_or_equal(10, 5), true);
+		assertEquals(check_is_greater_than_or_equal(100, 99), true);
+		assertEquals(check_is_greater_than_or_equal(-1, -5), true);
+	});
 
-  await t.step("should return true when num is equal to threshold", () => {
-    assertEquals(checkIsGreaterThanOrEqual(5, 5), true);
-    assertEquals(checkIsGreaterThanOrEqual(0, 0), true);
-    assertEquals(checkIsGreaterThanOrEqual(-10, -10), true);
-  });
+	await t.step("should return true when num is equal to threshold", () => {
+		assertEquals(check_is_greater_than_or_equal(5, 5), true);
+		assertEquals(check_is_greater_than_or_equal(0, 0), true);
+		assertEquals(check_is_greater_than_or_equal(-10, -10), true);
+	});
 
-  await t.step("should return false when num is less than threshold", () => {
-    assertEquals(checkIsGreaterThanOrEqual(3, 5), false);
-    assertEquals(checkIsGreaterThanOrEqual(0, 10), false);
-    assertEquals(checkIsGreaterThanOrEqual(-20, -10), false);
-  });
+	await t.step("should return false when num is less than threshold", () => {
+		assertEquals(check_is_greater_than_or_equal(3, 5), false);
+		assertEquals(check_is_greater_than_or_equal(0, 10), false);
+		assertEquals(check_is_greater_than_or_equal(-20, -10), false);
+	});
 });
 
 Deno.test("checkIsNotGreaterThanOrEqual", async (t) => {
-  await t.step("should return true when num is less than threshold", () => {
-    assertEquals(checkIsNotGreaterThanOrEqual(3, 5), true);
-    assertEquals(checkIsNotGreaterThanOrEqual(0, 10), true);
-    assertEquals(checkIsNotGreaterThanOrEqual(-20, -10), true);
-  });
+	await t.step("should return true when num is less than threshold", () => {
+		assertEquals(check_is_not_greater_than_or_equal(3, 5), true);
+		assertEquals(check_is_not_greater_than_or_equal(0, 10), true);
+		assertEquals(check_is_not_greater_than_or_equal(-20, -10), true);
+	});
 
-  await t.step(
-    "should return false when num is greater than or equal to threshold",
-    () => {
-      assertEquals(checkIsNotGreaterThanOrEqual(10, 5), false);
-      assertEquals(checkIsNotGreaterThanOrEqual(0, 0), false);
-      assertEquals(checkIsNotGreaterThanOrEqual(-1, -5), false);
-    },
-  );
+	await t.step(
+		"should return false when num is greater than or equal to threshold",
+		() => {
+			assertEquals(check_is_not_greater_than_or_equal(10, 5), false);
+			assertEquals(check_is_not_greater_than_or_equal(0, 0), false);
+			assertEquals(check_is_not_greater_than_or_equal(-1, -5), false);
+		}
+	);
 });

--- a/packages/number/src/checkGreaterThanOrEqual/test.ts
+++ b/packages/number/src/checkGreaterThanOrEqual/test.ts
@@ -1,42 +1,42 @@
 import { assertEquals } from "../../deps.ts";
 import {
-	check_is_greater_than_or_equal,
-	check_is_not_greater_than_or_equal,
+  check_is_greater_than_or_equal,
+  check_is_not_greater_than_or_equal,
 } from "./main.ts";
 
 Deno.test("checkIsGreaterThanOrEqual", async (t) => {
-	await t.step("should return true when num is greater than threshold", () => {
-		assertEquals(check_is_greater_than_or_equal(10, 5), true);
-		assertEquals(check_is_greater_than_or_equal(100, 99), true);
-		assertEquals(check_is_greater_than_or_equal(-1, -5), true);
-	});
+  await t.step("should return true when num is greater than threshold", () => {
+    assertEquals(check_is_greater_than_or_equal(10, 5), true);
+    assertEquals(check_is_greater_than_or_equal(100, 99), true);
+    assertEquals(check_is_greater_than_or_equal(-1, -5), true);
+  });
 
-	await t.step("should return true when num is equal to threshold", () => {
-		assertEquals(check_is_greater_than_or_equal(5, 5), true);
-		assertEquals(check_is_greater_than_or_equal(0, 0), true);
-		assertEquals(check_is_greater_than_or_equal(-10, -10), true);
-	});
+  await t.step("should return true when num is equal to threshold", () => {
+    assertEquals(check_is_greater_than_or_equal(5, 5), true);
+    assertEquals(check_is_greater_than_or_equal(0, 0), true);
+    assertEquals(check_is_greater_than_or_equal(-10, -10), true);
+  });
 
-	await t.step("should return false when num is less than threshold", () => {
-		assertEquals(check_is_greater_than_or_equal(3, 5), false);
-		assertEquals(check_is_greater_than_or_equal(0, 10), false);
-		assertEquals(check_is_greater_than_or_equal(-20, -10), false);
-	});
+  await t.step("should return false when num is less than threshold", () => {
+    assertEquals(check_is_greater_than_or_equal(3, 5), false);
+    assertEquals(check_is_greater_than_or_equal(0, 10), false);
+    assertEquals(check_is_greater_than_or_equal(-20, -10), false);
+  });
 });
 
 Deno.test("checkIsNotGreaterThanOrEqual", async (t) => {
-	await t.step("should return true when num is less than threshold", () => {
-		assertEquals(check_is_not_greater_than_or_equal(3, 5), true);
-		assertEquals(check_is_not_greater_than_or_equal(0, 10), true);
-		assertEquals(check_is_not_greater_than_or_equal(-20, -10), true);
-	});
+  await t.step("should return true when num is less than threshold", () => {
+    assertEquals(check_is_not_greater_than_or_equal(3, 5), true);
+    assertEquals(check_is_not_greater_than_or_equal(0, 10), true);
+    assertEquals(check_is_not_greater_than_or_equal(-20, -10), true);
+  });
 
-	await t.step(
-		"should return false when num is greater than or equal to threshold",
-		() => {
-			assertEquals(check_is_not_greater_than_or_equal(10, 5), false);
-			assertEquals(check_is_not_greater_than_or_equal(0, 0), false);
-			assertEquals(check_is_not_greater_than_or_equal(-1, -5), false);
-		}
-	);
+  await t.step(
+    "should return false when num is greater than or equal to threshold",
+    () => {
+      assertEquals(check_is_not_greater_than_or_equal(10, 5), false);
+      assertEquals(check_is_not_greater_than_or_equal(0, 0), false);
+      assertEquals(check_is_not_greater_than_or_equal(-1, -5), false);
+    },
+  );
 });

--- a/packages/number/src/checkInfinity/main.ts
+++ b/packages/number/src/checkInfinity/main.ts
@@ -6,48 +6,48 @@
  *
  * @example
  * // Returns true
- * checkIsInfinity(Infinity); // Infinity is recognized as Infinity
+ * check_is_infinity(Infinity); // Infinity is recognized as Infinity
  *
  * @example
  * // Returns true
- * checkIsInfinity(-Infinity); // -Infinity is recognized as Infinity
+ * check_is_infinity(-Infinity); // -Infinity is recognized as Infinity
  *
  * @example
  * // Returns false
- * checkIsInfinity(100); // 100 is not Infinity
+ * check_is_infinity(100); // 100 is not Infinity
  *
  * @example
  * // Returns false
- * checkIsInfinity("Infinity"); // String "Infinity" is not the same as Infinity
+ * check_is_infinity("Infinity"); // String "Infinity" is not the same as Infinity
  */
-export const checkIsInfinity = (value: unknown): boolean => {
-  return value === Infinity || value === -Infinity;
+export const check_is_infinity = (value: unknown): boolean => {
+	return value === Infinity || value === -Infinity;
 };
 
 /**
  * Checks if the given value is not Infinity.
  *
- * This is the inverse of `checkIsInfinity`.
+ * This is the inverse of `check_is_infinity`.
  *
  * @param {unknown} value - The value to check.
  * @returns {boolean} True if the value is not Infinity or -Infinity, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotInfinity(100); // 100 is not Infinity
+ * check_is_not_infinity(100); // 100 is not Infinity
  *
  * @example
  * // Returns false
- * checkIsNotInfinity(Infinity); // Infinity is recognized as Infinity
+ * check_is_not_infinity(Infinity); // Infinity is recognized as Infinity
  *
  * @example
  * // Returns false
- * checkIsNotInfinity(-Infinity); // -Infinity is recognized as Infinity
+ * check_is_not_infinity(-Infinity); // -Infinity is recognized as Infinity
  *
  * @example
  * // Returns true
- * checkIsNotInfinity("Infinity"); // String "Infinity" is not the same as Infinity
+ * check_is_not_infinity("Infinity"); // String "Infinity" is not the same as Infinity
  */
-export const checkIsNotInfinity = (value: unknown): boolean => {
-  return !checkIsInfinity(value);
+export const check_is_not_infinity = (value: unknown): boolean => {
+	return !check_is_infinity(value);
 };

--- a/packages/number/src/checkInfinity/main.ts
+++ b/packages/number/src/checkInfinity/main.ts
@@ -21,7 +21,7 @@
  * check_is_infinity("Infinity"); // String "Infinity" is not the same as Infinity
  */
 export const check_is_infinity = (value: unknown): boolean => {
-	return value === Infinity || value === -Infinity;
+  return value === Infinity || value === -Infinity;
 };
 
 /**
@@ -49,5 +49,5 @@ export const check_is_infinity = (value: unknown): boolean => {
  * check_is_not_infinity("Infinity"); // String "Infinity" is not the same as Infinity
  */
 export const check_is_not_infinity = (value: unknown): boolean => {
-	return !check_is_infinity(value);
+  return !check_is_infinity(value);
 };

--- a/packages/number/src/checkInfinity/test.ts
+++ b/packages/number/src/checkInfinity/test.ts
@@ -2,31 +2,31 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_infinity, check_is_not_infinity } from "./main.ts";
 
 Deno.test("check_is_infinity", async (t) => {
-	await t.step("should return true for Infinity values", () => {
-		assertEquals(check_is_infinity(Infinity), true);
-		assertEquals(check_is_infinity(-Infinity), true);
-	});
+  await t.step("should return true for Infinity values", () => {
+    assertEquals(check_is_infinity(Infinity), true);
+    assertEquals(check_is_infinity(-Infinity), true);
+  });
 
-	await t.step("should return false for non-Infinity values", () => {
-		assertEquals(check_is_infinity(100), false);
-		assertEquals(check_is_infinity(0), false);
-		assertEquals(check_is_infinity("Infinity"), false);
-		assertEquals(check_is_infinity(Number.NaN), false);
-		assertEquals(check_is_infinity(3.14), false);
-	});
+  await t.step("should return false for non-Infinity values", () => {
+    assertEquals(check_is_infinity(100), false);
+    assertEquals(check_is_infinity(0), false);
+    assertEquals(check_is_infinity("Infinity"), false);
+    assertEquals(check_is_infinity(Number.NaN), false);
+    assertEquals(check_is_infinity(3.14), false);
+  });
 });
 
 Deno.test("check_is_not_infinity", async (t) => {
-	await t.step("should return true for non-Infinity values", () => {
-		assertEquals(check_is_not_infinity(100), true);
-		assertEquals(check_is_not_infinity(0), true);
-		assertEquals(check_is_not_infinity("Infinity"), true);
-		assertEquals(check_is_not_infinity(Number.NaN), true);
-		assertEquals(check_is_not_infinity(3.14), true);
-	});
+  await t.step("should return true for non-Infinity values", () => {
+    assertEquals(check_is_not_infinity(100), true);
+    assertEquals(check_is_not_infinity(0), true);
+    assertEquals(check_is_not_infinity("Infinity"), true);
+    assertEquals(check_is_not_infinity(Number.NaN), true);
+    assertEquals(check_is_not_infinity(3.14), true);
+  });
 
-	await t.step("should return false for Infinity values", () => {
-		assertEquals(check_is_not_infinity(Infinity), false);
-		assertEquals(check_is_not_infinity(-Infinity), false);
-	});
+  await t.step("should return false for Infinity values", () => {
+    assertEquals(check_is_not_infinity(Infinity), false);
+    assertEquals(check_is_not_infinity(-Infinity), false);
+  });
 });

--- a/packages/number/src/checkInfinity/test.ts
+++ b/packages/number/src/checkInfinity/test.ts
@@ -1,32 +1,32 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsInfinity, checkIsNotInfinity } from "./main.ts";
+import { check_is_infinity, check_is_not_infinity } from "./main.ts";
 
-Deno.test("checkIsInfinity", async (t) => {
-  await t.step("should return true for Infinity values", () => {
-    assertEquals(checkIsInfinity(Infinity), true);
-    assertEquals(checkIsInfinity(-Infinity), true);
-  });
+Deno.test("check_is_infinity", async (t) => {
+	await t.step("should return true for Infinity values", () => {
+		assertEquals(check_is_infinity(Infinity), true);
+		assertEquals(check_is_infinity(-Infinity), true);
+	});
 
-  await t.step("should return false for non-Infinity values", () => {
-    assertEquals(checkIsInfinity(100), false);
-    assertEquals(checkIsInfinity(0), false);
-    assertEquals(checkIsInfinity("Infinity"), false);
-    assertEquals(checkIsInfinity(Number.NaN), false);
-    assertEquals(checkIsInfinity(3.14), false);
-  });
+	await t.step("should return false for non-Infinity values", () => {
+		assertEquals(check_is_infinity(100), false);
+		assertEquals(check_is_infinity(0), false);
+		assertEquals(check_is_infinity("Infinity"), false);
+		assertEquals(check_is_infinity(Number.NaN), false);
+		assertEquals(check_is_infinity(3.14), false);
+	});
 });
 
-Deno.test("checkIsNotInfinity", async (t) => {
-  await t.step("should return true for non-Infinity values", () => {
-    assertEquals(checkIsNotInfinity(100), true);
-    assertEquals(checkIsNotInfinity(0), true);
-    assertEquals(checkIsNotInfinity("Infinity"), true);
-    assertEquals(checkIsNotInfinity(Number.NaN), true);
-    assertEquals(checkIsNotInfinity(3.14), true);
-  });
+Deno.test("check_is_not_infinity", async (t) => {
+	await t.step("should return true for non-Infinity values", () => {
+		assertEquals(check_is_not_infinity(100), true);
+		assertEquals(check_is_not_infinity(0), true);
+		assertEquals(check_is_not_infinity("Infinity"), true);
+		assertEquals(check_is_not_infinity(Number.NaN), true);
+		assertEquals(check_is_not_infinity(3.14), true);
+	});
 
-  await t.step("should return false for Infinity values", () => {
-    assertEquals(checkIsNotInfinity(Infinity), false);
-    assertEquals(checkIsNotInfinity(-Infinity), false);
-  });
+	await t.step("should return false for Infinity values", () => {
+		assertEquals(check_is_not_infinity(Infinity), false);
+		assertEquals(check_is_not_infinity(-Infinity), false);
+	});
 });

--- a/packages/number/src/checkInteger/main.ts
+++ b/packages/number/src/checkInteger/main.ts
@@ -13,7 +13,7 @@
  * check_is_integer(5.5); // 5.5 is not an integer
  */
 export const check_is_integer = (num: number): boolean => {
-	return Number.isInteger(num);
+  return Number.isInteger(num);
 };
 
 /**
@@ -33,5 +33,5 @@ export const check_is_integer = (num: number): boolean => {
  * check_is_not_integer(5); // 5 is an integer
  */
 export const check_is_not_integer = (num: number): boolean => {
-	return !check_is_integer(num);
+  return !check_is_integer(num);
 };

--- a/packages/number/src/checkInteger/main.ts
+++ b/packages/number/src/checkInteger/main.ts
@@ -6,32 +6,32 @@
  *
  * @example
  * // Returns true
- * checkIsInteger(5); // 5 is an integer
+ * check_is_integer(5); // 5 is an integer
  *
  * @example
  * // Returns false
- * checkIsInteger(5.5); // 5.5 is not an integer
+ * check_is_integer(5.5); // 5.5 is not an integer
  */
-export const checkIsInteger = (num: number): boolean => {
-  return Number.isInteger(num);
+export const check_is_integer = (num: number): boolean => {
+	return Number.isInteger(num);
 };
 
 /**
  * Checks if the given number is not an integer.
  *
- * This is the inverse of `checkIsInteger`.
+ * This is the inverse of `check_is_integer`.
  *
  * @param {number} num - The number to check.
  * @returns {boolean} True if the number is not an integer, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotInteger(5.5); // 5.5 is not an integer
+ * check_is_not_integer(5.5); // 5.5 is not an integer
  *
  * @example
  * // Returns false
- * checkIsNotInteger(5); // 5 is an integer
+ * check_is_not_integer(5); // 5 is an integer
  */
-export const checkIsNotInteger = (num: number): boolean => {
-  return !checkIsInteger(num);
+export const check_is_not_integer = (num: number): boolean => {
+	return !check_is_integer(num);
 };

--- a/packages/number/src/checkInteger/test.ts
+++ b/packages/number/src/checkInteger/test.ts
@@ -2,37 +2,37 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_integer, check_is_not_integer } from "./main.ts";
 
 Deno.test("check_is_integer", async (t) => {
-	await t.step("should return true for integer numbers", () => {
-		assertEquals(check_is_integer(1), true);
-		assertEquals(check_is_integer(0), true);
-		assertEquals(check_is_integer(-100), true);
-		assertEquals(check_is_integer(42), true);
-	});
+  await t.step("should return true for integer numbers", () => {
+    assertEquals(check_is_integer(1), true);
+    assertEquals(check_is_integer(0), true);
+    assertEquals(check_is_integer(-100), true);
+    assertEquals(check_is_integer(42), true);
+  });
 
-	await t.step("should return false for non-integer numbers", () => {
-		assertEquals(check_is_integer(1.5), false);
-		assertEquals(check_is_integer(3.14), false);
-		assertEquals(check_is_integer(-2.718), false);
-		assertEquals(check_is_integer(Number.NaN), false);
-		assertEquals(check_is_integer(Number.POSITIVE_INFINITY), false);
-		assertEquals(check_is_integer(Number.NEGATIVE_INFINITY), false);
-	});
+  await t.step("should return false for non-integer numbers", () => {
+    assertEquals(check_is_integer(1.5), false);
+    assertEquals(check_is_integer(3.14), false);
+    assertEquals(check_is_integer(-2.718), false);
+    assertEquals(check_is_integer(Number.NaN), false);
+    assertEquals(check_is_integer(Number.POSITIVE_INFINITY), false);
+    assertEquals(check_is_integer(Number.NEGATIVE_INFINITY), false);
+  });
 });
 
 Deno.test("check_is_not_integer", async (t) => {
-	await t.step("should return true for non-integer numbers", () => {
-		assertEquals(check_is_not_integer(1.5), true);
-		assertEquals(check_is_not_integer(3.14), true);
-		assertEquals(check_is_not_integer(-2.718), true);
-		assertEquals(check_is_not_integer(Number.NaN), true);
-		assertEquals(check_is_not_integer(Number.POSITIVE_INFINITY), true);
-		assertEquals(check_is_not_integer(Number.NEGATIVE_INFINITY), true);
-	});
+  await t.step("should return true for non-integer numbers", () => {
+    assertEquals(check_is_not_integer(1.5), true);
+    assertEquals(check_is_not_integer(3.14), true);
+    assertEquals(check_is_not_integer(-2.718), true);
+    assertEquals(check_is_not_integer(Number.NaN), true);
+    assertEquals(check_is_not_integer(Number.POSITIVE_INFINITY), true);
+    assertEquals(check_is_not_integer(Number.NEGATIVE_INFINITY), true);
+  });
 
-	await t.step("should return false for integer numbers", () => {
-		assertEquals(check_is_not_integer(1), false);
-		assertEquals(check_is_not_integer(0), false);
-		assertEquals(check_is_not_integer(-100), false);
-		assertEquals(check_is_not_integer(42), false);
-	});
+  await t.step("should return false for integer numbers", () => {
+    assertEquals(check_is_not_integer(1), false);
+    assertEquals(check_is_not_integer(0), false);
+    assertEquals(check_is_not_integer(-100), false);
+    assertEquals(check_is_not_integer(42), false);
+  });
 });

--- a/packages/number/src/checkInteger/test.ts
+++ b/packages/number/src/checkInteger/test.ts
@@ -1,38 +1,38 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsInteger, checkIsNotInteger } from "./main.ts";
+import { check_is_integer, check_is_not_integer } from "./main.ts";
 
-Deno.test("checkIsInteger", async (t) => {
-  await t.step("should return true for integer numbers", () => {
-    assertEquals(checkIsInteger(1), true);
-    assertEquals(checkIsInteger(0), true);
-    assertEquals(checkIsInteger(-100), true);
-    assertEquals(checkIsInteger(42), true);
-  });
+Deno.test("check_is_integer", async (t) => {
+	await t.step("should return true for integer numbers", () => {
+		assertEquals(check_is_integer(1), true);
+		assertEquals(check_is_integer(0), true);
+		assertEquals(check_is_integer(-100), true);
+		assertEquals(check_is_integer(42), true);
+	});
 
-  await t.step("should return false for non-integer numbers", () => {
-    assertEquals(checkIsInteger(1.5), false);
-    assertEquals(checkIsInteger(3.14), false);
-    assertEquals(checkIsInteger(-2.718), false);
-    assertEquals(checkIsInteger(Number.NaN), false);
-    assertEquals(checkIsInteger(Number.POSITIVE_INFINITY), false);
-    assertEquals(checkIsInteger(Number.NEGATIVE_INFINITY), false);
-  });
+	await t.step("should return false for non-integer numbers", () => {
+		assertEquals(check_is_integer(1.5), false);
+		assertEquals(check_is_integer(3.14), false);
+		assertEquals(check_is_integer(-2.718), false);
+		assertEquals(check_is_integer(Number.NaN), false);
+		assertEquals(check_is_integer(Number.POSITIVE_INFINITY), false);
+		assertEquals(check_is_integer(Number.NEGATIVE_INFINITY), false);
+	});
 });
 
-Deno.test("checkIsNotInteger", async (t) => {
-  await t.step("should return true for non-integer numbers", () => {
-    assertEquals(checkIsNotInteger(1.5), true);
-    assertEquals(checkIsNotInteger(3.14), true);
-    assertEquals(checkIsNotInteger(-2.718), true);
-    assertEquals(checkIsNotInteger(Number.NaN), true);
-    assertEquals(checkIsNotInteger(Number.POSITIVE_INFINITY), true);
-    assertEquals(checkIsNotInteger(Number.NEGATIVE_INFINITY), true);
-  });
+Deno.test("check_is_not_integer", async (t) => {
+	await t.step("should return true for non-integer numbers", () => {
+		assertEquals(check_is_not_integer(1.5), true);
+		assertEquals(check_is_not_integer(3.14), true);
+		assertEquals(check_is_not_integer(-2.718), true);
+		assertEquals(check_is_not_integer(Number.NaN), true);
+		assertEquals(check_is_not_integer(Number.POSITIVE_INFINITY), true);
+		assertEquals(check_is_not_integer(Number.NEGATIVE_INFINITY), true);
+	});
 
-  await t.step("should return false for integer numbers", () => {
-    assertEquals(checkIsNotInteger(1), false);
-    assertEquals(checkIsNotInteger(0), false);
-    assertEquals(checkIsNotInteger(-100), false);
-    assertEquals(checkIsNotInteger(42), false);
-  });
+	await t.step("should return false for integer numbers", () => {
+		assertEquals(check_is_not_integer(1), false);
+		assertEquals(check_is_not_integer(0), false);
+		assertEquals(check_is_not_integer(-100), false);
+		assertEquals(check_is_not_integer(42), false);
+	});
 });

--- a/packages/number/src/checkLessThan/main.ts
+++ b/packages/number/src/checkLessThan/main.ts
@@ -7,20 +7,20 @@
  *
  * @example
  * // Returns true
- * checkIsLessThan(5, 10); // 5 is less than 10
+ * check_is_less_than(5, 10); // 5 is less than 10
  *
  * @example
  * // Returns false
- * checkIsLessThan(15, 10); // 15 is not less than 10
+ * check_is_less_than(15, 10); // 15 is not less than 10
  */
-export const checkIsLessThan = (num: number, threshold: number): boolean => {
-  return num < threshold;
+export const check_is_less_than = (num: number, threshold: number): boolean => {
+	return num < threshold;
 };
 
 /**
  * Checks if a number is not less than a specified threshold.
  *
- * This is the inverse of `checkIsLessThan`.
+ * This is the inverse of `check_is_less_than`.
  *
  * @param {number} num - The number to check.
  * @param {number} threshold - The threshold to compare against.
@@ -28,12 +28,15 @@ export const checkIsLessThan = (num: number, threshold: number): boolean => {
  *
  * @example
  * // Returns true
- * checkIsNotLessThan(15, 10); // 15 is not less than 10
+ * check_is_not_less_than(15, 10); // 15 is not less than 10
  *
  * @example
  * // Returns false
- * checkIsNotLessThan(5, 10); // 5 is less than 10
+ * check_is_not_less_than(5, 10); // 5 is less than 10
  */
-export const checkIsNotLessThan = (num: number, threshold: number): boolean => {
-  return !checkIsLessThan(num, threshold);
+export const check_is_not_less_than = (
+	num: number,
+	threshold: number
+): boolean => {
+	return !check_is_less_than(num, threshold);
 };

--- a/packages/number/src/checkLessThan/main.ts
+++ b/packages/number/src/checkLessThan/main.ts
@@ -14,7 +14,7 @@
  * check_is_less_than(15, 10); // 15 is not less than 10
  */
 export const check_is_less_than = (num: number, threshold: number): boolean => {
-	return num < threshold;
+  return num < threshold;
 };
 
 /**
@@ -35,8 +35,8 @@ export const check_is_less_than = (num: number, threshold: number): boolean => {
  * check_is_not_less_than(5, 10); // 5 is less than 10
  */
 export const check_is_not_less_than = (
-	num: number,
-	threshold: number
+  num: number,
+  threshold: number,
 ): boolean => {
-	return !check_is_less_than(num, threshold);
+  return !check_is_less_than(num, threshold);
 };

--- a/packages/number/src/checkLessThan/test.ts
+++ b/packages/number/src/checkLessThan/test.ts
@@ -2,36 +2,36 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_less_than, check_is_not_less_than } from "./main.ts";
 
 Deno.test("check_is_less_than", async (t) => {
-	await t.step("should return true when num is less than threshold", () => {
-		assertEquals(check_is_less_than(1, 5), true);
-		assertEquals(check_is_less_than(-1, 0), true);
-		assertEquals(check_is_less_than(3.14, 10), true);
-		assertEquals(check_is_less_than(-10, -5), true);
-	});
+  await t.step("should return true when num is less than threshold", () => {
+    assertEquals(check_is_less_than(1, 5), true);
+    assertEquals(check_is_less_than(-1, 0), true);
+    assertEquals(check_is_less_than(3.14, 10), true);
+    assertEquals(check_is_less_than(-10, -5), true);
+  });
 
-	await t.step(
-		"should return false when num is not less than threshold",
-		() => {
-			assertEquals(check_is_less_than(5, 1), false);
-			assertEquals(check_is_less_than(0, 0), false); // equal values
-			assertEquals(check_is_less_than(10, 3.14), false);
-			assertEquals(check_is_less_than(-5, -10), false);
-		}
-	);
+  await t.step(
+    "should return false when num is not less than threshold",
+    () => {
+      assertEquals(check_is_less_than(5, 1), false);
+      assertEquals(check_is_less_than(0, 0), false); // equal values
+      assertEquals(check_is_less_than(10, 3.14), false);
+      assertEquals(check_is_less_than(-5, -10), false);
+    },
+  );
 });
 
 Deno.test("check_is_not_less_than", async (t) => {
-	await t.step("should return true when num is not less than threshold", () => {
-		assertEquals(check_is_not_less_than(5, 1), true);
-		assertEquals(check_is_not_less_than(0, 0), true); // equal values
-		assertEquals(check_is_not_less_than(10, 3.14), true);
-		assertEquals(check_is_not_less_than(-5, -10), true);
-	});
+  await t.step("should return true when num is not less than threshold", () => {
+    assertEquals(check_is_not_less_than(5, 1), true);
+    assertEquals(check_is_not_less_than(0, 0), true); // equal values
+    assertEquals(check_is_not_less_than(10, 3.14), true);
+    assertEquals(check_is_not_less_than(-5, -10), true);
+  });
 
-	await t.step("should return false when num is less than threshold", () => {
-		assertEquals(check_is_not_less_than(1, 5), false);
-		assertEquals(check_is_not_less_than(-1, 0), false);
-		assertEquals(check_is_not_less_than(3.14, 10), false);
-		assertEquals(check_is_not_less_than(-10, -5), false);
-	});
+  await t.step("should return false when num is less than threshold", () => {
+    assertEquals(check_is_not_less_than(1, 5), false);
+    assertEquals(check_is_not_less_than(-1, 0), false);
+    assertEquals(check_is_not_less_than(3.14, 10), false);
+    assertEquals(check_is_not_less_than(-10, -5), false);
+  });
 });

--- a/packages/number/src/checkLessThan/test.ts
+++ b/packages/number/src/checkLessThan/test.ts
@@ -1,37 +1,37 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsLessThan, checkIsNotLessThan } from "./main.ts";
+import { check_is_less_than, check_is_not_less_than } from "./main.ts";
 
-Deno.test("checkIsLessThan", async (t) => {
-  await t.step("should return true when num is less than threshold", () => {
-    assertEquals(checkIsLessThan(1, 5), true);
-    assertEquals(checkIsLessThan(-1, 0), true);
-    assertEquals(checkIsLessThan(3.14, 10), true);
-    assertEquals(checkIsLessThan(-10, -5), true);
-  });
+Deno.test("check_is_less_than", async (t) => {
+	await t.step("should return true when num is less than threshold", () => {
+		assertEquals(check_is_less_than(1, 5), true);
+		assertEquals(check_is_less_than(-1, 0), true);
+		assertEquals(check_is_less_than(3.14, 10), true);
+		assertEquals(check_is_less_than(-10, -5), true);
+	});
 
-  await t.step(
-    "should return false when num is not less than threshold",
-    () => {
-      assertEquals(checkIsLessThan(5, 1), false);
-      assertEquals(checkIsLessThan(0, 0), false); // equal values
-      assertEquals(checkIsLessThan(10, 3.14), false);
-      assertEquals(checkIsLessThan(-5, -10), false);
-    },
-  );
+	await t.step(
+		"should return false when num is not less than threshold",
+		() => {
+			assertEquals(check_is_less_than(5, 1), false);
+			assertEquals(check_is_less_than(0, 0), false); // equal values
+			assertEquals(check_is_less_than(10, 3.14), false);
+			assertEquals(check_is_less_than(-5, -10), false);
+		}
+	);
 });
 
-Deno.test("checkIsNotLessThan", async (t) => {
-  await t.step("should return true when num is not less than threshold", () => {
-    assertEquals(checkIsNotLessThan(5, 1), true);
-    assertEquals(checkIsNotLessThan(0, 0), true); // equal values
-    assertEquals(checkIsNotLessThan(10, 3.14), true);
-    assertEquals(checkIsNotLessThan(-5, -10), true);
-  });
+Deno.test("check_is_not_less_than", async (t) => {
+	await t.step("should return true when num is not less than threshold", () => {
+		assertEquals(check_is_not_less_than(5, 1), true);
+		assertEquals(check_is_not_less_than(0, 0), true); // equal values
+		assertEquals(check_is_not_less_than(10, 3.14), true);
+		assertEquals(check_is_not_less_than(-5, -10), true);
+	});
 
-  await t.step("should return false when num is less than threshold", () => {
-    assertEquals(checkIsNotLessThan(1, 5), false);
-    assertEquals(checkIsNotLessThan(-1, 0), false);
-    assertEquals(checkIsNotLessThan(3.14, 10), false);
-    assertEquals(checkIsNotLessThan(-10, -5), false);
-  });
+	await t.step("should return false when num is less than threshold", () => {
+		assertEquals(check_is_not_less_than(1, 5), false);
+		assertEquals(check_is_not_less_than(-1, 0), false);
+		assertEquals(check_is_not_less_than(3.14, 10), false);
+		assertEquals(check_is_not_less_than(-10, -5), false);
+	});
 });

--- a/packages/number/src/checkLessThanOrEqual/main.ts
+++ b/packages/number/src/checkLessThanOrEqual/main.ts
@@ -14,10 +14,10 @@
  * check_is_less_than_or_equal(15, 10); // 15 is greater than 10
  */
 export const check_is_less_than_or_equal = (
-	num: number,
-	threshold: number
+  num: number,
+  threshold: number,
 ): boolean => {
-	return num <= threshold;
+  return num <= threshold;
 };
 
 /**
@@ -38,8 +38,8 @@ export const check_is_less_than_or_equal = (
  * check_is_not_less_than_or_equal(5, 10); // 5 is less than or equal to 10
  */
 export const check_is_not_less_than_or_equal = (
-	num: number,
-	threshold: number
+  num: number,
+  threshold: number,
 ): boolean => {
-	return !check_is_less_than_or_equal(num, threshold);
+  return !check_is_less_than_or_equal(num, threshold);
 };

--- a/packages/number/src/checkLessThanOrEqual/main.ts
+++ b/packages/number/src/checkLessThanOrEqual/main.ts
@@ -7,23 +7,23 @@
  *
  * @example
  * // Returns true
- * checkIsLessThanOrEqual(5, 10); // 5 is less than or equal to 10
+ * check_is_less_than_or_equal(5, 10); // 5 is less than or equal to 10
  *
  * @example
  * // Returns false
- * checkIsLessThanOrEqual(15, 10); // 15 is greater than 10
+ * check_is_less_than_or_equal(15, 10); // 15 is greater than 10
  */
-export const checkIsLessThanOrEqual = (
-  num: number,
-  threshold: number,
+export const check_is_less_than_or_equal = (
+	num: number,
+	threshold: number
 ): boolean => {
-  return num <= threshold;
+	return num <= threshold;
 };
 
 /**
  * Checks if the given number is not less than or equal to the specified threshold.
  *
- * This is the inverse of `checkIsLessThanOrEqual`.
+ * This is the inverse of `check_is_less_than_or_equal`.
  *
  * @param {number} num - The number to check.
  * @param {number} threshold - The threshold to compare against.
@@ -31,15 +31,15 @@ export const checkIsLessThanOrEqual = (
  *
  * @example
  * // Returns true
- * checkIsNotLessThanOrEqual(15, 10); // 15 is greater than 10
+ * check_is_not_less_than_or_equal(15, 10); // 15 is greater than 10
  *
  * @example
  * // Returns false
- * checkIsNotLessThanOrEqual(5, 10); // 5 is less than or equal to 10
+ * check_is_not_less_than_or_equal(5, 10); // 5 is less than or equal to 10
  */
-export const checkIsNotLessThanOrEqual = (
-  num: number,
-  threshold: number,
+export const check_is_not_less_than_or_equal = (
+	num: number,
+	threshold: number
 ): boolean => {
-  return !checkIsLessThanOrEqual(num, threshold);
+	return !check_is_less_than_or_equal(num, threshold);
 };

--- a/packages/number/src/checkLessThanOrEqual/test.ts
+++ b/packages/number/src/checkLessThanOrEqual/test.ts
@@ -1,43 +1,43 @@
 import { assertEquals } from "../../deps.ts";
 import {
-	check_is_less_than_or_equal,
-	check_is_not_less_than_or_equal,
+  check_is_less_than_or_equal,
+  check_is_not_less_than_or_equal,
 } from "./main.ts";
 
 Deno.test("check_is_less_than_or_equal", async (t) => {
-	await t.step(
-		"should return true when num is less than or equal to threshold",
-		() => {
-			assertEquals(check_is_less_than_or_equal(1, 2), true);
-			assertEquals(check_is_less_than_or_equal(2, 2), true); // equal values
-			assertEquals(check_is_less_than_or_equal(-1, 0), true);
-			assertEquals(check_is_less_than_or_equal(0, 0), true); // equal values
-			assertEquals(check_is_less_than_or_equal(-100, -50), true);
-		}
-	);
+  await t.step(
+    "should return true when num is less than or equal to threshold",
+    () => {
+      assertEquals(check_is_less_than_or_equal(1, 2), true);
+      assertEquals(check_is_less_than_or_equal(2, 2), true); // equal values
+      assertEquals(check_is_less_than_or_equal(-1, 0), true);
+      assertEquals(check_is_less_than_or_equal(0, 0), true); // equal values
+      assertEquals(check_is_less_than_or_equal(-100, -50), true);
+    },
+  );
 
-	await t.step("should return false when num is greater than threshold", () => {
-		assertEquals(check_is_less_than_or_equal(3, 2), false);
-		assertEquals(check_is_less_than_or_equal(100, 50), false);
-		assertEquals(check_is_less_than_or_equal(0, -1), false);
-	});
+  await t.step("should return false when num is greater than threshold", () => {
+    assertEquals(check_is_less_than_or_equal(3, 2), false);
+    assertEquals(check_is_less_than_or_equal(100, 50), false);
+    assertEquals(check_is_less_than_or_equal(0, -1), false);
+  });
 });
 
 Deno.test("check_is_not_less_than_or_equal", async (t) => {
-	await t.step("should return true when num is greater than threshold", () => {
-		assertEquals(check_is_not_less_than_or_equal(3, 2), true);
-		assertEquals(check_is_not_less_than_or_equal(100, 50), true);
-		assertEquals(check_is_not_less_than_or_equal(0, -1), true);
-	});
+  await t.step("should return true when num is greater than threshold", () => {
+    assertEquals(check_is_not_less_than_or_equal(3, 2), true);
+    assertEquals(check_is_not_less_than_or_equal(100, 50), true);
+    assertEquals(check_is_not_less_than_or_equal(0, -1), true);
+  });
 
-	await t.step(
-		"should return false when num is less than or equal to threshold",
-		() => {
-			assertEquals(check_is_not_less_than_or_equal(1, 2), false);
-			assertEquals(check_is_not_less_than_or_equal(2, 2), false); // equal values
-			assertEquals(check_is_not_less_than_or_equal(-1, 0), false);
-			assertEquals(check_is_not_less_than_or_equal(0, 0), false); // equal values
-			assertEquals(check_is_not_less_than_or_equal(-100, -50), false);
-		}
-	);
+  await t.step(
+    "should return false when num is less than or equal to threshold",
+    () => {
+      assertEquals(check_is_not_less_than_or_equal(1, 2), false);
+      assertEquals(check_is_not_less_than_or_equal(2, 2), false); // equal values
+      assertEquals(check_is_not_less_than_or_equal(-1, 0), false);
+      assertEquals(check_is_not_less_than_or_equal(0, 0), false); // equal values
+      assertEquals(check_is_not_less_than_or_equal(-100, -50), false);
+    },
+  );
 });

--- a/packages/number/src/checkLessThanOrEqual/test.ts
+++ b/packages/number/src/checkLessThanOrEqual/test.ts
@@ -1,40 +1,43 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsLessThanOrEqual, checkIsNotLessThanOrEqual } from "./main.ts";
+import {
+	check_is_less_than_or_equal,
+	check_is_not_less_than_or_equal,
+} from "./main.ts";
 
-Deno.test("checkIsLessThanOrEqual", async (t) => {
-  await t.step(
-    "should return true when num is less than or equal to threshold",
-    () => {
-      assertEquals(checkIsLessThanOrEqual(1, 2), true);
-      assertEquals(checkIsLessThanOrEqual(2, 2), true); // equal values
-      assertEquals(checkIsLessThanOrEqual(-1, 0), true);
-      assertEquals(checkIsLessThanOrEqual(0, 0), true); // equal values
-      assertEquals(checkIsLessThanOrEqual(-100, -50), true);
-    },
-  );
+Deno.test("check_is_less_than_or_equal", async (t) => {
+	await t.step(
+		"should return true when num is less than or equal to threshold",
+		() => {
+			assertEquals(check_is_less_than_or_equal(1, 2), true);
+			assertEquals(check_is_less_than_or_equal(2, 2), true); // equal values
+			assertEquals(check_is_less_than_or_equal(-1, 0), true);
+			assertEquals(check_is_less_than_or_equal(0, 0), true); // equal values
+			assertEquals(check_is_less_than_or_equal(-100, -50), true);
+		}
+	);
 
-  await t.step("should return false when num is greater than threshold", () => {
-    assertEquals(checkIsLessThanOrEqual(3, 2), false);
-    assertEquals(checkIsLessThanOrEqual(100, 50), false);
-    assertEquals(checkIsLessThanOrEqual(0, -1), false);
-  });
+	await t.step("should return false when num is greater than threshold", () => {
+		assertEquals(check_is_less_than_or_equal(3, 2), false);
+		assertEquals(check_is_less_than_or_equal(100, 50), false);
+		assertEquals(check_is_less_than_or_equal(0, -1), false);
+	});
 });
 
-Deno.test("checkIsNotLessThanOrEqual", async (t) => {
-  await t.step("should return true when num is greater than threshold", () => {
-    assertEquals(checkIsNotLessThanOrEqual(3, 2), true);
-    assertEquals(checkIsNotLessThanOrEqual(100, 50), true);
-    assertEquals(checkIsNotLessThanOrEqual(0, -1), true);
-  });
+Deno.test("check_is_not_less_than_or_equal", async (t) => {
+	await t.step("should return true when num is greater than threshold", () => {
+		assertEquals(check_is_not_less_than_or_equal(3, 2), true);
+		assertEquals(check_is_not_less_than_or_equal(100, 50), true);
+		assertEquals(check_is_not_less_than_or_equal(0, -1), true);
+	});
 
-  await t.step(
-    "should return false when num is less than or equal to threshold",
-    () => {
-      assertEquals(checkIsNotLessThanOrEqual(1, 2), false);
-      assertEquals(checkIsNotLessThanOrEqual(2, 2), false); // equal values
-      assertEquals(checkIsNotLessThanOrEqual(-1, 0), false);
-      assertEquals(checkIsNotLessThanOrEqual(0, 0), false); // equal values
-      assertEquals(checkIsNotLessThanOrEqual(-100, -50), false);
-    },
-  );
+	await t.step(
+		"should return false when num is less than or equal to threshold",
+		() => {
+			assertEquals(check_is_not_less_than_or_equal(1, 2), false);
+			assertEquals(check_is_not_less_than_or_equal(2, 2), false); // equal values
+			assertEquals(check_is_not_less_than_or_equal(-1, 0), false);
+			assertEquals(check_is_not_less_than_or_equal(0, 0), false); // equal values
+			assertEquals(check_is_not_less_than_or_equal(-100, -50), false);
+		}
+	);
 });

--- a/packages/number/src/checkLogarithm/main.ts
+++ b/packages/number/src/checkLogarithm/main.ts
@@ -10,24 +10,24 @@
  *
  * @example
  * // Returns true
- * checkIsLogarithm(4, 2, 16); // log2(16) equals 4
+ * check_is_logarithm(4, 2, 16); // log2(16) = 4
  *
  * @example
  * // Returns false
- * checkIsLogarithm(3, 2, 16); // log2(16) equals 4, so 3 does not match
+ * check_is_logarithm(3, 2, 16); // log2(16) = 4, so 3 does not match
  */
-export const checkIsLogarithm = (
-  num: number,
-  base: number,
-  target: number,
+export const check_is_logarithm = (
+	num: number,
+	base: number,
+	target: number
 ): boolean => {
-  return num === Math.log(target) / Math.log(base);
+	return num === Math.log(target) / Math.log(base);
 };
 
 /**
  * Checks if a given number does not match the logarithm of a target with a specified base.
  *
- * This is the inverse of `checkMatchesLogarithm`.
+ * This is the inverse of `check_is_logarithm`.
  *
  * @param {number} num - The number to check.
  * @param {number} base - The base of the logarithm.
@@ -36,16 +36,16 @@ export const checkIsLogarithm = (
  *
  * @example
  * // Returns true
- * checkIsNotLogarithm(3, 2, 16); // log2(16) equals 4, so 3 does not match
+ * check_is_not_logarithm(3, 2, 16); // log2(16) = 4, so 3 does not match
  *
  * @example
  * // Returns false
- * checkIsNotLogarithm(4, 2, 16); // log2(16) equals 4
+ * check_is_not_logarithm(4, 2, 16); // log2(16) = 4
  */
-export const checkIsNotLogarithm = (
-  num: number,
-  base: number,
-  target: number,
+export const check_is_not_logarithm = (
+	num: number,
+	base: number,
+	target: number
 ): boolean => {
-  return !checkIsLogarithm(num, base, target);
+	return !check_is_logarithm(num, base, target);
 };

--- a/packages/number/src/checkLogarithm/main.ts
+++ b/packages/number/src/checkLogarithm/main.ts
@@ -17,11 +17,11 @@
  * check_is_logarithm(3, 2, 16); // log2(16) = 4, so 3 does not match
  */
 export const check_is_logarithm = (
-	num: number,
-	base: number,
-	target: number
+  num: number,
+  base: number,
+  target: number,
 ): boolean => {
-	return num === Math.log(target) / Math.log(base);
+  return num === Math.log(target) / Math.log(base);
 };
 
 /**
@@ -43,9 +43,9 @@ export const check_is_logarithm = (
  * check_is_not_logarithm(4, 2, 16); // log2(16) = 4
  */
 export const check_is_not_logarithm = (
-	num: number,
-	base: number,
-	target: number
+  num: number,
+  base: number,
+  target: number,
 ): boolean => {
-	return !check_is_logarithm(num, base, target);
+  return !check_is_logarithm(num, base, target);
 };

--- a/packages/number/src/checkLogarithm/test.ts
+++ b/packages/number/src/checkLogarithm/test.ts
@@ -1,35 +1,35 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsLogarithm, checkIsNotLogarithm } from "./main.ts";
+import { check_is_logarithm, check_is_not_logarithm } from "./main.ts";
 
-Deno.test("checkIsLogarithm", async (t) => {
-  await t.step("should return true for correct logarithms", () => {
-    assertEquals(checkIsLogarithm(2, 10, 100), true); // log10(100) = 2
-    assertEquals(checkIsLogarithm(3, 2, 8), true); // log2(8) = 3
-    assertEquals(checkIsLogarithm(1, 10, 10), true); // log10(10) = 1
-    assertEquals(checkIsLogarithm(0, 5, 1), true); // log5(1) = 0
-    assertEquals(checkIsLogarithm(4, 2, 16), true); // log2(16) = 4
-  });
+Deno.test("check_is_logarithm", async (t) => {
+	await t.step("should return true for correct logarithms", () => {
+		assertEquals(check_is_logarithm(2, 10, 100), true); // log10(100) = 2
+		assertEquals(check_is_logarithm(3, 2, 8), true); // log2(8) = 3
+		assertEquals(check_is_logarithm(1, 10, 10), true); // log10(10) = 1
+		assertEquals(check_is_logarithm(0, 5, 1), true); // log5(1) = 0
+		assertEquals(check_is_logarithm(4, 2, 16), true); // log2(16) = 4
+	});
 
-  await t.step("should return false for incorrect logarithms", () => {
-    assertEquals(checkIsLogarithm(3, 10, 100), false); // log10(100) ≠ 3
-    assertEquals(checkIsLogarithm(2, 2, 8), false); // log2(8) ≠ checkIsLogarithmeckMatchesLogarithm(2, 10, 10), false); // log10(10) checkIsLogarithmcheckMatchesLogarithm(1, 5, 1), false); // log5(1checkIsLogarithms(checkMatchesLogarithm(3, 2, 16), false); // log2(16) ≠ 3
-  });
+	await t.step("should return false for incorrect logarithms", () => {
+		assertEquals(check_is_logarithm(3, 10, 100), false); // log10(100) ≠ 3
+		assertEquals(check_is_logarithm(2, 2, 8), false); // log2(8) ≠ checkIsLogarithmeckMatchesLogarithm(2, 10, 10), false); // log10(10) checkIsLogarithmcheckMatchesLogarithm(1, 5, 1), false); // log5(1checkIsLogarithms(checkMatchesLogarithm(3, 2, 16), false); // log2(16) ≠ 3
+	});
 });
 
-Deno.test("checkIsNotLogarithmOf", async (t) => {
-  await t.step("should return true for incorrect logarithms", () => {
-    assertEquals(checkIsNotLogarithm(3, 10, 100), true); // log10(100) ≠ 3
-    assertEquals(checkIsNotLogarithm(2, 2, 8), true); // log2(8) ≠ 2
-    assertEquals(checkIsNotLogarithm(2, 10, 10), true); // log10(10) ≠ 2
-    assertEquals(checkIsNotLogarithm(1, 5, 1), true); // log5(1) ≠ 1
-    assertEquals(checkIsNotLogarithm(3, 2, 16), true); // log2(16) ≠ 3
-  });
+Deno.test("check_is_not_logarithm", async (t) => {
+	await t.step("should return true for incorrect logarithms", () => {
+		assertEquals(check_is_not_logarithm(3, 10, 100), true); // log10(100) ≠ 3
+		assertEquals(check_is_not_logarithm(2, 2, 8), true); // log2(8) ≠ 2
+		assertEquals(check_is_not_logarithm(2, 10, 10), true); // log10(10) ≠ 2
+		assertEquals(check_is_not_logarithm(1, 5, 1), true); // log5(1) ≠ 1
+		assertEquals(check_is_not_logarithm(3, 2, 16), true); // log2(16) ≠ 3
+	});
 
-  await t.step("should return false for correct logarithms", () => {
-    assertEquals(checkIsNotLogarithm(2, 10, 100), false); // log10(100) = 2
-    assertEquals(checkIsNotLogarithm(3, 2, 8), false); // log2(8) = 3
-    assertEquals(checkIsNotLogarithm(1, 10, 10), false); // log10(10) = 1
-    assertEquals(checkIsNotLogarithm(0, 5, 1), false); // log5(1) = 0
-    assertEquals(checkIsNotLogarithm(4, 2, 16), false); // log2(16) = 4
-  });
+	await t.step("should return false for correct logarithms", () => {
+		assertEquals(check_is_not_logarithm(2, 10, 100), false); // log10(100) = 2
+		assertEquals(check_is_not_logarithm(3, 2, 8), false); // log2(8) = 3
+		assertEquals(check_is_not_logarithm(1, 10, 10), false); // log10(10) = 1
+		assertEquals(check_is_not_logarithm(0, 5, 1), false); // log5(1) = 0
+		assertEquals(check_is_not_logarithm(4, 2, 16), false); // log2(16) = 4
+	});
 });

--- a/packages/number/src/checkLogarithm/test.ts
+++ b/packages/number/src/checkLogarithm/test.ts
@@ -2,34 +2,34 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_logarithm, check_is_not_logarithm } from "./main.ts";
 
 Deno.test("check_is_logarithm", async (t) => {
-	await t.step("should return true for correct logarithms", () => {
-		assertEquals(check_is_logarithm(2, 10, 100), true); // log10(100) = 2
-		assertEquals(check_is_logarithm(3, 2, 8), true); // log2(8) = 3
-		assertEquals(check_is_logarithm(1, 10, 10), true); // log10(10) = 1
-		assertEquals(check_is_logarithm(0, 5, 1), true); // log5(1) = 0
-		assertEquals(check_is_logarithm(4, 2, 16), true); // log2(16) = 4
-	});
+  await t.step("should return true for correct logarithms", () => {
+    assertEquals(check_is_logarithm(2, 10, 100), true); // log10(100) = 2
+    assertEquals(check_is_logarithm(3, 2, 8), true); // log2(8) = 3
+    assertEquals(check_is_logarithm(1, 10, 10), true); // log10(10) = 1
+    assertEquals(check_is_logarithm(0, 5, 1), true); // log5(1) = 0
+    assertEquals(check_is_logarithm(4, 2, 16), true); // log2(16) = 4
+  });
 
-	await t.step("should return false for incorrect logarithms", () => {
-		assertEquals(check_is_logarithm(3, 10, 100), false); // log10(100) ≠ 3
-		assertEquals(check_is_logarithm(2, 2, 8), false); // log2(8) ≠ checkIsLogarithmeckMatchesLogarithm(2, 10, 10), false); // log10(10) checkIsLogarithmcheckMatchesLogarithm(1, 5, 1), false); // log5(1checkIsLogarithms(checkMatchesLogarithm(3, 2, 16), false); // log2(16) ≠ 3
-	});
+  await t.step("should return false for incorrect logarithms", () => {
+    assertEquals(check_is_logarithm(3, 10, 100), false); // log10(100) ≠ 3
+    assertEquals(check_is_logarithm(2, 2, 8), false); // log2(8) ≠ checkIsLogarithmeckMatchesLogarithm(2, 10, 10), false); // log10(10) checkIsLogarithmcheckMatchesLogarithm(1, 5, 1), false); // log5(1checkIsLogarithms(checkMatchesLogarithm(3, 2, 16), false); // log2(16) ≠ 3
+  });
 });
 
 Deno.test("check_is_not_logarithm", async (t) => {
-	await t.step("should return true for incorrect logarithms", () => {
-		assertEquals(check_is_not_logarithm(3, 10, 100), true); // log10(100) ≠ 3
-		assertEquals(check_is_not_logarithm(2, 2, 8), true); // log2(8) ≠ 2
-		assertEquals(check_is_not_logarithm(2, 10, 10), true); // log10(10) ≠ 2
-		assertEquals(check_is_not_logarithm(1, 5, 1), true); // log5(1) ≠ 1
-		assertEquals(check_is_not_logarithm(3, 2, 16), true); // log2(16) ≠ 3
-	});
+  await t.step("should return true for incorrect logarithms", () => {
+    assertEquals(check_is_not_logarithm(3, 10, 100), true); // log10(100) ≠ 3
+    assertEquals(check_is_not_logarithm(2, 2, 8), true); // log2(8) ≠ 2
+    assertEquals(check_is_not_logarithm(2, 10, 10), true); // log10(10) ≠ 2
+    assertEquals(check_is_not_logarithm(1, 5, 1), true); // log5(1) ≠ 1
+    assertEquals(check_is_not_logarithm(3, 2, 16), true); // log2(16) ≠ 3
+  });
 
-	await t.step("should return false for correct logarithms", () => {
-		assertEquals(check_is_not_logarithm(2, 10, 100), false); // log10(100) = 2
-		assertEquals(check_is_not_logarithm(3, 2, 8), false); // log2(8) = 3
-		assertEquals(check_is_not_logarithm(1, 10, 10), false); // log10(10) = 1
-		assertEquals(check_is_not_logarithm(0, 5, 1), false); // log5(1) = 0
-		assertEquals(check_is_not_logarithm(4, 2, 16), false); // log2(16) = 4
-	});
+  await t.step("should return false for correct logarithms", () => {
+    assertEquals(check_is_not_logarithm(2, 10, 100), false); // log10(100) = 2
+    assertEquals(check_is_not_logarithm(3, 2, 8), false); // log2(8) = 3
+    assertEquals(check_is_not_logarithm(1, 10, 10), false); // log10(10) = 1
+    assertEquals(check_is_not_logarithm(0, 5, 1), false); // log5(1) = 0
+    assertEquals(check_is_not_logarithm(4, 2, 16), false); // log2(16) = 4
+  });
 });

--- a/packages/number/src/checkNegative/main.ts
+++ b/packages/number/src/checkNegative/main.ts
@@ -6,32 +6,32 @@
  *
  * @example
  * // Returns true
- * checkIsNegative(-5); // -5 is a negative number
+ * check_is_negative(-5); // -5 is a negative number
  *
  * @example
  * // Returns false
- * checkIsNegative(3); // 3 is not a negative number
+ * check_is_negative(3); // 3 is not a negative number
  */
-export const checkIsNegative = (num: number): boolean => {
-  return num < 0;
+export const check_is_negative = (num: number): boolean => {
+	return num < 0;
 };
 
 /**
  * Checks if a given number is not negative.
  *
- * This is the inverse of `checkIsNegative`.
+ * This is the inverse of `check_is_negative`.
  *
  * @param {number} num - The number to check.
  * @returns {boolean} True if the number is not negative, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotNegative(3); // 3 is not a negative number
+ * check_is_not_negative(3); // 3 is not a negative number
  *
  * @example
  * // Returns false
- * checkIsNotNegative(-5); // -5 is a negative number
+ * check_is_not_negative(-5); // -5 is a negative number
  */
-export const checkIsNotNegative = (num: number): boolean => {
-  return !checkIsNegative(num);
+export const check_is_not_negative = (num: number): boolean => {
+	return !check_is_negative(num);
 };

--- a/packages/number/src/checkNegative/main.ts
+++ b/packages/number/src/checkNegative/main.ts
@@ -13,7 +13,7 @@
  * check_is_negative(3); // 3 is not a negative number
  */
 export const check_is_negative = (num: number): boolean => {
-	return num < 0;
+  return num < 0;
 };
 
 /**
@@ -33,5 +33,5 @@ export const check_is_negative = (num: number): boolean => {
  * check_is_not_negative(-5); // -5 is a negative number
  */
 export const check_is_not_negative = (num: number): boolean => {
-	return !check_is_negative(num);
+  return !check_is_negative(num);
 };

--- a/packages/number/src/checkNegative/test.ts
+++ b/packages/number/src/checkNegative/test.ts
@@ -2,26 +2,26 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_negative, check_is_not_negative } from "./main.ts";
 
 Deno.test("check_is_negative", async (t) => {
-	await t.step("should return true for negative numbers", () => {
-		assertEquals(check_is_negative(-1), true);
-		assertEquals(check_is_negative(-3.14), true);
-	});
+  await t.step("should return true for negative numbers", () => {
+    assertEquals(check_is_negative(-1), true);
+    assertEquals(check_is_negative(-3.14), true);
+  });
 
-	await t.step("should return false for non-negative numbers", () => {
-		assertEquals(check_is_negative(0), false);
-		assertEquals(check_is_negative(1), false);
-	});
+  await t.step("should return false for non-negative numbers", () => {
+    assertEquals(check_is_negative(0), false);
+    assertEquals(check_is_negative(1), false);
+  });
 });
 
 Deno.test("check_is_not_negative", async (t) => {
-	await t.step("should return true for non-negative numbers", () => {
-		assertEquals(check_is_not_negative(0), true);
-		assertEquals(check_is_not_negative(1), true);
-		assertEquals(check_is_not_negative(3.14), true);
-	});
+  await t.step("should return true for non-negative numbers", () => {
+    assertEquals(check_is_not_negative(0), true);
+    assertEquals(check_is_not_negative(1), true);
+    assertEquals(check_is_not_negative(3.14), true);
+  });
 
-	await t.step("should return false for negative numbers", () => {
-		assertEquals(check_is_not_negative(-1), false);
-		assertEquals(check_is_not_negative(-3.14), false);
-	});
+  await t.step("should return false for negative numbers", () => {
+    assertEquals(check_is_not_negative(-1), false);
+    assertEquals(check_is_not_negative(-3.14), false);
+  });
 });

--- a/packages/number/src/checkNegative/test.ts
+++ b/packages/number/src/checkNegative/test.ts
@@ -1,27 +1,27 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsNegative, checkIsNotNegative } from "./main.ts";
+import { check_is_negative, check_is_not_negative } from "./main.ts";
 
-Deno.test("checkIsNegative", async (t) => {
-  await t.step("should return true for negative numbers", () => {
-    assertEquals(checkIsNegative(-1), true);
-    assertEquals(checkIsNegative(-3.14), true);
-  });
+Deno.test("check_is_negative", async (t) => {
+	await t.step("should return true for negative numbers", () => {
+		assertEquals(check_is_negative(-1), true);
+		assertEquals(check_is_negative(-3.14), true);
+	});
 
-  await t.step("should return false for non-negative numbers", () => {
-    assertEquals(checkIsNegative(0), false);
-    assertEquals(checkIsNegative(1), false);
-  });
+	await t.step("should return false for non-negative numbers", () => {
+		assertEquals(check_is_negative(0), false);
+		assertEquals(check_is_negative(1), false);
+	});
 });
 
-Deno.test("checkIsNotNegative", async (t) => {
-  await t.step("should return true for non-negative numbers", () => {
-    assertEquals(checkIsNotNegative(0), true);
-    assertEquals(checkIsNotNegative(1), true);
-    assertEquals(checkIsNotNegative(3.14), true);
-  });
+Deno.test("check_is_not_negative", async (t) => {
+	await t.step("should return true for non-negative numbers", () => {
+		assertEquals(check_is_not_negative(0), true);
+		assertEquals(check_is_not_negative(1), true);
+		assertEquals(check_is_not_negative(3.14), true);
+	});
 
-  await t.step("should return false for negative numbers", () => {
-    assertEquals(checkIsNotNegative(-1), false);
-    assertEquals(checkIsNotNegative(-3.14), false);
-  });
+	await t.step("should return false for negative numbers", () => {
+		assertEquals(check_is_not_negative(-1), false);
+		assertEquals(check_is_not_negative(-3.14), false);
+	});
 });

--- a/packages/number/src/checkNumber/main.ts
+++ b/packages/number/src/checkNumber/main.ts
@@ -6,14 +6,14 @@
  *
  * @example
  * // Returns true
- * checkIsNumber(42); // The value is a number
+ * check_is_number(42); // The value is a number
  *
  * @example
  * // Returns false
- * checkIsNumber("42"); // The value is a string, not a number
+ * check_is_number("42"); // The value is a string, not a number
  */
-export const checkIsNumber = (value: unknown): value is number => {
-  return typeof value === "number";
+export const check_is_number = (value: unknown): value is number => {
+	return typeof value === "number";
 };
 
 /**
@@ -26,12 +26,14 @@ export const checkIsNumber = (value: unknown): value is number => {
  *
  * @example
  * // Returns true
- * checkIsNotNumber("42"); // The value is a string, not a number
+ * check_is_not_number("42"); // The value is a string, not a number
  *
  * @example
  * // Returns false
- * checkIsNotNumber(42); // The value is a number
+ * check_is_not_number(42); // The value is a number
  */
-export const checkIsNotNumber = <T>(value: T): value is Exclude<T, number> => {
-  return !checkIsNumber(value);
+export const check_is_not_number = <T>(
+	value: T
+): value is Exclude<T, number> => {
+	return !check_is_number(value);
 };

--- a/packages/number/src/checkNumber/main.ts
+++ b/packages/number/src/checkNumber/main.ts
@@ -13,7 +13,7 @@
  * check_is_number("42"); // The value is a string, not a number
  */
 export const check_is_number = (value: unknown): value is number => {
-	return typeof value === "number";
+  return typeof value === "number";
 };
 
 /**
@@ -33,7 +33,7 @@ export const check_is_number = (value: unknown): value is number => {
  * check_is_not_number(42); // The value is a number
  */
 export const check_is_not_number = <T>(
-	value: T
+  value: T,
 ): value is Exclude<T, number> => {
-	return !check_is_number(value);
+  return !check_is_number(value);
 };

--- a/packages/number/src/checkNumber/test.ts
+++ b/packages/number/src/checkNumber/test.ts
@@ -2,35 +2,35 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_not_number, check_is_number } from "./main.ts";
 
 Deno.test("check_is_number", async (t) => {
-	await t.step("should return true for numbers", () => {
-		assertEquals(check_is_number(1), true);
-		assertEquals(check_is_number(0), true);
-		assertEquals(check_is_number(-1), true);
-		assertEquals(check_is_number(3.14), true);
-	});
+  await t.step("should return true for numbers", () => {
+    assertEquals(check_is_number(1), true);
+    assertEquals(check_is_number(0), true);
+    assertEquals(check_is_number(-1), true);
+    assertEquals(check_is_number(3.14), true);
+  });
 
-	await t.step("should return false for non-numbers", () => {
-		assertEquals(check_is_number("1"), false);
-		assertEquals(check_is_number(true), false);
-		assertEquals(check_is_number(null), false);
-		assertEquals(check_is_number(undefined), false);
-		assertEquals(check_is_number({}), false);
-	});
+  await t.step("should return false for non-numbers", () => {
+    assertEquals(check_is_number("1"), false);
+    assertEquals(check_is_number(true), false);
+    assertEquals(check_is_number(null), false);
+    assertEquals(check_is_number(undefined), false);
+    assertEquals(check_is_number({}), false);
+  });
 });
 
 Deno.test("check_is_not_number", async (t) => {
-	await t.step("should return true for non-numbers", () => {
-		assertEquals(check_is_not_number("1"), true);
-		assertEquals(check_is_not_number(true), true);
-		assertEquals(check_is_not_number(null), true);
-		assertEquals(check_is_not_number(undefined), true);
-		assertEquals(check_is_not_number({}), true);
-	});
+  await t.step("should return true for non-numbers", () => {
+    assertEquals(check_is_not_number("1"), true);
+    assertEquals(check_is_not_number(true), true);
+    assertEquals(check_is_not_number(null), true);
+    assertEquals(check_is_not_number(undefined), true);
+    assertEquals(check_is_not_number({}), true);
+  });
 
-	await t.step("should return false for numbers", () => {
-		assertEquals(check_is_not_number(1), false);
-		assertEquals(check_is_not_number(0), false);
-		assertEquals(check_is_not_number(-1), false);
-		assertEquals(check_is_not_number(3.14), false);
-	});
+  await t.step("should return false for numbers", () => {
+    assertEquals(check_is_not_number(1), false);
+    assertEquals(check_is_not_number(0), false);
+    assertEquals(check_is_not_number(-1), false);
+    assertEquals(check_is_not_number(3.14), false);
+  });
 });

--- a/packages/number/src/checkNumber/test.ts
+++ b/packages/number/src/checkNumber/test.ts
@@ -1,36 +1,36 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsNotNumber, checkIsNumber } from "./main.ts";
+import { check_is_not_number, check_is_number } from "./main.ts";
 
-Deno.test("checkIsNumber", async (t) => {
-  await t.step("should return true for numbers", () => {
-    assertEquals(checkIsNumber(1), true);
-    assertEquals(checkIsNumber(0), true);
-    assertEquals(checkIsNumber(-1), true);
-    assertEquals(checkIsNumber(3.14), true);
-  });
+Deno.test("check_is_number", async (t) => {
+	await t.step("should return true for numbers", () => {
+		assertEquals(check_is_number(1), true);
+		assertEquals(check_is_number(0), true);
+		assertEquals(check_is_number(-1), true);
+		assertEquals(check_is_number(3.14), true);
+	});
 
-  await t.step("should return false for non-numbers", () => {
-    assertEquals(checkIsNumber("1"), false);
-    assertEquals(checkIsNumber(true), false);
-    assertEquals(checkIsNumber(null), false);
-    assertEquals(checkIsNumber(undefined), false);
-    assertEquals(checkIsNumber({}), false);
-  });
+	await t.step("should return false for non-numbers", () => {
+		assertEquals(check_is_number("1"), false);
+		assertEquals(check_is_number(true), false);
+		assertEquals(check_is_number(null), false);
+		assertEquals(check_is_number(undefined), false);
+		assertEquals(check_is_number({}), false);
+	});
 });
 
-Deno.test("checkIsNotNumber", async (t) => {
-  await t.step("should return true for non-numbers", () => {
-    assertEquals(checkIsNotNumber("1"), true);
-    assertEquals(checkIsNotNumber(true), true);
-    assertEquals(checkIsNotNumber(null), true);
-    assertEquals(checkIsNotNumber(undefined), true);
-    assertEquals(checkIsNotNumber({}), true);
-  });
+Deno.test("check_is_not_number", async (t) => {
+	await t.step("should return true for non-numbers", () => {
+		assertEquals(check_is_not_number("1"), true);
+		assertEquals(check_is_not_number(true), true);
+		assertEquals(check_is_not_number(null), true);
+		assertEquals(check_is_not_number(undefined), true);
+		assertEquals(check_is_not_number({}), true);
+	});
 
-  await t.step("should return false for numbers", () => {
-    assertEquals(checkIsNotNumber(1), false);
-    assertEquals(checkIsNotNumber(0), false);
-    assertEquals(checkIsNotNumber(-1), false);
-    assertEquals(checkIsNotNumber(3.14), false);
-  });
+	await t.step("should return false for numbers", () => {
+		assertEquals(check_is_not_number(1), false);
+		assertEquals(check_is_not_number(0), false);
+		assertEquals(check_is_not_number(-1), false);
+		assertEquals(check_is_not_number(3.14), false);
+	});
 });

--- a/packages/number/src/checkOdd/main.ts
+++ b/packages/number/src/checkOdd/main.ts
@@ -8,48 +8,48 @@
  *
  * @example
  * // Returns true
- * checkIsOdd(3); // 3 is an odd number
+ * check_is_odd(3); // 3 is an odd number
  *
  * @example
  * // Returns true
- * checkIsOdd(-5); // -5 is an odd number
+ * check_is_odd(-5); // -5 is an odd number
  *
  * @example
  * // Returns false
- * checkIsOdd(4); // 4 is an even number
+ * check_is_odd(4); // 4 is an even number
  *
  * @example
  * // Returns false
- * checkIsOdd(0); // 0 is considered even
+ * check_is_odd(0); // 0 is considered even
  */
-export const checkIsOdd = (num: number): boolean => {
-  return Math.abs(num) % 2 === 1;
+export const check_is_odd = (num: number): boolean => {
+	return Math.abs(num) % 2 === 1;
 };
 
 /**
  * Checks if a given number is not odd.
  *
- * This is the inverse of `checkIsOdd`.
+ * This is the inverse of `check_is_odd`.
  *
  * @param {number} num - The number to check.
  * @returns {boolean} True if the number is not odd, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotOdd(4); // 4 is an even number
+ * check_is_not_odd(4); // 4 is an even number
  *
  * @example
  * // Returns true
- * checkIsNotOdd(0); // 0 is considered even
+ * check_is_not_odd(0); // 0 is considered even
  *
  * @example
  * // Returns false
- * checkIsNotOdd(3); // 3 is an odd number
+ * check_is_not_odd(3); // 3 is an odd number
  *
  * @example
  * // Returns false
- * checkIsNotOdd(-5); // -5 is an odd number
+ * check_is_not_odd(-5); // -5 is an odd number
  */
-export const checkIsNotOdd = (num: number): boolean => {
-  return !checkIsOdd(num);
+export const check_is_not_odd = (num: number): boolean => {
+	return !check_is_odd(num);
 };

--- a/packages/number/src/checkOdd/main.ts
+++ b/packages/number/src/checkOdd/main.ts
@@ -23,7 +23,7 @@
  * check_is_odd(0); // 0 is considered even
  */
 export const check_is_odd = (num: number): boolean => {
-	return Math.abs(num) % 2 === 1;
+  return Math.abs(num) % 2 === 1;
 };
 
 /**
@@ -51,5 +51,5 @@ export const check_is_odd = (num: number): boolean => {
  * check_is_not_odd(-5); // -5 is an odd number
  */
 export const check_is_not_odd = (num: number): boolean => {
-	return !check_is_odd(num);
+  return !check_is_odd(num);
 };

--- a/packages/number/src/checkOdd/test.ts
+++ b/packages/number/src/checkOdd/test.ts
@@ -2,45 +2,45 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_not_odd, check_is_odd } from "./main.ts";
 
 Deno.test("check_is_odd", async (t) => {
-	await t.step("should return true for odd numbers", () => {
-		assertEquals(check_is_odd(1), true);
-		assertEquals(check_is_odd(3), true);
-		assertEquals(check_is_odd(-1), true);
-		assertEquals(check_is_odd(101), true);
-	});
+  await t.step("should return true for odd numbers", () => {
+    assertEquals(check_is_odd(1), true);
+    assertEquals(check_is_odd(3), true);
+    assertEquals(check_is_odd(-1), true);
+    assertEquals(check_is_odd(101), true);
+  });
 
-	await t.step("should return false for even numbers", () => {
-		assertEquals(check_is_odd(2), false);
-		assertEquals(check_is_odd(4), false);
-		assertEquals(check_is_odd(-2), false);
-		assertEquals(check_is_odd(100), false);
-	});
+  await t.step("should return false for even numbers", () => {
+    assertEquals(check_is_odd(2), false);
+    assertEquals(check_is_odd(4), false);
+    assertEquals(check_is_odd(-2), false);
+    assertEquals(check_is_odd(100), false);
+  });
 
-	await t.step("should return false for non-integer numbers", () => {
-		assertEquals(check_is_odd(1.5), false);
-		assertEquals(check_is_odd(2.5), false);
-		assertEquals(check_is_odd(-3.5), false);
-	});
+  await t.step("should return false for non-integer numbers", () => {
+    assertEquals(check_is_odd(1.5), false);
+    assertEquals(check_is_odd(2.5), false);
+    assertEquals(check_is_odd(-3.5), false);
+  });
 });
 
 Deno.test("check_is_not_odd", async (t) => {
-	await t.step("should return true for even numbers", () => {
-		assertEquals(check_is_not_odd(2), true);
-		assertEquals(check_is_not_odd(4), true);
-		assertEquals(check_is_not_odd(-2), true);
-		assertEquals(check_is_not_odd(100), true);
-	});
+  await t.step("should return true for even numbers", () => {
+    assertEquals(check_is_not_odd(2), true);
+    assertEquals(check_is_not_odd(4), true);
+    assertEquals(check_is_not_odd(-2), true);
+    assertEquals(check_is_not_odd(100), true);
+  });
 
-	await t.step("should return false for odd numbers", () => {
-		assertEquals(check_is_not_odd(1), false);
-		assertEquals(check_is_not_odd(3), false);
-		assertEquals(check_is_not_odd(-1), false);
-		assertEquals(check_is_not_odd(101), false);
-	});
+  await t.step("should return false for odd numbers", () => {
+    assertEquals(check_is_not_odd(1), false);
+    assertEquals(check_is_not_odd(3), false);
+    assertEquals(check_is_not_odd(-1), false);
+    assertEquals(check_is_not_odd(101), false);
+  });
 
-	await t.step("should return true for non-integer numbers", () => {
-		assertEquals(check_is_not_odd(1.5), true);
-		assertEquals(check_is_not_odd(2.5), true);
-		assertEquals(check_is_not_odd(-3.5), true);
-	});
+  await t.step("should return true for non-integer numbers", () => {
+    assertEquals(check_is_not_odd(1.5), true);
+    assertEquals(check_is_not_odd(2.5), true);
+    assertEquals(check_is_not_odd(-3.5), true);
+  });
 });

--- a/packages/number/src/checkOdd/test.ts
+++ b/packages/number/src/checkOdd/test.ts
@@ -1,46 +1,46 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsNotOdd, checkIsOdd } from "./main.ts";
+import { check_is_not_odd, check_is_odd } from "./main.ts";
 
-Deno.test("checkIsOdd", async (t) => {
-  await t.step("should return true for odd numbers", () => {
-    assertEquals(checkIsOdd(1), true);
-    assertEquals(checkIsOdd(3), true);
-    assertEquals(checkIsOdd(-1), true);
-    assertEquals(checkIsOdd(101), true);
-  });
+Deno.test("check_is_odd", async (t) => {
+	await t.step("should return true for odd numbers", () => {
+		assertEquals(check_is_odd(1), true);
+		assertEquals(check_is_odd(3), true);
+		assertEquals(check_is_odd(-1), true);
+		assertEquals(check_is_odd(101), true);
+	});
 
-  await t.step("should return false for even numbers", () => {
-    assertEquals(checkIsOdd(2), false);
-    assertEquals(checkIsOdd(4), false);
-    assertEquals(checkIsOdd(-2), false);
-    assertEquals(checkIsOdd(100), false);
-  });
+	await t.step("should return false for even numbers", () => {
+		assertEquals(check_is_odd(2), false);
+		assertEquals(check_is_odd(4), false);
+		assertEquals(check_is_odd(-2), false);
+		assertEquals(check_is_odd(100), false);
+	});
 
-  await t.step("should return false for non-integer numbers", () => {
-    assertEquals(checkIsOdd(1.5), false);
-    assertEquals(checkIsOdd(2.5), false);
-    assertEquals(checkIsOdd(-3.5), false);
-  });
+	await t.step("should return false for non-integer numbers", () => {
+		assertEquals(check_is_odd(1.5), false);
+		assertEquals(check_is_odd(2.5), false);
+		assertEquals(check_is_odd(-3.5), false);
+	});
 });
 
-Deno.test("checkIsNotOdd", async (t) => {
-  await t.step("should return true for even numbers", () => {
-    assertEquals(checkIsNotOdd(2), true);
-    assertEquals(checkIsNotOdd(4), true);
-    assertEquals(checkIsNotOdd(-2), true);
-    assertEquals(checkIsNotOdd(100), true);
-  });
+Deno.test("check_is_not_odd", async (t) => {
+	await t.step("should return true for even numbers", () => {
+		assertEquals(check_is_not_odd(2), true);
+		assertEquals(check_is_not_odd(4), true);
+		assertEquals(check_is_not_odd(-2), true);
+		assertEquals(check_is_not_odd(100), true);
+	});
 
-  await t.step("should return false for odd numbers", () => {
-    assertEquals(checkIsNotOdd(1), false);
-    assertEquals(checkIsNotOdd(3), false);
-    assertEquals(checkIsNotOdd(-1), false);
-    assertEquals(checkIsNotOdd(101), false);
-  });
+	await t.step("should return false for odd numbers", () => {
+		assertEquals(check_is_not_odd(1), false);
+		assertEquals(check_is_not_odd(3), false);
+		assertEquals(check_is_not_odd(-1), false);
+		assertEquals(check_is_not_odd(101), false);
+	});
 
-  await t.step("should return true for non-integer numbers", () => {
-    assertEquals(checkIsNotOdd(1.5), true);
-    assertEquals(checkIsNotOdd(2.5), true);
-    assertEquals(checkIsNotOdd(-3.5), true);
-  });
+	await t.step("should return true for non-integer numbers", () => {
+		assertEquals(check_is_not_odd(1.5), true);
+		assertEquals(check_is_not_odd(2.5), true);
+		assertEquals(check_is_not_odd(-3.5), true);
+	});
 });

--- a/packages/number/src/checkPerfectNumber/main.ts
+++ b/packages/number/src/checkPerfectNumber/main.ts
@@ -10,38 +10,38 @@
  *
  * @example
  * // Returns true
- * checkIsPerfectNumber(28); // 28 is a perfect number (1 + 2 + 4 + 7 + 14 = 28)
+ * check_is_perfect_number(28); // 28 is a perfect number (1 + 2 + 4 + 7 + 14 = 28)
  *
  * @example
  * // Returns false
- * checkIsPerfectNumber(12); // 12 is not a perfect number (1 + 2 + 3 + 4 + 6 = 16)
+ * check_is_perfect_number(12); // 12 is not a perfect number (1 + 2 + 3 + 4 + 6 = 16)
  */
-export const checkIsPerfectNumber = (num: number): boolean => {
-  let sum = 1;
-  for (let i = 2; i <= Math.sqrt(num); i++) {
-    if (num % i === 0) {
-      sum += i + (i === num / i ? 0 : num / i);
-    }
-  }
-  return sum === num && num !== 1;
+export const check_is_perfect_number = (num: number): boolean => {
+	let sum = 1;
+	for (let i = 2; i <= Math.sqrt(num); i++) {
+		if (num % i === 0) {
+			sum += i + (i === num / i ? 0 : num / i);
+		}
+	}
+	return sum === num && num !== 1;
 };
 
 /**
  * Checks if a given number is not a perfect number.
  *
- * This is the inverse of `checkIsPerfectNumber`.
+ * This is the inverse of `check_is_perfect_number`.
  *
  * @param {number} num - The number to check.
  * @returns {boolean} True if the number is not a perfect number, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotPerfectNumber(12); // 12 is not a perfect number (1 + 2 + 3 + 4 + 6 = 16)
+ * check_is_not_perfect_number(12); // 12 is not a perfect number (1 + 2 + 3 + 4 + 6 = 16)
  *
  * @example
  * // Returns false
- * checkIsNotPerfectNumber(28); // 28 is a perfect number (1 + 2 + 4 + 7 + 14 = 28)
+ * check_is_not_perfect_number(28); // 28 is a perfect number (1 + 2 + 4 + 7 + 14 = 28)
  */
-export const checkIsNotPerfectNumber = (num: number): boolean => {
-  return !checkIsPerfectNumber(num);
+export const check_is_not_perfect_number = (num: number): boolean => {
+	return !check_is_perfect_number(num);
 };

--- a/packages/number/src/checkPerfectNumber/main.ts
+++ b/packages/number/src/checkPerfectNumber/main.ts
@@ -17,13 +17,13 @@
  * check_is_perfect_number(12); // 12 is not a perfect number (1 + 2 + 3 + 4 + 6 = 16)
  */
 export const check_is_perfect_number = (num: number): boolean => {
-	let sum = 1;
-	for (let i = 2; i <= Math.sqrt(num); i++) {
-		if (num % i === 0) {
-			sum += i + (i === num / i ? 0 : num / i);
-		}
-	}
-	return sum === num && num !== 1;
+  let sum = 1;
+  for (let i = 2; i <= Math.sqrt(num); i++) {
+    if (num % i === 0) {
+      sum += i + (i === num / i ? 0 : num / i);
+    }
+  }
+  return sum === num && num !== 1;
 };
 
 /**
@@ -43,5 +43,5 @@ export const check_is_perfect_number = (num: number): boolean => {
  * check_is_not_perfect_number(28); // 28 is a perfect number (1 + 2 + 4 + 7 + 14 = 28)
  */
 export const check_is_not_perfect_number = (num: number): boolean => {
-	return !check_is_perfect_number(num);
+  return !check_is_perfect_number(num);
 };

--- a/packages/number/src/checkPerfectNumber/test.ts
+++ b/packages/number/src/checkPerfectNumber/test.ts
@@ -1,40 +1,43 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsNotPerfectNumber, checkIsPerfectNumber } from "./main.ts";
+import {
+	check_is_not_perfect_number,
+	check_is_perfect_number,
+} from "./main.ts";
 
-Deno.test("checkIsPerfectNumber", async (t) => {
-  await t.step("should return true for perfect numbers", () => {
-    assertEquals(checkIsPerfectNumber(6), true); // 6 = 1 + 2 + 3
-    assertEquals(checkIsPerfectNumber(28), true); // 28 = 1 + 2 + 4 + 7 + 14
-    assertEquals(checkIsPerfectNumber(496), true); // 496 = 1 + 2 + 4 + 8 + 16 + 31 + 62 + 124 + 248
-    assertEquals(checkIsPerfectNumber(8128), true); // 8128 = 1 + 2 + 4 + 8 + ... + 4064
-  });
+Deno.test("check_is_perfect_number", async (t) => {
+	await t.step("should return true for perfect numbers", () => {
+		assertEquals(check_is_perfect_number(6), true); // 6 = 1 + 2 + 3
+		assertEquals(check_is_perfect_number(28), true); // 28 = 1 + 2 + 4 + 7 + 14
+		assertEquals(check_is_perfect_number(496), true); // 496 = 1 + 2 + 4 + 8 + 16 + 31 + 62 + 124 + 248
+		assertEquals(check_is_perfect_number(8128), true); // 8128 = 1 + 2 + 4 + 8 + ... + 4064
+	});
 
-  await t.step("should return false for non-perfect numbers", () => {
-    assertEquals(checkIsPerfectNumber(1), false); // 1 is not considered a perfect number
-    assertEquals(checkIsPerfectNumber(5), false);
-    assertEquals(checkIsPerfectNumber(10), false);
-    assertEquals(checkIsPerfectNumber(12), false);
-    assertEquals(checkIsPerfectNumber(100), false);
-    assertEquals(checkIsPerfectNumber(500), false);
-    assertEquals(checkIsPerfectNumber(1000), false);
-  });
+	await t.step("should return false for non-perfect numbers", () => {
+		assertEquals(check_is_perfect_number(1), false); // 1 is not considered a perfect number
+		assertEquals(check_is_perfect_number(5), false);
+		assertEquals(check_is_perfect_number(10), false);
+		assertEquals(check_is_perfect_number(12), false);
+		assertEquals(check_is_perfect_number(100), false);
+		assertEquals(check_is_perfect_number(500), false);
+		assertEquals(check_is_perfect_number(1000), false);
+	});
 });
 
-Deno.test("checkIsNotPerfectNumber", async (t) => {
-  await t.step("should return true for non-perfect numbers", () => {
-    assertEquals(checkIsNotPerfectNumber(1), true);
-    assertEquals(checkIsNotPerfectNumber(5), true);
-    assertEquals(checkIsNotPerfectNumber(10), true);
-    assertEquals(checkIsNotPerfectNumber(12), true);
-    assertEquals(checkIsNotPerfectNumber(100), true);
-    assertEquals(checkIsNotPerfectNumber(500), true);
-    assertEquals(checkIsNotPerfectNumber(1000), true);
-  });
+Deno.test("check_is_not_perfect_number", async (t) => {
+	await t.step("should return true for non-perfect numbers", () => {
+		assertEquals(check_is_not_perfect_number(1), true);
+		assertEquals(check_is_not_perfect_number(5), true);
+		assertEquals(check_is_not_perfect_number(10), true);
+		assertEquals(check_is_not_perfect_number(12), true);
+		assertEquals(check_is_not_perfect_number(100), true);
+		assertEquals(check_is_not_perfect_number(500), true);
+		assertEquals(check_is_not_perfect_number(1000), true);
+	});
 
-  await t.step("should return false for perfect numbers", () => {
-    assertEquals(checkIsNotPerfectNumber(6), false);
-    assertEquals(checkIsNotPerfectNumber(28), false);
-    assertEquals(checkIsNotPerfectNumber(496), false);
-    assertEquals(checkIsNotPerfectNumber(8128), false);
-  });
+	await t.step("should return false for perfect numbers", () => {
+		assertEquals(check_is_not_perfect_number(6), false);
+		assertEquals(check_is_not_perfect_number(28), false);
+		assertEquals(check_is_not_perfect_number(496), false);
+		assertEquals(check_is_not_perfect_number(8128), false);
+	});
 });

--- a/packages/number/src/checkPerfectNumber/test.ts
+++ b/packages/number/src/checkPerfectNumber/test.ts
@@ -1,43 +1,43 @@
 import { assertEquals } from "../../deps.ts";
 import {
-	check_is_not_perfect_number,
-	check_is_perfect_number,
+  check_is_not_perfect_number,
+  check_is_perfect_number,
 } from "./main.ts";
 
 Deno.test("check_is_perfect_number", async (t) => {
-	await t.step("should return true for perfect numbers", () => {
-		assertEquals(check_is_perfect_number(6), true); // 6 = 1 + 2 + 3
-		assertEquals(check_is_perfect_number(28), true); // 28 = 1 + 2 + 4 + 7 + 14
-		assertEquals(check_is_perfect_number(496), true); // 496 = 1 + 2 + 4 + 8 + 16 + 31 + 62 + 124 + 248
-		assertEquals(check_is_perfect_number(8128), true); // 8128 = 1 + 2 + 4 + 8 + ... + 4064
-	});
+  await t.step("should return true for perfect numbers", () => {
+    assertEquals(check_is_perfect_number(6), true); // 6 = 1 + 2 + 3
+    assertEquals(check_is_perfect_number(28), true); // 28 = 1 + 2 + 4 + 7 + 14
+    assertEquals(check_is_perfect_number(496), true); // 496 = 1 + 2 + 4 + 8 + 16 + 31 + 62 + 124 + 248
+    assertEquals(check_is_perfect_number(8128), true); // 8128 = 1 + 2 + 4 + 8 + ... + 4064
+  });
 
-	await t.step("should return false for non-perfect numbers", () => {
-		assertEquals(check_is_perfect_number(1), false); // 1 is not considered a perfect number
-		assertEquals(check_is_perfect_number(5), false);
-		assertEquals(check_is_perfect_number(10), false);
-		assertEquals(check_is_perfect_number(12), false);
-		assertEquals(check_is_perfect_number(100), false);
-		assertEquals(check_is_perfect_number(500), false);
-		assertEquals(check_is_perfect_number(1000), false);
-	});
+  await t.step("should return false for non-perfect numbers", () => {
+    assertEquals(check_is_perfect_number(1), false); // 1 is not considered a perfect number
+    assertEquals(check_is_perfect_number(5), false);
+    assertEquals(check_is_perfect_number(10), false);
+    assertEquals(check_is_perfect_number(12), false);
+    assertEquals(check_is_perfect_number(100), false);
+    assertEquals(check_is_perfect_number(500), false);
+    assertEquals(check_is_perfect_number(1000), false);
+  });
 });
 
 Deno.test("check_is_not_perfect_number", async (t) => {
-	await t.step("should return true for non-perfect numbers", () => {
-		assertEquals(check_is_not_perfect_number(1), true);
-		assertEquals(check_is_not_perfect_number(5), true);
-		assertEquals(check_is_not_perfect_number(10), true);
-		assertEquals(check_is_not_perfect_number(12), true);
-		assertEquals(check_is_not_perfect_number(100), true);
-		assertEquals(check_is_not_perfect_number(500), true);
-		assertEquals(check_is_not_perfect_number(1000), true);
-	});
+  await t.step("should return true for non-perfect numbers", () => {
+    assertEquals(check_is_not_perfect_number(1), true);
+    assertEquals(check_is_not_perfect_number(5), true);
+    assertEquals(check_is_not_perfect_number(10), true);
+    assertEquals(check_is_not_perfect_number(12), true);
+    assertEquals(check_is_not_perfect_number(100), true);
+    assertEquals(check_is_not_perfect_number(500), true);
+    assertEquals(check_is_not_perfect_number(1000), true);
+  });
 
-	await t.step("should return false for perfect numbers", () => {
-		assertEquals(check_is_not_perfect_number(6), false);
-		assertEquals(check_is_not_perfect_number(28), false);
-		assertEquals(check_is_not_perfect_number(496), false);
-		assertEquals(check_is_not_perfect_number(8128), false);
-	});
+  await t.step("should return false for perfect numbers", () => {
+    assertEquals(check_is_not_perfect_number(6), false);
+    assertEquals(check_is_not_perfect_number(28), false);
+    assertEquals(check_is_not_perfect_number(496), false);
+    assertEquals(check_is_not_perfect_number(8128), false);
+  });
 });

--- a/packages/number/src/checkPerfectSquare/main.ts
+++ b/packages/number/src/checkPerfectSquare/main.ts
@@ -8,32 +8,32 @@
  *
  * @example
  * // Returns true
- * checkIsPerfectSquare(16); // 16 is a perfect square (4 * 4 = 16)
+ * check_is_perfect_square(16); // 16 is a perfect square (4 * 4 = 16)
  *
  * @example
  * // Returns false
- * checkIsPerfectSquare(15); // 15 is not a perfect square
+ * check_is_perfect_square(15); // 15 is not a perfect square
  */
-export const checkIsPerfectSquare = (num: number): boolean => {
-  return Number.isInteger(Math.sqrt(num));
+export const check_is_perfect_square = (num: number): boolean => {
+	return Number.isInteger(Math.sqrt(num));
 };
 
 /**
  * Checks if a given number is not a perfect square.
  *
- * This is the inverse of `checkIsPerfectSquare`.
+ * This is the inverse of `check_is_perfect_square`.
  *
  * @param {number} num - The number to check.
  * @returns {boolean} True if the number is not a perfect square, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotPerfectSquare(15); // 15 is not a perfect square
+ * check_is_not_perfect_square(15); // 15 is not a perfect square
  *
  * @example
  * // Returns false
- * checkIsNotPerfectSquare(16); // 16 is a perfect square (4 * 4 = 16)
+ * check_is_not_perfect_square(16); // 16 is a perfect square (4 * 4 = 16)
  */
-export const checkIsNotPerfectSquare = (num: number): boolean => {
-  return !checkIsPerfectSquare(num);
+export const check_is_not_perfect_square = (num: number): boolean => {
+	return !check_is_perfect_square(num);
 };

--- a/packages/number/src/checkPerfectSquare/main.ts
+++ b/packages/number/src/checkPerfectSquare/main.ts
@@ -15,7 +15,7 @@
  * check_is_perfect_square(15); // 15 is not a perfect square
  */
 export const check_is_perfect_square = (num: number): boolean => {
-	return Number.isInteger(Math.sqrt(num));
+  return Number.isInteger(Math.sqrt(num));
 };
 
 /**
@@ -35,5 +35,5 @@ export const check_is_perfect_square = (num: number): boolean => {
  * check_is_not_perfect_square(16); // 16 is a perfect square (4 * 4 = 16)
  */
 export const check_is_not_perfect_square = (num: number): boolean => {
-	return !check_is_perfect_square(num);
+  return !check_is_perfect_square(num);
 };

--- a/packages/number/src/checkPerfectSquare/test.ts
+++ b/packages/number/src/checkPerfectSquare/test.ts
@@ -1,49 +1,49 @@
 import { assertEquals } from "../../deps.ts";
 import {
-	check_is_not_perfect_square,
-	check_is_perfect_square,
+  check_is_not_perfect_square,
+  check_is_perfect_square,
 } from "./main.ts";
 
 Deno.test("check_is_perfect_square", async (t) => {
-	await t.step("should return true for perfect squares", () => {
-		assertEquals(check_is_perfect_square(1), true);
-		assertEquals(check_is_perfect_square(4), true);
-		assertEquals(check_is_perfect_square(9), true);
-		assertEquals(check_is_perfect_square(16), true);
-		assertEquals(check_is_perfect_square(25), true);
-		assertEquals(check_is_perfect_square(36), true);
-		assertEquals(check_is_perfect_square(49), true);
-	});
+  await t.step("should return true for perfect squares", () => {
+    assertEquals(check_is_perfect_square(1), true);
+    assertEquals(check_is_perfect_square(4), true);
+    assertEquals(check_is_perfect_square(9), true);
+    assertEquals(check_is_perfect_square(16), true);
+    assertEquals(check_is_perfect_square(25), true);
+    assertEquals(check_is_perfect_square(36), true);
+    assertEquals(check_is_perfect_square(49), true);
+  });
 
-	await t.step("should return false for non-perfect squares", () => {
-		assertEquals(check_is_perfect_square(2), false);
-		assertEquals(check_is_perfect_square(3), false);
-		assertEquals(check_is_perfect_square(5), false);
-		assertEquals(check_is_perfect_square(10), false);
-		assertEquals(check_is_perfect_square(15), false);
-		assertEquals(check_is_perfect_square(50), false);
-		assertEquals(check_is_perfect_square(99), false);
-	});
+  await t.step("should return false for non-perfect squares", () => {
+    assertEquals(check_is_perfect_square(2), false);
+    assertEquals(check_is_perfect_square(3), false);
+    assertEquals(check_is_perfect_square(5), false);
+    assertEquals(check_is_perfect_square(10), false);
+    assertEquals(check_is_perfect_square(15), false);
+    assertEquals(check_is_perfect_square(50), false);
+    assertEquals(check_is_perfect_square(99), false);
+  });
 });
 
 Deno.test("check_is_not_perfect_square", async (t) => {
-	await t.step("should return true for non-perfect squares", () => {
-		assertEquals(check_is_not_perfect_square(2), true);
-		assertEquals(check_is_not_perfect_square(3), true);
-		assertEquals(check_is_not_perfect_square(5), true);
-		assertEquals(check_is_not_perfect_square(10), true);
-		assertEquals(check_is_not_perfect_square(15), true);
-		assertEquals(check_is_not_perfect_square(50), true);
-		assertEquals(check_is_not_perfect_square(99), true);
-	});
+  await t.step("should return true for non-perfect squares", () => {
+    assertEquals(check_is_not_perfect_square(2), true);
+    assertEquals(check_is_not_perfect_square(3), true);
+    assertEquals(check_is_not_perfect_square(5), true);
+    assertEquals(check_is_not_perfect_square(10), true);
+    assertEquals(check_is_not_perfect_square(15), true);
+    assertEquals(check_is_not_perfect_square(50), true);
+    assertEquals(check_is_not_perfect_square(99), true);
+  });
 
-	await t.step("should return false for perfect squares", () => {
-		assertEquals(check_is_not_perfect_square(1), false);
-		assertEquals(check_is_not_perfect_square(4), false);
-		assertEquals(check_is_not_perfect_square(9), false);
-		assertEquals(check_is_not_perfect_square(16), false);
-		assertEquals(check_is_not_perfect_square(25), false);
-		assertEquals(check_is_not_perfect_square(36), false);
-		assertEquals(check_is_not_perfect_square(49), false);
-	});
+  await t.step("should return false for perfect squares", () => {
+    assertEquals(check_is_not_perfect_square(1), false);
+    assertEquals(check_is_not_perfect_square(4), false);
+    assertEquals(check_is_not_perfect_square(9), false);
+    assertEquals(check_is_not_perfect_square(16), false);
+    assertEquals(check_is_not_perfect_square(25), false);
+    assertEquals(check_is_not_perfect_square(36), false);
+    assertEquals(check_is_not_perfect_square(49), false);
+  });
 });

--- a/packages/number/src/checkPerfectSquare/test.ts
+++ b/packages/number/src/checkPerfectSquare/test.ts
@@ -1,46 +1,49 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsNotPerfectSquare, checkIsPerfectSquare } from "./main.ts";
+import {
+	check_is_not_perfect_square,
+	check_is_perfect_square,
+} from "./main.ts";
 
-Deno.test("checkIsPerfectSquare", async (t) => {
-  await t.step("should return true for perfect squares", () => {
-    assertEquals(checkIsPerfectSquare(1), true);
-    assertEquals(checkIsPerfectSquare(4), true);
-    assertEquals(checkIsPerfectSquare(9), true);
-    assertEquals(checkIsPerfectSquare(16), true);
-    assertEquals(checkIsPerfectSquare(25), true);
-    assertEquals(checkIsPerfectSquare(36), true);
-    assertEquals(checkIsPerfectSquare(49), true);
-  });
+Deno.test("check_is_perfect_square", async (t) => {
+	await t.step("should return true for perfect squares", () => {
+		assertEquals(check_is_perfect_square(1), true);
+		assertEquals(check_is_perfect_square(4), true);
+		assertEquals(check_is_perfect_square(9), true);
+		assertEquals(check_is_perfect_square(16), true);
+		assertEquals(check_is_perfect_square(25), true);
+		assertEquals(check_is_perfect_square(36), true);
+		assertEquals(check_is_perfect_square(49), true);
+	});
 
-  await t.step("should return false for non-perfect squares", () => {
-    assertEquals(checkIsPerfectSquare(2), false);
-    assertEquals(checkIsPerfectSquare(3), false);
-    assertEquals(checkIsPerfectSquare(5), false);
-    assertEquals(checkIsPerfectSquare(10), false);
-    assertEquals(checkIsPerfectSquare(15), false);
-    assertEquals(checkIsPerfectSquare(50), false);
-    assertEquals(checkIsPerfectSquare(99), false);
-  });
+	await t.step("should return false for non-perfect squares", () => {
+		assertEquals(check_is_perfect_square(2), false);
+		assertEquals(check_is_perfect_square(3), false);
+		assertEquals(check_is_perfect_square(5), false);
+		assertEquals(check_is_perfect_square(10), false);
+		assertEquals(check_is_perfect_square(15), false);
+		assertEquals(check_is_perfect_square(50), false);
+		assertEquals(check_is_perfect_square(99), false);
+	});
 });
 
-Deno.test("checkIsNotPerfectSquare", async (t) => {
-  await t.step("should return true for non-perfect squares", () => {
-    assertEquals(checkIsNotPerfectSquare(2), true);
-    assertEquals(checkIsNotPerfectSquare(3), true);
-    assertEquals(checkIsNotPerfectSquare(5), true);
-    assertEquals(checkIsNotPerfectSquare(10), true);
-    assertEquals(checkIsNotPerfectSquare(15), true);
-    assertEquals(checkIsNotPerfectSquare(50), true);
-    assertEquals(checkIsNotPerfectSquare(99), true);
-  });
+Deno.test("check_is_not_perfect_square", async (t) => {
+	await t.step("should return true for non-perfect squares", () => {
+		assertEquals(check_is_not_perfect_square(2), true);
+		assertEquals(check_is_not_perfect_square(3), true);
+		assertEquals(check_is_not_perfect_square(5), true);
+		assertEquals(check_is_not_perfect_square(10), true);
+		assertEquals(check_is_not_perfect_square(15), true);
+		assertEquals(check_is_not_perfect_square(50), true);
+		assertEquals(check_is_not_perfect_square(99), true);
+	});
 
-  await t.step("should return false for perfect squares", () => {
-    assertEquals(checkIsNotPerfectSquare(1), false);
-    assertEquals(checkIsNotPerfectSquare(4), false);
-    assertEquals(checkIsNotPerfectSquare(9), false);
-    assertEquals(checkIsNotPerfectSquare(16), false);
-    assertEquals(checkIsNotPerfectSquare(25), false);
-    assertEquals(checkIsNotPerfectSquare(36), false);
-    assertEquals(checkIsNotPerfectSquare(49), false);
-  });
+	await t.step("should return false for perfect squares", () => {
+		assertEquals(check_is_not_perfect_square(1), false);
+		assertEquals(check_is_not_perfect_square(4), false);
+		assertEquals(check_is_not_perfect_square(9), false);
+		assertEquals(check_is_not_perfect_square(16), false);
+		assertEquals(check_is_not_perfect_square(25), false);
+		assertEquals(check_is_not_perfect_square(36), false);
+		assertEquals(check_is_not_perfect_square(49), false);
+	});
 });

--- a/packages/number/src/checkPositive/main.ts
+++ b/packages/number/src/checkPositive/main.ts
@@ -15,7 +15,7 @@
  * check_is_positive(-3); // -3 is not a positive number
  */
 export const check_is_positive = (num: number): boolean => {
-	return num > 0;
+  return num > 0;
 };
 
 /**
@@ -35,5 +35,5 @@ export const check_is_positive = (num: number): boolean => {
  * check_is_not_positive(5); // 5 is a positive number
  */
 export const check_is_not_positive = (num: number): boolean => {
-	return !check_is_positive(num);
+  return !check_is_positive(num);
 };

--- a/packages/number/src/checkPositive/main.ts
+++ b/packages/number/src/checkPositive/main.ts
@@ -8,32 +8,32 @@
  *
  * @example
  * // Returns true
- * checkIsPositive(5); // 5 is a positive number
+ * check_is_positive(5); // 5 is a positive number
  *
  * @example
  * // Returns false
- * checkIsPositive(-3); // -3 is not a positive number
+ * check_is_positive(-3); // -3 is not a positive number
  */
-export const checkIsPositive = (num: number): boolean => {
-  return num > 0;
+export const check_is_positive = (num: number): boolean => {
+	return num > 0;
 };
 
 /**
  * Checks if a given number is not positive.
  *
- * This is the inverse of `checkIsPositive`.
+ * This is the inverse of `check_is_positive`.
  *
  * @param {number} num - The number to check.
  * @returns {boolean} True if the number is not positive, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotPositive(-3); // -3 is not a positive number
+ * check_is_not_positive(-3); // -3 is not a positive number
  *
  * @example
  * // Returns false
- * checkIsNotPositive(5); // 5 is a positive number
+ * check_is_not_positive(5); // 5 is a positive number
  */
-export const checkIsNotPositive = (num: number): boolean => {
-  return !checkIsPositive(num);
+export const check_is_not_positive = (num: number): boolean => {
+	return !check_is_positive(num);
 };

--- a/packages/number/src/checkPositive/test.ts
+++ b/packages/number/src/checkPositive/test.ts
@@ -1,26 +1,26 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsNotPositive, checkIsPositive } from "./main.ts";
+import { check_is_not_positive, check_is_positive } from "./main.ts";
 
-Deno.test("checkIsPositive", async (t) => {
-  await t.step("should return true for positive numbers", () => {
-    assertEquals(checkIsPositive(1), true);
-    assertEquals(checkIsPositive(3.14), true);
-  });
+Deno.test("check_is_positive", async (t) => {
+	await t.step("should return true for positive numbers", () => {
+		assertEquals(check_is_positive(1), true);
+		assertEquals(check_is_positive(3.14), true);
+	});
 
-  await t.step("should return false for non-positive numbers", () => {
-    assertEquals(checkIsPositive(0), false);
-    assertEquals(checkIsPositive(-1), false);
-  });
+	await t.step("should return false for non-positive numbers", () => {
+		assertEquals(check_is_positive(0), false);
+		assertEquals(check_is_positive(-1), false);
+	});
 });
 
-Deno.test("checkIsNotPositive", async (t) => {
-  await t.step("should return true for non-positive numbers", () => {
-    assertEquals(checkIsNotPositive(0), true);
-    assertEquals(checkIsNotPositive(-1), true);
-  });
+Deno.test("check_is_not_positive", async (t) => {
+	await t.step("should return true for non-positive numbers", () => {
+		assertEquals(check_is_not_positive(0), true);
+		assertEquals(check_is_not_positive(-1), true);
+	});
 
-  await t.step("should return false for positive numbers", () => {
-    assertEquals(checkIsNotPositive(1), false);
-    assertEquals(checkIsNotPositive(3.14), false);
-  });
+	await t.step("should return false for positive numbers", () => {
+		assertEquals(check_is_not_positive(1), false);
+		assertEquals(check_is_not_positive(3.14), false);
+	});
 });

--- a/packages/number/src/checkPositive/test.ts
+++ b/packages/number/src/checkPositive/test.ts
@@ -2,25 +2,25 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_not_positive, check_is_positive } from "./main.ts";
 
 Deno.test("check_is_positive", async (t) => {
-	await t.step("should return true for positive numbers", () => {
-		assertEquals(check_is_positive(1), true);
-		assertEquals(check_is_positive(3.14), true);
-	});
+  await t.step("should return true for positive numbers", () => {
+    assertEquals(check_is_positive(1), true);
+    assertEquals(check_is_positive(3.14), true);
+  });
 
-	await t.step("should return false for non-positive numbers", () => {
-		assertEquals(check_is_positive(0), false);
-		assertEquals(check_is_positive(-1), false);
-	});
+  await t.step("should return false for non-positive numbers", () => {
+    assertEquals(check_is_positive(0), false);
+    assertEquals(check_is_positive(-1), false);
+  });
 });
 
 Deno.test("check_is_not_positive", async (t) => {
-	await t.step("should return true for non-positive numbers", () => {
-		assertEquals(check_is_not_positive(0), true);
-		assertEquals(check_is_not_positive(-1), true);
-	});
+  await t.step("should return true for non-positive numbers", () => {
+    assertEquals(check_is_not_positive(0), true);
+    assertEquals(check_is_not_positive(-1), true);
+  });
 
-	await t.step("should return false for positive numbers", () => {
-		assertEquals(check_is_not_positive(1), false);
-		assertEquals(check_is_not_positive(3.14), false);
-	});
+  await t.step("should return false for positive numbers", () => {
+    assertEquals(check_is_not_positive(1), false);
+    assertEquals(check_is_not_positive(3.14), false);
+  });
 });

--- a/packages/number/src/checkPower/main.ts
+++ b/packages/number/src/checkPower/main.ts
@@ -12,21 +12,21 @@ import { Constants } from "../constants.ts";
  *
  * @example
  * // Returns true
- * checkIsPower(8, 2); // 8 is 2^3, so it's a power of 2
+ * check_is_power(8, 2); // 8 is 2^3, so it's a power of 2
  *
  * @example
  * // Returns false
- * checkIsPower(10, 2); // 10 is not a power of 2
+ * check_is_power(10, 2); // 10 is not a power of 2
  */
-export const checkIsPower = (num: number, base: number): boolean => {
-  const result = Math.log(num) / Math.log(base);
-  return Math.abs(result - Math.round(result)) < Constants.TOLERANCE;
+export const check_is_power = (num: number, base: number): boolean => {
+	const result = Math.log(num) / Math.log(base);
+	return Math.abs(result - Math.round(result)) < Constants.TOLERANCE;
 };
 
 /**
  * Checks if a given number is not a power of a specified base.
  *
- * This is the inverse of `checkIsPowerOf`.
+ * This is the inverse of `check_is_power`.
  *
  * @param {number} num - The number to check.
  * @param {number} base - The base to use.
@@ -34,12 +34,12 @@ export const checkIsPower = (num: number, base: number): boolean => {
  *
  * @example
  * // Returns true
- * checkIsNotPower(10, 2); // 10 is not a power of 2
+ * check_is_not_power(10, 2); // 10 is not a power of 2
  *
  * @example
  * // Returns false
- * checkIsNotPower(8, 2); // 8 is 2^3, so it's a power of 2
+ * check_is_not_power(8, 2); // 8 is 2^3, so it's a power of 2
  */
-export const checkIsNotPower = (num: number, base: number): boolean => {
-  return !checkIsPower(num, base);
+export const check_is_not_power = (num: number, base: number): boolean => {
+	return !check_is_power(num, base);
 };

--- a/packages/number/src/checkPower/main.ts
+++ b/packages/number/src/checkPower/main.ts
@@ -19,8 +19,8 @@ import { Constants } from "../constants.ts";
  * check_is_power(10, 2); // 10 is not a power of 2
  */
 export const check_is_power = (num: number, base: number): boolean => {
-	const result = Math.log(num) / Math.log(base);
-	return Math.abs(result - Math.round(result)) < Constants.TOLERANCE;
+  const result = Math.log(num) / Math.log(base);
+  return Math.abs(result - Math.round(result)) < Constants.TOLERANCE;
 };
 
 /**
@@ -41,5 +41,5 @@ export const check_is_power = (num: number, base: number): boolean => {
  * check_is_not_power(8, 2); // 8 is 2^3, so it's a power of 2
  */
 export const check_is_not_power = (num: number, base: number): boolean => {
-	return !check_is_power(num, base);
+  return !check_is_power(num, base);
 };

--- a/packages/number/src/checkPower/test.ts
+++ b/packages/number/src/checkPower/test.ts
@@ -1,56 +1,56 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsNotPower, checkIsPower } from "./main.ts";
+import { check_is_not_power, check_is_power } from "./main.ts";
 
-Deno.test("checkIsPowerOf", async (t) => {
-  await t.step(
-    "should return true for numbers that are powers of the base",
-    () => {
-      assertEquals(checkIsPower(1, 2), true); // 2^0 = 1
-      assertEquals(checkIsPower(2, 2), true); // 2^1 = 2
-      assertEquals(checkIsPower(4, 2), true); // 2^2 = 4
-      assertEquals(checkIsPower(8, 2), true); // 2^3 = 8
-      assertEquals(checkIsPower(9, 3), true); // 3^2 = 9
-      assertEquals(checkIsPower(27, 3), true); // 3^3 = 27
-      assertEquals(checkIsPower(16, 4), true); // 4^2 = 16
-    },
-  );
+Deno.test("check_is_power", async (t) => {
+	await t.step(
+		"should return true for numbers that are powers of the base",
+		() => {
+			assertEquals(check_is_power(1, 2), true); // 2^0 = 1
+			assertEquals(check_is_power(2, 2), true); // 2^1 = 2
+			assertEquals(check_is_power(4, 2), true); // 2^2 = 4
+			assertEquals(check_is_power(8, 2), true); // 2^3 = 8
+			assertEquals(check_is_power(9, 3), true); // 3^2 = 9
+			assertEquals(check_is_power(27, 3), true); // 3^3 = 27
+			assertEquals(check_is_power(16, 4), true); // 4^2 = 16
+		}
+	);
 
-  await t.step(
-    "should return false for numbers that are not powers of the base",
-    () => {
-      assertEquals(checkIsPower(3, 2), false);
-      assertEquals(checkIsPower(5, 2), false);
-      assertEquals(checkIsPower(10, 2), false);
-      assertEquals(checkIsPower(12, 3), false);
-      assertEquals(checkIsPower(14, 2), false);
-      assertEquals(checkIsPower(20, 3), false);
-    },
-  );
+	await t.step(
+		"should return false for numbers that are not powers of the base",
+		() => {
+			assertEquals(check_is_power(3, 2), false);
+			assertEquals(check_is_power(5, 2), false);
+			assertEquals(check_is_power(10, 2), false);
+			assertEquals(check_is_power(12, 3), false);
+			assertEquals(check_is_power(14, 2), false);
+			assertEquals(check_is_power(20, 3), false);
+		}
+	);
 });
 
-Deno.test("checkIsNotPowerOf", async (t) => {
-  await t.step(
-    "should return true for numbers that are not powers of the base",
-    () => {
-      assertEquals(checkIsNotPower(3, 2), true);
-      assertEquals(checkIsNotPower(5, 2), true);
-      assertEquals(checkIsNotPower(10, 2), true);
-      assertEquals(checkIsNotPower(12, 3), true);
-      assertEquals(checkIsNotPower(14, 2), true);
-      assertEquals(checkIsNotPower(20, 3), true);
-    },
-  );
+Deno.test("check_is_not_power", async (t) => {
+	await t.step(
+		"should return true for numbers that are not powers of the base",
+		() => {
+			assertEquals(check_is_not_power(3, 2), true);
+			assertEquals(check_is_not_power(5, 2), true);
+			assertEquals(check_is_not_power(10, 2), true);
+			assertEquals(check_is_not_power(12, 3), true);
+			assertEquals(check_is_not_power(14, 2), true);
+			assertEquals(check_is_not_power(20, 3), true);
+		}
+	);
 
-  await t.step(
-    "should return false for numbers that are powers of the base",
-    () => {
-      assertEquals(checkIsNotPower(1, 2), false);
-      assertEquals(checkIsNotPower(2, 2), false);
-      assertEquals(checkIsNotPower(4, 2), false);
-      assertEquals(checkIsNotPower(8, 2), false);
-      assertEquals(checkIsNotPower(9, 3), false);
-      assertEquals(checkIsNotPower(27, 3), false);
-      assertEquals(checkIsNotPower(16, 4), false);
-    },
-  );
+	await t.step(
+		"should return false for numbers that are powers of the base",
+		() => {
+			assertEquals(check_is_not_power(1, 2), false);
+			assertEquals(check_is_not_power(2, 2), false);
+			assertEquals(check_is_not_power(4, 2), false);
+			assertEquals(check_is_not_power(8, 2), false);
+			assertEquals(check_is_not_power(9, 3), false);
+			assertEquals(check_is_not_power(27, 3), false);
+			assertEquals(check_is_not_power(16, 4), false);
+		}
+	);
 });

--- a/packages/number/src/checkPower/test.ts
+++ b/packages/number/src/checkPower/test.ts
@@ -2,55 +2,55 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_not_power, check_is_power } from "./main.ts";
 
 Deno.test("check_is_power", async (t) => {
-	await t.step(
-		"should return true for numbers that are powers of the base",
-		() => {
-			assertEquals(check_is_power(1, 2), true); // 2^0 = 1
-			assertEquals(check_is_power(2, 2), true); // 2^1 = 2
-			assertEquals(check_is_power(4, 2), true); // 2^2 = 4
-			assertEquals(check_is_power(8, 2), true); // 2^3 = 8
-			assertEquals(check_is_power(9, 3), true); // 3^2 = 9
-			assertEquals(check_is_power(27, 3), true); // 3^3 = 27
-			assertEquals(check_is_power(16, 4), true); // 4^2 = 16
-		}
-	);
+  await t.step(
+    "should return true for numbers that are powers of the base",
+    () => {
+      assertEquals(check_is_power(1, 2), true); // 2^0 = 1
+      assertEquals(check_is_power(2, 2), true); // 2^1 = 2
+      assertEquals(check_is_power(4, 2), true); // 2^2 = 4
+      assertEquals(check_is_power(8, 2), true); // 2^3 = 8
+      assertEquals(check_is_power(9, 3), true); // 3^2 = 9
+      assertEquals(check_is_power(27, 3), true); // 3^3 = 27
+      assertEquals(check_is_power(16, 4), true); // 4^2 = 16
+    },
+  );
 
-	await t.step(
-		"should return false for numbers that are not powers of the base",
-		() => {
-			assertEquals(check_is_power(3, 2), false);
-			assertEquals(check_is_power(5, 2), false);
-			assertEquals(check_is_power(10, 2), false);
-			assertEquals(check_is_power(12, 3), false);
-			assertEquals(check_is_power(14, 2), false);
-			assertEquals(check_is_power(20, 3), false);
-		}
-	);
+  await t.step(
+    "should return false for numbers that are not powers of the base",
+    () => {
+      assertEquals(check_is_power(3, 2), false);
+      assertEquals(check_is_power(5, 2), false);
+      assertEquals(check_is_power(10, 2), false);
+      assertEquals(check_is_power(12, 3), false);
+      assertEquals(check_is_power(14, 2), false);
+      assertEquals(check_is_power(20, 3), false);
+    },
+  );
 });
 
 Deno.test("check_is_not_power", async (t) => {
-	await t.step(
-		"should return true for numbers that are not powers of the base",
-		() => {
-			assertEquals(check_is_not_power(3, 2), true);
-			assertEquals(check_is_not_power(5, 2), true);
-			assertEquals(check_is_not_power(10, 2), true);
-			assertEquals(check_is_not_power(12, 3), true);
-			assertEquals(check_is_not_power(14, 2), true);
-			assertEquals(check_is_not_power(20, 3), true);
-		}
-	);
+  await t.step(
+    "should return true for numbers that are not powers of the base",
+    () => {
+      assertEquals(check_is_not_power(3, 2), true);
+      assertEquals(check_is_not_power(5, 2), true);
+      assertEquals(check_is_not_power(10, 2), true);
+      assertEquals(check_is_not_power(12, 3), true);
+      assertEquals(check_is_not_power(14, 2), true);
+      assertEquals(check_is_not_power(20, 3), true);
+    },
+  );
 
-	await t.step(
-		"should return false for numbers that are powers of the base",
-		() => {
-			assertEquals(check_is_not_power(1, 2), false);
-			assertEquals(check_is_not_power(2, 2), false);
-			assertEquals(check_is_not_power(4, 2), false);
-			assertEquals(check_is_not_power(8, 2), false);
-			assertEquals(check_is_not_power(9, 3), false);
-			assertEquals(check_is_not_power(27, 3), false);
-			assertEquals(check_is_not_power(16, 4), false);
-		}
-	);
+  await t.step(
+    "should return false for numbers that are powers of the base",
+    () => {
+      assertEquals(check_is_not_power(1, 2), false);
+      assertEquals(check_is_not_power(2, 2), false);
+      assertEquals(check_is_not_power(4, 2), false);
+      assertEquals(check_is_not_power(8, 2), false);
+      assertEquals(check_is_not_power(9, 3), false);
+      assertEquals(check_is_not_power(27, 3), false);
+      assertEquals(check_is_not_power(16, 4), false);
+    },
+  );
 });

--- a/packages/number/src/checkPrime/main.ts
+++ b/packages/number/src/checkPrime/main.ts
@@ -15,12 +15,12 @@
  * check_is_prime(10); // 10 is not a prime number (divisible by 2 and 5)
  */
 export const check_is_prime = (num: number): boolean => {
-	if (num <= 1) return false;
-	if (num === 2) return true;
-	for (let i = 2; i < Math.sqrt(num) + 1; i++) {
-		if (num % i === 0) return false;
-	}
-	return true;
+  if (num <= 1) return false;
+  if (num === 2) return true;
+  for (let i = 2; i < Math.sqrt(num) + 1; i++) {
+    if (num % i === 0) return false;
+  }
+  return true;
 };
 
 /**
@@ -40,5 +40,5 @@ export const check_is_prime = (num: number): boolean => {
  * check_is_not_prime(7); // 7 is a prime number
  */
 export const check_is_not_prime = (num: number): boolean => {
-	return !check_is_prime(num);
+  return !check_is_prime(num);
 };

--- a/packages/number/src/checkPrime/main.ts
+++ b/packages/number/src/checkPrime/main.ts
@@ -8,37 +8,37 @@
  *
  * @example
  * // Returns true
- * checkIsPrime(7); // 7 is a prime number
+ * check_is_prime(7); // 7 is a prime number
  *
  * @example
  * // Returns false
- * checkIsPrime(10); // 10 is not a prime number (divisible by 2 and 5)
+ * check_is_prime(10); // 10 is not a prime number (divisible by 2 and 5)
  */
-export const checkIsPrime = (num: number): boolean => {
-  if (num <= 1) return false;
-  if (num === 2) return true;
-  for (let i = 2; i < Math.sqrt(num) + 1; i++) {
-    if (num % i === 0) return false;
-  }
-  return true;
+export const check_is_prime = (num: number): boolean => {
+	if (num <= 1) return false;
+	if (num === 2) return true;
+	for (let i = 2; i < Math.sqrt(num) + 1; i++) {
+		if (num % i === 0) return false;
+	}
+	return true;
 };
 
 /**
  * Checks if a given number is not a prime number.
  *
- * This is the inverse of `checkIsPrime`.
+ * This is the inverse of `check_is_prime`.
  *
  * @param {number} num - The number to check.
  * @returns {boolean} True if the number is not a prime number, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotPrime(10); // 10 is not a prime number (divisible by 2 and 5)
+ * check_is_not_prime(10); // 10 is not a prime number (divisible by 2 and 5)
  *
  * @example
  * // Returns false
- * checkIsNotPrime(7); // 7 is a prime number
+ * check_is_not_prime(7); // 7 is a prime number
  */
-export const checkIsNotPrime = (num: number): boolean => {
-  return !checkIsPrime(num);
+export const check_is_not_prime = (num: number): boolean => {
+	return !check_is_prime(num);
 };

--- a/packages/number/src/checkPrime/test.ts
+++ b/packages/number/src/checkPrime/test.ts
@@ -1,44 +1,44 @@
 import { assertEquals } from "../../deps.ts";
-import { check_is_prime, check_is_not_prime } from "./main.ts";
+import { check_is_not_prime, check_is_prime } from "./main.ts";
 
 Deno.test("check_is_prime", async (t) => {
-	await t.step("should return true for prime numbers", () => {
-		assertEquals(check_is_prime(2), true); // 2 is a prime number
-		assertEquals(check_is_prime(3), true); // 3 is a prime number
-		assertEquals(check_is_prime(5), true); // 5 is a prime number
-		assertEquals(check_is_prime(7), true); // 7 is a prime number
-		assertEquals(check_is_prime(11), true); // 11 is a prime number
-		assertEquals(check_is_prime(13), true); // 13 is a prime number
-		assertEquals(check_is_prime(17), true); // 17 is a prime number
-	});
+  await t.step("should return true for prime numbers", () => {
+    assertEquals(check_is_prime(2), true); // 2 is a prime number
+    assertEquals(check_is_prime(3), true); // 3 is a prime number
+    assertEquals(check_is_prime(5), true); // 5 is a prime number
+    assertEquals(check_is_prime(7), true); // 7 is a prime number
+    assertEquals(check_is_prime(11), true); // 11 is a prime number
+    assertEquals(check_is_prime(13), true); // 13 is a prime number
+    assertEquals(check_is_prime(17), true); // 17 is a prime number
+  });
 
-	await t.step("should return false for non-prime numbers", () => {
-		assertEquals(check_is_prime(1), false); // 1 is not a prime number
-		assertEquals(check_is_prime(4), false); // 4 is divisible by 2
-		assertEquals(check_is_prime(6), false); // 6 is divisible by 2 and 3
-		assertEquals(check_is_prime(8), false); // 8 is divisible by 2
-		assertEquals(check_is_prime(9), false); // 9 is divisible by 3
-		assertEquals(check_is_prime(10), false); // 10 is divisible by 2 and 5
-	});
+  await t.step("should return false for non-prime numbers", () => {
+    assertEquals(check_is_prime(1), false); // 1 is not a prime number
+    assertEquals(check_is_prime(4), false); // 4 is divisible by 2
+    assertEquals(check_is_prime(6), false); // 6 is divisible by 2 and 3
+    assertEquals(check_is_prime(8), false); // 8 is divisible by 2
+    assertEquals(check_is_prime(9), false); // 9 is divisible by 3
+    assertEquals(check_is_prime(10), false); // 10 is divisible by 2 and 5
+  });
 });
 
 Deno.test("check_is_not_prime", async (t) => {
-	await t.step("should return true for non-prime numbers", () => {
-		assertEquals(check_is_not_prime(1), true); // 1 is not a prime number
-		assertEquals(check_is_not_prime(4), true); // 4 is divisible by 2
-		assertEquals(check_is_not_prime(6), true); // 6 is divisible by 2 and 3
-		assertEquals(check_is_not_prime(8), true); // 8 is divisible by 2
-		assertEquals(check_is_not_prime(9), true); // 9 is divisible by 3
-		assertEquals(check_is_not_prime(10), true); // 10 is divisible by 2 and 5
-	});
+  await t.step("should return true for non-prime numbers", () => {
+    assertEquals(check_is_not_prime(1), true); // 1 is not a prime number
+    assertEquals(check_is_not_prime(4), true); // 4 is divisible by 2
+    assertEquals(check_is_not_prime(6), true); // 6 is divisible by 2 and 3
+    assertEquals(check_is_not_prime(8), true); // 8 is divisible by 2
+    assertEquals(check_is_not_prime(9), true); // 9 is divisible by 3
+    assertEquals(check_is_not_prime(10), true); // 10 is divisible by 2 and 5
+  });
 
-	await t.step("should return false for prime numbers", () => {
-		assertEquals(check_is_not_prime(2), false); // 2 is a prime number
-		assertEquals(check_is_not_prime(3), false); // 3 is a prime number
-		assertEquals(check_is_not_prime(5), false); // 5 is a prime number
-		assertEquals(check_is_not_prime(7), false); // 7 is a prime number
-		assertEquals(check_is_not_prime(11), false); // 11 is a prime number
-		assertEquals(check_is_not_prime(13), false); // 13 is a prime number
-		assertEquals(check_is_not_prime(17), false); // 17 is a prime number
-	});
+  await t.step("should return false for prime numbers", () => {
+    assertEquals(check_is_not_prime(2), false); // 2 is a prime number
+    assertEquals(check_is_not_prime(3), false); // 3 is a prime number
+    assertEquals(check_is_not_prime(5), false); // 5 is a prime number
+    assertEquals(check_is_not_prime(7), false); // 7 is a prime number
+    assertEquals(check_is_not_prime(11), false); // 11 is a prime number
+    assertEquals(check_is_not_prime(13), false); // 13 is a prime number
+    assertEquals(check_is_not_prime(17), false); // 17 is a prime number
+  });
 });

--- a/packages/number/src/checkPrime/test.ts
+++ b/packages/number/src/checkPrime/test.ts
@@ -1,0 +1,44 @@
+import { assertEquals } from "../../deps.ts";
+import { check_is_prime, check_is_not_prime } from "./main.ts";
+
+Deno.test("check_is_prime", async (t) => {
+	await t.step("should return true for prime numbers", () => {
+		assertEquals(check_is_prime(2), true); // 2 is a prime number
+		assertEquals(check_is_prime(3), true); // 3 is a prime number
+		assertEquals(check_is_prime(5), true); // 5 is a prime number
+		assertEquals(check_is_prime(7), true); // 7 is a prime number
+		assertEquals(check_is_prime(11), true); // 11 is a prime number
+		assertEquals(check_is_prime(13), true); // 13 is a prime number
+		assertEquals(check_is_prime(17), true); // 17 is a prime number
+	});
+
+	await t.step("should return false for non-prime numbers", () => {
+		assertEquals(check_is_prime(1), false); // 1 is not a prime number
+		assertEquals(check_is_prime(4), false); // 4 is divisible by 2
+		assertEquals(check_is_prime(6), false); // 6 is divisible by 2 and 3
+		assertEquals(check_is_prime(8), false); // 8 is divisible by 2
+		assertEquals(check_is_prime(9), false); // 9 is divisible by 3
+		assertEquals(check_is_prime(10), false); // 10 is divisible by 2 and 5
+	});
+});
+
+Deno.test("check_is_not_prime", async (t) => {
+	await t.step("should return true for non-prime numbers", () => {
+		assertEquals(check_is_not_prime(1), true); // 1 is not a prime number
+		assertEquals(check_is_not_prime(4), true); // 4 is divisible by 2
+		assertEquals(check_is_not_prime(6), true); // 6 is divisible by 2 and 3
+		assertEquals(check_is_not_prime(8), true); // 8 is divisible by 2
+		assertEquals(check_is_not_prime(9), true); // 9 is divisible by 3
+		assertEquals(check_is_not_prime(10), true); // 10 is divisible by 2 and 5
+	});
+
+	await t.step("should return false for prime numbers", () => {
+		assertEquals(check_is_not_prime(2), false); // 2 is a prime number
+		assertEquals(check_is_not_prime(3), false); // 3 is a prime number
+		assertEquals(check_is_not_prime(5), false); // 5 is a prime number
+		assertEquals(check_is_not_prime(7), false); // 7 is a prime number
+		assertEquals(check_is_not_prime(11), false); // 11 is a prime number
+		assertEquals(check_is_not_prime(13), false); // 13 is a prime number
+		assertEquals(check_is_not_prime(17), false); // 17 is a prime number
+	});
+});

--- a/packages/number/src/checkSquareRoot/main.ts
+++ b/packages/number/src/checkSquareRoot/main.ts
@@ -16,7 +16,7 @@
  * check_is_square_root(4, 20); // 4 is not the square root of 20
  */
 export const check_is_square_root = (num: number, target: number): boolean => {
-	return num === Math.sqrt(target);
+  return num === Math.sqrt(target);
 };
 
 /**
@@ -37,8 +37,8 @@ export const check_is_square_root = (num: number, target: number): boolean => {
  * check_is_not_square_root(3, 9); // 3 is the square root of 9
  */
 export const check_is_not_square_root = (
-	num: number,
-	target: number
+  num: number,
+  target: number,
 ): boolean => {
-	return !check_is_square_root(num, target);
+  return !check_is_square_root(num, target);
 };

--- a/packages/number/src/checkSquareRoot/main.ts
+++ b/packages/number/src/checkSquareRoot/main.ts
@@ -9,20 +9,20 @@
  *
  * @example
  * // Returns true
- * checkIsSquareRootOf(3, 9); // 3 is the square root of 9
+ * check_is_square_root(3, 9); // 3 is the square root of 9
  *
  * @example
  * // Returns false
- * checkIsSquareRootOf(4, 20); // 4 is not the square root of 20
+ * check_is_square_root(4, 20); // 4 is not the square root of 20
  */
-export const checkIsSquareRoot = (num: number, target: number): boolean => {
-  return num === Math.sqrt(target);
+export const check_is_square_root = (num: number, target: number): boolean => {
+	return num === Math.sqrt(target);
 };
 
 /**
  * Checks if a given number is not the square root of the target number.
  *
- * This is the inverse of `checkIsSquareRootOf`.
+ * This is the inverse of `check_is_square_root`.
  *
  * @param {number} num - The number to check.
  * @param {number} target - The target number to compare against.
@@ -30,12 +30,15 @@ export const checkIsSquareRoot = (num: number, target: number): boolean => {
  *
  * @example
  * // Returns true
- * checkIsNotSquareRootOf(4, 20); // 4 is not the square root of 20
+ * check_is_not_square_root(4, 20); // 4 is not the square root of 20
  *
  * @example
  * // Returns false
- * checkIsNotSquareRootOf(3, 9); // 3 is the square root of 9
+ * check_is_not_square_root(3, 9); // 3 is the square root of 9
  */
-export const checkIsNotSquareRoot = (num: number, target: number): boolean => {
-  return !checkIsSquareRoot(num, target);
+export const check_is_not_square_root = (
+	num: number,
+	target: number
+): boolean => {
+	return !check_is_square_root(num, target);
 };

--- a/packages/number/src/checkSquareRoot/test.ts
+++ b/packages/number/src/checkSquareRoot/test.ts
@@ -2,51 +2,51 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_not_square_root, check_is_square_root } from "./main.ts";
 
 Deno.test("check_is_square_root", async (t) => {
-	await t.step(
-		"should return true if the number is the square root of the target",
-		() => {
-			assertEquals(check_is_square_root(2, 4), true);
-			assertEquals(check_is_square_root(3, 9), true);
-			assertEquals(check_is_square_root(5, 25), true);
-			assertEquals(check_is_square_root(0, 0), true);
-			assertEquals(check_is_square_root(1, 1), true);
-			assertEquals(check_is_square_root(10, 100), true);
-		}
-	);
+  await t.step(
+    "should return true if the number is the square root of the target",
+    () => {
+      assertEquals(check_is_square_root(2, 4), true);
+      assertEquals(check_is_square_root(3, 9), true);
+      assertEquals(check_is_square_root(5, 25), true);
+      assertEquals(check_is_square_root(0, 0), true);
+      assertEquals(check_is_square_root(1, 1), true);
+      assertEquals(check_is_square_root(10, 100), true);
+    },
+  );
 
-	await t.step(
-		"should return false if the number is not the square root of the target",
-		() => {
-			// assertEquals(checkIsSquareRootOf(2, 5), false);
-			// assertEquals(checkIsSquareRootOf(3, 8), false);
-			// assertEquals(checkIsSquareRootOf(4, 20), false);
-			// assertEquals(checkIsSquareRootOf(7, 50), false);
-			// assertEquals(checkIsSquareRootOf(10, 99), false); // Incorrect square root
-		}
-	);
+  await t.step(
+    "should return false if the number is not the square root of the target",
+    () => {
+      // assertEquals(checkIsSquareRootOf(2, 5), false);
+      // assertEquals(checkIsSquareRootOf(3, 8), false);
+      // assertEquals(checkIsSquareRootOf(4, 20), false);
+      // assertEquals(checkIsSquareRootOf(7, 50), false);
+      // assertEquals(checkIsSquareRootOf(10, 99), false); // Incorrect square root
+    },
+  );
 });
 
 Deno.test("check_is_not_square_root", async (t) => {
-	await t.step(
-		"should return true if the number is not the square root of the target",
-		() => {
-			assertEquals(check_is_not_square_root(2, 5), true);
-			assertEquals(check_is_not_square_root(3, 8), true);
-			assertEquals(check_is_not_square_root(4, 20), true);
-			assertEquals(check_is_not_square_root(7, 50), true);
-			assertEquals(check_is_not_square_root(10, 99), true); // Incorrect square root
-		}
-	);
+  await t.step(
+    "should return true if the number is not the square root of the target",
+    () => {
+      assertEquals(check_is_not_square_root(2, 5), true);
+      assertEquals(check_is_not_square_root(3, 8), true);
+      assertEquals(check_is_not_square_root(4, 20), true);
+      assertEquals(check_is_not_square_root(7, 50), true);
+      assertEquals(check_is_not_square_root(10, 99), true); // Incorrect square root
+    },
+  );
 
-	await t.step(
-		"should return false if the number is the square root of the target",
-		() => {
-			assertEquals(check_is_not_square_root(2, 4), false);
-			assertEquals(check_is_not_square_root(3, 9), false);
-			assertEquals(check_is_not_square_root(5, 25), false);
-			assertEquals(check_is_not_square_root(0, 0), false);
-			assertEquals(check_is_not_square_root(1, 1), false);
-			assertEquals(check_is_not_square_root(10, 100), false);
-		}
-	);
+  await t.step(
+    "should return false if the number is the square root of the target",
+    () => {
+      assertEquals(check_is_not_square_root(2, 4), false);
+      assertEquals(check_is_not_square_root(3, 9), false);
+      assertEquals(check_is_not_square_root(5, 25), false);
+      assertEquals(check_is_not_square_root(0, 0), false);
+      assertEquals(check_is_not_square_root(1, 1), false);
+      assertEquals(check_is_not_square_root(10, 100), false);
+    },
+  );
 });

--- a/packages/number/src/checkSquareRoot/test.ts
+++ b/packages/number/src/checkSquareRoot/test.ts
@@ -1,52 +1,52 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsNotSquareRoot, checkIsSquareRoot } from "./main.ts";
+import { check_is_not_square_root, check_is_square_root } from "./main.ts";
 
-Deno.test("checkIsSquareRootOf", async (t) => {
-  await t.step(
-    "should return true if the number is the square root of the target",
-    () => {
-      assertEquals(checkIsSquareRoot(2, 4), true);
-      assertEquals(checkIsSquareRoot(3, 9), true);
-      assertEquals(checkIsSquareRoot(5, 25), true);
-      assertEquals(checkIsSquareRoot(0, 0), true);
-      assertEquals(checkIsSquareRoot(1, 1), true);
-      assertEquals(checkIsSquareRoot(10, 100), true);
-    },
-  );
+Deno.test("check_is_square_root", async (t) => {
+	await t.step(
+		"should return true if the number is the square root of the target",
+		() => {
+			assertEquals(check_is_square_root(2, 4), true);
+			assertEquals(check_is_square_root(3, 9), true);
+			assertEquals(check_is_square_root(5, 25), true);
+			assertEquals(check_is_square_root(0, 0), true);
+			assertEquals(check_is_square_root(1, 1), true);
+			assertEquals(check_is_square_root(10, 100), true);
+		}
+	);
 
-  await t.step(
-    "should return false if the number is not the square root of the target",
-    () => {
-      // assertEquals(checkIsSquareRootOf(2, 5), false);
-      // assertEquals(checkIsSquareRootOf(3, 8), false);
-      // assertEquals(checkIsSquareRootOf(4, 20), false);
-      // assertEquals(checkIsSquareRootOf(7, 50), false);
-      // assertEquals(checkIsSquareRootOf(10, 99), false); // Incorrect square root
-    },
-  );
+	await t.step(
+		"should return false if the number is not the square root of the target",
+		() => {
+			// assertEquals(checkIsSquareRootOf(2, 5), false);
+			// assertEquals(checkIsSquareRootOf(3, 8), false);
+			// assertEquals(checkIsSquareRootOf(4, 20), false);
+			// assertEquals(checkIsSquareRootOf(7, 50), false);
+			// assertEquals(checkIsSquareRootOf(10, 99), false); // Incorrect square root
+		}
+	);
 });
 
-Deno.test("checkIsNotSquareRootOf", async (t) => {
-  await t.step(
-    "should return true if the number is not the square root of the target",
-    () => {
-      assertEquals(checkIsNotSquareRoot(2, 5), true);
-      assertEquals(checkIsNotSquareRoot(3, 8), true);
-      assertEquals(checkIsNotSquareRoot(4, 20), true);
-      assertEquals(checkIsNotSquareRoot(7, 50), true);
-      assertEquals(checkIsNotSquareRoot(10, 99), true); // Incorrect square root
-    },
-  );
+Deno.test("check_is_not_square_root", async (t) => {
+	await t.step(
+		"should return true if the number is not the square root of the target",
+		() => {
+			assertEquals(check_is_not_square_root(2, 5), true);
+			assertEquals(check_is_not_square_root(3, 8), true);
+			assertEquals(check_is_not_square_root(4, 20), true);
+			assertEquals(check_is_not_square_root(7, 50), true);
+			assertEquals(check_is_not_square_root(10, 99), true); // Incorrect square root
+		}
+	);
 
-  await t.step(
-    "should return false if the number is the square root of the target",
-    () => {
-      assertEquals(checkIsNotSquareRoot(2, 4), false);
-      assertEquals(checkIsNotSquareRoot(3, 9), false);
-      assertEquals(checkIsNotSquareRoot(5, 25), false);
-      assertEquals(checkIsNotSquareRoot(0, 0), false);
-      assertEquals(checkIsNotSquareRoot(1, 1), false);
-      assertEquals(checkIsNotSquareRoot(10, 100), false);
-    },
-  );
+	await t.step(
+		"should return false if the number is the square root of the target",
+		() => {
+			assertEquals(check_is_not_square_root(2, 4), false);
+			assertEquals(check_is_not_square_root(3, 9), false);
+			assertEquals(check_is_not_square_root(5, 25), false);
+			assertEquals(check_is_not_square_root(0, 0), false);
+			assertEquals(check_is_not_square_root(1, 1), false);
+			assertEquals(check_is_not_square_root(10, 100), false);
+		}
+	);
 });

--- a/packages/number/src/checkWithinRange/main.ts
+++ b/packages/number/src/checkWithinRange/main.ts
@@ -11,24 +11,24 @@
  *
  * @example
  * // Returns true
- * checkIsWithinRange(5, 1, 10); // 5 is within the range [1, 10]
+ * check_is_within_range(5, 1, 10); // 5 is within the range [1, 10]
  *
  * @example
  * // Returns false
- * checkIsWithinRange(15, 1, 10); // 15 is not within the range [1, 10]
+ * check_is_within_range(15, 1, 10); // 15 is not within the range [1, 10]
  */
-export const checkIsWithinRange = (
-  num: number,
-  min: number,
-  max: number,
+export const check_is_within_range = (
+	num: number,
+	min: number,
+	max: number
 ): boolean => {
-  return num >= min && num <= max;
+	return num >= min && num <= max;
 };
 
 /**
  * Checks if a given number is not within a specified range.
  *
- * This is the inverse of `checkIsWithinRange`.
+ * This is the inverse of `check_is_within_range`.
  *
  * The function evaluates whether `num` is less than `min` or greater than `max`.
  *
@@ -39,16 +39,16 @@ export const checkIsWithinRange = (
  *
  * @example
  * // Returns true
- * checkIsNotWithinRange(15, 1, 10); // 15 is not within the range [1, 10]
+ * check_is_not_within_range(15, 1, 10); // 15 is not within the range [1, 10]
  *
  * @example
  * // Returns false
- * checkIsNotWithinRange(5, 1, 10); // 5 is within the range [1, 10]
+ * check_is_not_within_range(5, 1, 10); // 5 is within the range [1, 10]
  */
-export const checkIsNotWithinRange = (
-  num: number,
-  min: number,
-  max: number,
+export const check_is_not_within_range = (
+	num: number,
+	min: number,
+	max: number
 ): boolean => {
-  return !checkIsWithinRange(num, min, max);
+	return !check_is_within_range(num, min, max);
 };

--- a/packages/number/src/checkWithinRange/main.ts
+++ b/packages/number/src/checkWithinRange/main.ts
@@ -18,11 +18,11 @@
  * check_is_within_range(15, 1, 10); // 15 is not within the range [1, 10]
  */
 export const check_is_within_range = (
-	num: number,
-	min: number,
-	max: number
+  num: number,
+  min: number,
+  max: number,
 ): boolean => {
-	return num >= min && num <= max;
+  return num >= min && num <= max;
 };
 
 /**
@@ -46,9 +46,9 @@ export const check_is_within_range = (
  * check_is_not_within_range(5, 1, 10); // 5 is within the range [1, 10]
  */
 export const check_is_not_within_range = (
-	num: number,
-	min: number,
-	max: number
+  num: number,
+  min: number,
+  max: number,
 ): boolean => {
-	return !check_is_within_range(num, min, max);
+  return !check_is_within_range(num, min, max);
 };

--- a/packages/number/src/checkWithinRange/test.ts
+++ b/packages/number/src/checkWithinRange/test.ts
@@ -1,38 +1,38 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsNotWithinRange, checkIsWithinRange } from "./main.ts";
+import { check_is_not_within_range, check_is_within_range } from "./main.ts";
 
-Deno.test("checkIsWithinRange", async (t) => {
-  await t.step("should return true for numbers within the range", () => {
-    assertEquals(checkIsWithinRange(5, 1, 10), true);
-    assertEquals(checkIsWithinRange(1, 1, 10), true); // Testing the lower boundary
-    assertEquals(checkIsWithinRange(10, 1, 10), true); // Testing the upper boundary
-    assertEquals(checkIsWithinRange(0, -5, 5), true);
-    assertEquals(checkIsWithinRange(-1, -10, 0), true);
-  });
+Deno.test("check_is_within_range", async (t) => {
+	await t.step("should return true for numbers within the range", () => {
+		assertEquals(check_is_within_range(5, 1, 10), true);
+		assertEquals(check_is_within_range(1, 1, 10), true); // Testing the lower boundary
+		assertEquals(check_is_within_range(10, 1, 10), true); // Testing the upper boundary
+		assertEquals(check_is_within_range(0, -5, 5), true);
+		assertEquals(check_is_within_range(-1, -10, 0), true);
+	});
 
-  await t.step("should return false for numbers outside the range", () => {
-    assertEquals(checkIsWithinRange(0, 1, 10), false); // Below the lower boundary
-    assertEquals(checkIsWithinRange(11, 1, 10), false); // Above the upper boundary
-    assertEquals(checkIsWithinRange(-6, -5, 5), false); // Below the lower boundary
-    assertEquals(checkIsWithinRange(6, -5, 5), false); // Above the upper boundary
-    assertEquals(checkIsWithinRange(-11, -10, 0), false); // Below the lower boundary
-  });
+	await t.step("should return false for numbers outside the range", () => {
+		assertEquals(check_is_within_range(0, 1, 10), false); // Below the lower boundary
+		assertEquals(check_is_within_range(11, 1, 10), false); // Above the upper boundary
+		assertEquals(check_is_within_range(-6, -5, 5), false); // Below the lower boundary
+		assertEquals(check_is_within_range(6, -5, 5), false); // Above the upper boundary
+		assertEquals(check_is_within_range(-11, -10, 0), false); // Below the lower boundary
+	});
 });
 
-Deno.test("checkIsNotWithinRange", async (t) => {
-  await t.step("should return true for numbers outside the range", () => {
-    assertEquals(checkIsNotWithinRange(0, 1, 10), true); // Below the lower boundary
-    assertEquals(checkIsNotWithinRange(11, 1, 10), true); // Above the upper boundary
-    assertEquals(checkIsNotWithinRange(-6, -5, 5), true); // Below the lower boundary
-    assertEquals(checkIsNotWithinRange(6, -5, 5), true); // Above the upper boundary
-    assertEquals(checkIsNotWithinRange(-11, -10, 0), true); // Below the lower boundary
-  });
+Deno.test("check_is_not_within_range", async (t) => {
+	await t.step("should return true for numbers outside the range", () => {
+		assertEquals(check_is_not_within_range(0, 1, 10), true); // Below the lower boundary
+		assertEquals(check_is_not_within_range(11, 1, 10), true); // Above the upper boundary
+		assertEquals(check_is_not_within_range(-6, -5, 5), true); // Below the lower boundary
+		assertEquals(check_is_not_within_range(6, -5, 5), true); // Above the upper boundary
+		assertEquals(check_is_not_within_range(-11, -10, 0), true); // Below the lower boundary
+	});
 
-  await t.step("should return false for numbers within the range", () => {
-    assertEquals(checkIsNotWithinRange(5, 1, 10), false);
-    assertEquals(checkIsNotWithinRange(1, 1, 10), false); // Testing the lower boundary
-    assertEquals(checkIsNotWithinRange(10, 1, 10), false); // Testing the upper boundary
-    assertEquals(checkIsNotWithinRange(0, -5, 5), false);
-    assertEquals(checkIsNotWithinRange(-1, -10, 0), false);
-  });
+	await t.step("should return false for numbers within the range", () => {
+		assertEquals(check_is_not_within_range(5, 1, 10), false);
+		assertEquals(check_is_not_within_range(1, 1, 10), false); // Testing the lower boundary
+		assertEquals(check_is_not_within_range(10, 1, 10), false); // Testing the upper boundary
+		assertEquals(check_is_not_within_range(0, -5, 5), false);
+		assertEquals(check_is_not_within_range(-1, -10, 0), false);
+	});
 });

--- a/packages/number/src/checkWithinRange/test.ts
+++ b/packages/number/src/checkWithinRange/test.ts
@@ -2,37 +2,37 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_not_within_range, check_is_within_range } from "./main.ts";
 
 Deno.test("check_is_within_range", async (t) => {
-	await t.step("should return true for numbers within the range", () => {
-		assertEquals(check_is_within_range(5, 1, 10), true);
-		assertEquals(check_is_within_range(1, 1, 10), true); // Testing the lower boundary
-		assertEquals(check_is_within_range(10, 1, 10), true); // Testing the upper boundary
-		assertEquals(check_is_within_range(0, -5, 5), true);
-		assertEquals(check_is_within_range(-1, -10, 0), true);
-	});
+  await t.step("should return true for numbers within the range", () => {
+    assertEquals(check_is_within_range(5, 1, 10), true);
+    assertEquals(check_is_within_range(1, 1, 10), true); // Testing the lower boundary
+    assertEquals(check_is_within_range(10, 1, 10), true); // Testing the upper boundary
+    assertEquals(check_is_within_range(0, -5, 5), true);
+    assertEquals(check_is_within_range(-1, -10, 0), true);
+  });
 
-	await t.step("should return false for numbers outside the range", () => {
-		assertEquals(check_is_within_range(0, 1, 10), false); // Below the lower boundary
-		assertEquals(check_is_within_range(11, 1, 10), false); // Above the upper boundary
-		assertEquals(check_is_within_range(-6, -5, 5), false); // Below the lower boundary
-		assertEquals(check_is_within_range(6, -5, 5), false); // Above the upper boundary
-		assertEquals(check_is_within_range(-11, -10, 0), false); // Below the lower boundary
-	});
+  await t.step("should return false for numbers outside the range", () => {
+    assertEquals(check_is_within_range(0, 1, 10), false); // Below the lower boundary
+    assertEquals(check_is_within_range(11, 1, 10), false); // Above the upper boundary
+    assertEquals(check_is_within_range(-6, -5, 5), false); // Below the lower boundary
+    assertEquals(check_is_within_range(6, -5, 5), false); // Above the upper boundary
+    assertEquals(check_is_within_range(-11, -10, 0), false); // Below the lower boundary
+  });
 });
 
 Deno.test("check_is_not_within_range", async (t) => {
-	await t.step("should return true for numbers outside the range", () => {
-		assertEquals(check_is_not_within_range(0, 1, 10), true); // Below the lower boundary
-		assertEquals(check_is_not_within_range(11, 1, 10), true); // Above the upper boundary
-		assertEquals(check_is_not_within_range(-6, -5, 5), true); // Below the lower boundary
-		assertEquals(check_is_not_within_range(6, -5, 5), true); // Above the upper boundary
-		assertEquals(check_is_not_within_range(-11, -10, 0), true); // Below the lower boundary
-	});
+  await t.step("should return true for numbers outside the range", () => {
+    assertEquals(check_is_not_within_range(0, 1, 10), true); // Below the lower boundary
+    assertEquals(check_is_not_within_range(11, 1, 10), true); // Above the upper boundary
+    assertEquals(check_is_not_within_range(-6, -5, 5), true); // Below the lower boundary
+    assertEquals(check_is_not_within_range(6, -5, 5), true); // Above the upper boundary
+    assertEquals(check_is_not_within_range(-11, -10, 0), true); // Below the lower boundary
+  });
 
-	await t.step("should return false for numbers within the range", () => {
-		assertEquals(check_is_not_within_range(5, 1, 10), false);
-		assertEquals(check_is_not_within_range(1, 1, 10), false); // Testing the lower boundary
-		assertEquals(check_is_not_within_range(10, 1, 10), false); // Testing the upper boundary
-		assertEquals(check_is_not_within_range(0, -5, 5), false);
-		assertEquals(check_is_not_within_range(-1, -10, 0), false);
-	});
+  await t.step("should return false for numbers within the range", () => {
+    assertEquals(check_is_not_within_range(5, 1, 10), false);
+    assertEquals(check_is_not_within_range(1, 1, 10), false); // Testing the lower boundary
+    assertEquals(check_is_not_within_range(10, 1, 10), false); // Testing the upper boundary
+    assertEquals(check_is_not_within_range(0, -5, 5), false);
+    assertEquals(check_is_not_within_range(-1, -10, 0), false);
+  });
 });

--- a/packages/number/src/checkZero/main.ts
+++ b/packages/number/src/checkZero/main.ts
@@ -6,34 +6,34 @@
  *
  * @example
  * // Returns true
- * checkIsZero(0); // 0 is zero
+ * check_is_zero(0); // 0 is zero
  *
  * @example
  * // Returns false
- * checkIsZero(5); // 5 is not zero
+ * check_is_zero(5); // 5 is not zero
  */
-export const checkIsZero = (num: number): num is 0 => {
-  return num === 0;
+export const check_is_zero = (num: number): num is 0 => {
+	return num === 0;
 };
 
 /**
  * Checks if the given number is not zero.
  *
- * This is the inverse of `checkIsZero`.
+ * This is the inverse of `check_is_zero`.
  *
  * @param {T extends number} num - The number to check.
  * @returns {num is Exclude<T, 0>} True if the number is not zero, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotZero(5); // 5 is not zero
+ * check_is_not_zero(5); // 5 is not zero
  *
  * @example
  * // Returns false
- * checkIsNotZero(0); // 0 is zero
+ * check_is_not_zero(0); // 0 is zero
  */
-export const checkIsNotZero = <T extends number>(
-  num: T,
+export const check_is_not_zero = <T extends number>(
+	num: T
 ): num is Exclude<T, 0> => {
-  return !checkIsZero(num);
+	return !check_is_zero(num);
 };

--- a/packages/number/src/checkZero/main.ts
+++ b/packages/number/src/checkZero/main.ts
@@ -13,7 +13,7 @@
  * check_is_zero(5); // 5 is not zero
  */
 export const check_is_zero = (num: number): num is 0 => {
-	return num === 0;
+  return num === 0;
 };
 
 /**
@@ -33,7 +33,7 @@ export const check_is_zero = (num: number): num is 0 => {
  * check_is_not_zero(0); // 0 is zero
  */
 export const check_is_not_zero = <T extends number>(
-	num: T
+  num: T,
 ): num is Exclude<T, 0> => {
-	return !check_is_zero(num);
+  return !check_is_zero(num);
 };

--- a/packages/number/src/checkZero/test.ts
+++ b/packages/number/src/checkZero/test.ts
@@ -1,26 +1,26 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsNotZero, checkIsZero } from "./main.ts";
+import { check_is_not_zero, check_is_zero } from "./main.ts";
 
 Deno.test("checkIsZero", async (t) => {
-  await t.step("should return true for zero", () => {
-    assertEquals(checkIsZero(0), true);
-  });
+	await t.step("should return true for zero", () => {
+		assertEquals(check_is_zero(0), true);
+	});
 
-  await t.step("should return false for non-zero numbers", () => {
-    assertEquals(checkIsZero(1), false);
-    assertEquals(checkIsZero(-1), false);
-    assertEquals(checkIsZero(3.14), false);
-  });
+	await t.step("should return false for non-zero numbers", () => {
+		assertEquals(check_is_zero(1), false);
+		assertEquals(check_is_zero(-1), false);
+		assertEquals(check_is_zero(3.14), false);
+	});
 });
 
 Deno.test("checkIsNotZero", async (t) => {
-  await t.step("should return true for non-zero numbers", () => {
-    assertEquals(checkIsNotZero(1), true);
-    assertEquals(checkIsNotZero(-1), true);
-    assertEquals(checkIsNotZero(3.14), true);
-  });
+	await t.step("should return true for non-zero numbers", () => {
+		assertEquals(check_is_not_zero(1), true);
+		assertEquals(check_is_not_zero(-1), true);
+		assertEquals(check_is_not_zero(3.14), true);
+	});
 
-  await t.step("should return false for zero", () => {
-    assertEquals(checkIsNotZero(0), false);
-  });
+	await t.step("should return false for zero", () => {
+		assertEquals(check_is_not_zero(0), false);
+	});
 });

--- a/packages/number/src/checkZero/test.ts
+++ b/packages/number/src/checkZero/test.ts
@@ -2,25 +2,25 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_not_zero, check_is_zero } from "./main.ts";
 
 Deno.test("checkIsZero", async (t) => {
-	await t.step("should return true for zero", () => {
-		assertEquals(check_is_zero(0), true);
-	});
+  await t.step("should return true for zero", () => {
+    assertEquals(check_is_zero(0), true);
+  });
 
-	await t.step("should return false for non-zero numbers", () => {
-		assertEquals(check_is_zero(1), false);
-		assertEquals(check_is_zero(-1), false);
-		assertEquals(check_is_zero(3.14), false);
-	});
+  await t.step("should return false for non-zero numbers", () => {
+    assertEquals(check_is_zero(1), false);
+    assertEquals(check_is_zero(-1), false);
+    assertEquals(check_is_zero(3.14), false);
+  });
 });
 
 Deno.test("checkIsNotZero", async (t) => {
-	await t.step("should return true for non-zero numbers", () => {
-		assertEquals(check_is_not_zero(1), true);
-		assertEquals(check_is_not_zero(-1), true);
-		assertEquals(check_is_not_zero(3.14), true);
-	});
+  await t.step("should return true for non-zero numbers", () => {
+    assertEquals(check_is_not_zero(1), true);
+    assertEquals(check_is_not_zero(-1), true);
+    assertEquals(check_is_not_zero(3.14), true);
+  });
 
-	await t.step("should return false for zero", () => {
-		assertEquals(check_is_not_zero(0), false);
-	});
+  await t.step("should return false for zero", () => {
+    assertEquals(check_is_not_zero(0), false);
+  });
 });

--- a/packages/object/README.md
+++ b/packages/object/README.md
@@ -98,11 +98,11 @@ type Obj = { a: 1; b: 2 } | { c: 3; d: 4 };
 const obj = {} as Obj;
 
 if ("c" in obj) {
-	obj; // obj type is { c: 3, d: 4 }
+  obj; // obj type is { c: 3, d: 4 }
 }
 
 if (check_key_exists_in_object(obj, "c")) {
-	obj; // obj type is Obj
+  obj; // obj type is Obj
 }
 ```
 

--- a/packages/object/README.md
+++ b/packages/object/README.md
@@ -41,45 +41,45 @@ bunx jsr add @checker/object
 
 ## Functions
 
-### `checkIsDeepEqual`
+### `check_is_deep_equal`
 
 Checks if two objects are deeply equal.
 
 ```ts
-checkIsDeepEqual({ a: 1, b: 2 }, { a: 1, b: 2 }); // true
-checkIsDeepEqual({ a: 1, b: 2 }, { a: 2, b: 3 }); // false
+check_is_deep_equal({ a: 1, b: 2 }, { a: 1, b: 2 }); // true
+check_is_deep_equal({ a: 1, b: 2 }, { a: 2, b: 3 }); // false
 ```
 
-### `checkIsNotDeepEqual`
+### `check_is_not_deep_equal`
 
 ```ts
-checkIsDeepEqual({ a: 1, b: 2 }, { a: 2, b: 3 }); // true
-checkIsDeepEqual({ a: 1, b: 2 }, { a: 1, b: 2 }); // false
+check_is_not_deep_equal({ a: 1, b: 2 }, { a: 2, b: 3 }); // true
+check_is_not_deep_equal({ a: 1, b: 2 }, { a: 1, b: 2 }); // false
 ```
 
-### `checkIsEmptyObject`
+### `check_is_empty_object`
 
 Checks if a given object is an empty plain object.
 
 ```ts
-checkIsEmptyObject({}); // true
+check_is_empty_object({}); // true
 
-checkIsEmptyObject(new Date()); // false
-checkIsEmptyObject({ a: 1 }); // false
+check_is_empty_object(new Date()); // false
+check_is_empty_object({ a: 1 }); // false
 ```
 
-### `checkIsNotEmptyObject`
+### `check_is_not_empty_object`
 
 Checks if a given object is not an empty plain object.
 
 ```ts
-checkIsNotEmptyObject(new Date()); // true
-checkIsNotEmptyObject({ a: 1 }); // true
+check_is_not_empty_object(new Date()); // true
+check_is_not_empty_object({ a: 1 }); // true
 
-checkIsNotEmptyObject({}); // false
+check_is_not_empty_object({}); // false
 ```
 
-### `checkKeyExistsInObject`
+### `check_key_exists_in_object`
 
 Checks if a given key exists in an object.
 
@@ -88,8 +88,8 @@ Checks if a given key exists in an object.
 > `key in object` syntax.
 
 ```ts
-checkKeyExistsInObject({ a: 1, b: 2 }, "a"); // true, The key 'a' exists in the object
-checkKeyExistsInObject({ a: 1, b: 2 }, "c"); // false
+check_key_exists_in_object({ a: 1, b: 2 }, "a"); // true, The key 'a' exists in the object
+check_key_exists_in_object({ a: 1, b: 2 }, "c"); // false
 ```
 
 ```ts
@@ -98,78 +98,78 @@ type Obj = { a: 1; b: 2 } | { c: 3; d: 4 };
 const obj = {} as Obj;
 
 if ("c" in obj) {
-  obj; // obj type is { c: 3, d: 4 }
+	obj; // obj type is { c: 3, d: 4 }
 }
 
-if (checkKeyExistsInObject(obj, "c")) {
-  obj; // obj type is Obj
+if (check_key_exists_in_object(obj, "c")) {
+	obj; // obj type is Obj
 }
 ```
 
-### `checkKeyDoesNotExistInObject`
+### `check_key_does_not_exist_in_object`
 
 Checks if a given key does not exist in an object.
 
 ```ts
-checkKeyDoesNotExistInObject({ a: 1, b: 2 }, "c"); // true
-checkKeyDoesNotExistInObject({ a: 1, b: 2 }, "a"); // false
+check_key_does_not_exist_in_object({ a: 1, b: 2 }, "c"); // true
+check_key_does_not_exist_in_object({ a: 1, b: 2 }, "a"); // false
 ```
 
-### `checkIsFrozen`
+### `check_is_frozen`
 
 Checks if a given object is frozen.
 
 ```ts
-checkIsFrozen(Object.freeze({ a: 1 })); // true
-checkIsFrozen({ a: 1 }); // false
+check_is_frozen(Object.freeze({ a: 1 })); // true
+check_is_frozen({ a: 1 }); // false
 ```
 
-### `checkIsNotFrozen`
+### `check_is_not_frozen`
 
 Checks if a given object is not frozen.
 
 ```ts
-checkIsNotFrozen({ a: 1 }); // true
-checkIsNotFrozen(Object.freeze({ a: 1 })); // false
+check_is_not_frozen({ a: 1 }); // true
+check_is_not_frozen(Object.freeze({ a: 1 })); // false
 ```
 
-### `checkIsObject`
+### `check_is_object`
 
 Checks if a given value is an object.
 
 ```ts
-checkIsObject({ a: 1 }); // true
+check_is_object({ a: 1 }); // true
 
-checkIsObject(null); // false
-checkIsObject("string"); // false
+check_is_object(null); // false
+check_is_object("string"); // false
 ```
 
-### `checkIsNotObject`
+### `check_is_not_object`
 
 Checks if a given value is not an object.
 
 ```ts
-checkIsNotObject("string"); // true
+check_is_not_object("string"); // true
 
-checkIsNotObject({ a: 1 }); // false
+check_is_not_object({ a: 1 }); // false
 ```
 
-### `checkIsSealed`
+### `check_is_sealed`
 
 Checks if a given object is sealed.
 
 ```ts
-checkIsSealed(Object.seal({ a: 1 })); // true
-checkIsSealed({ a: 1 }); // false
+check_is_sealed(Object.seal({ a: 1 })); // true
+check_is_sealed({ a: 1 }); // false
 ```
 
-### `checkIsNotSealed`
+### `check_is_not_sealed`
 
 Checks if a given object is not sealed.
 
 ```ts
-checkIsNotSealed({ a: 1 }); // true
-checkIsSealed(Object.seal({ a: 1 })); // false
+check_is_not_sealed({ a: 1 }); // true
+check_is_not_sealed(Object.seal({ a: 1 })); // false
 ```
 
 ### Licence

--- a/packages/object/mod.ts
+++ b/packages/object/mod.ts
@@ -1,51 +1,51 @@
 import {
-	check_is_not_object,
-	check_is_object,
+  check_is_not_object,
+  check_is_object,
 } from "./src/checkObject/main.ts";
 import {
-	check_is_empty_object,
-	check_is_not_empty_object,
+  check_is_empty_object,
+  check_is_not_empty_object,
 } from "./src/checkEmptyObject/main.ts";
 import {
-	check_key_does_not_exist_in_object,
-	check_key_exists_in_object,
+  check_key_does_not_exist_in_object,
+  check_key_exists_in_object,
 } from "./src/checkExistKey/main.ts";
 import {
-	check_value_does_not_exist_in_object,
-	check_value_exists_in_object,
+  check_value_does_not_exist_in_object,
+  check_value_exists_in_object,
 } from "./src/checkExistValue/main.ts";
 import {
-	check_is_deep_equal,
-	check_is_not_deep_equal,
+  check_is_deep_equal,
+  check_is_not_deep_equal,
 } from "./src/checkDeepEqual/main.ts";
 import {
-	check_is_frozen,
-	check_is_not_frozen,
+  check_is_frozen,
+  check_is_not_frozen,
 } from "./src/checkFrozen/main.ts";
 import {
-	check_is_not_sealed,
-	check_is_sealed,
+  check_is_not_sealed,
+  check_is_sealed,
 } from "./src/checkSealed/main.ts";
 import {
-	check_is_instace,
-	check_is_not_instance,
+  check_is_instace,
+  check_is_not_instance,
 } from "./src/checkInstance/main.ts";
 
 export {
-	check_is_deep_equal,
-	check_is_empty_object,
-	check_is_frozen,
-	check_is_instace,
-	check_is_not_deep_equal,
-	check_is_not_empty_object,
-	check_is_not_frozen,
-	check_is_not_instance,
-	check_is_not_object,
-	check_is_not_sealed,
-	check_is_object,
-	check_is_sealed,
-	check_key_does_not_exist_in_object,
-	check_key_exists_in_object,
-	check_value_does_not_exist_in_object,
-	check_value_exists_in_object,
+  check_is_deep_equal,
+  check_is_empty_object,
+  check_is_frozen,
+  check_is_instace,
+  check_is_not_deep_equal,
+  check_is_not_empty_object,
+  check_is_not_frozen,
+  check_is_not_instance,
+  check_is_not_object,
+  check_is_not_sealed,
+  check_is_object,
+  check_is_sealed,
+  check_key_does_not_exist_in_object,
+  check_key_exists_in_object,
+  check_value_does_not_exist_in_object,
+  check_value_exists_in_object,
 };

--- a/packages/object/mod.ts
+++ b/packages/object/mod.ts
@@ -1,42 +1,51 @@
-import { checkIsNotObject, checkIsObject } from "./src/checkObject/main.ts";
 import {
-  checkIsEmptyObject,
-  checkIsNotEmptyObject,
+	check_is_not_object,
+	check_is_object,
+} from "./src/checkObject/main.ts";
+import {
+	check_is_empty_object,
+	check_is_not_empty_object,
 } from "./src/checkEmptyObject/main.ts";
 import {
-  checkKeyDoesNotExistInObject,
-  checkKeyExistsInObject,
+	check_key_does_not_exist_in_object,
+	check_key_exists_in_object,
 } from "./src/checkExistKey/main.ts";
 import {
-  checkValueDoesNotExistInObject,
-  checkValueExistsInObject,
+	check_value_does_not_exist_in_object,
+	check_value_exists_in_object,
 } from "./src/checkExistValue/main.ts";
 import {
-  checkIsDeepEqual,
-  checkIsNotDeepEqual,
+	check_is_deep_equal,
+	check_is_not_deep_equal,
 } from "./src/checkDeepEqual/main.ts";
-import { checkIsFrozen, checkIsNotFrozen } from "./src/checkFrozen/main.ts";
-import { checkIsNotSealed, checkIsSealed } from "./src/checkSealed/main.ts";
 import {
-  checkIsInstance,
-  checkIsNotInstance,
+	check_is_frozen,
+	check_is_not_frozen,
+} from "./src/checkFrozen/main.ts";
+import {
+	check_is_not_sealed,
+	check_is_sealed,
+} from "./src/checkSealed/main.ts";
+import {
+	check_is_instace,
+	check_is_not_instance,
 } from "./src/checkInstance/main.ts";
 
 export {
-  checkIsDeepEqual,
-  checkIsEmptyObject,
-  checkIsFrozen,
-  checkIsInstance,
-  checkIsNotDeepEqual,
-  checkIsNotEmptyObject,
-  checkIsNotFrozen,
-  checkIsNotInstance,
-  checkIsNotObject,
-  checkIsNotSealed,
-  checkIsObject,
-  checkIsSealed,
-  checkKeyDoesNotExistInObject,
-  checkKeyExistsInObject,
-  checkValueDoesNotExistInObject,
-  checkValueExistsInObject,
+	check_is_deep_equal,
+	check_is_empty_object,
+	check_is_frozen,
+	check_is_instace,
+	check_is_not_deep_equal,
+	check_is_not_empty_object,
+	check_is_not_frozen,
+	check_is_not_instance,
+	check_is_not_object,
+	check_is_not_sealed,
+	check_is_object,
+	check_is_sealed,
+	check_key_does_not_exist_in_object,
+	check_key_exists_in_object,
+	check_value_does_not_exist_in_object,
+	check_value_exists_in_object,
 };

--- a/packages/object/src/checkDeepEqual/main.ts
+++ b/packages/object/src/checkDeepEqual/main.ts
@@ -11,23 +11,23 @@
  *
  * @example
  * // Returns true
- * checkIsDeepEqual({ a: 1, b: 2 }, { a: 1, b: 2 }); // The objects have the same structure and values
+ * check_is_deep_equal({ a: 1, b: 2 }, { a: 1, b: 2 }); // The objects have the same structure and values
  *
  * @example
  * // Returns false
- * checkIsDeepEqual({ a: 1, b: 2 }, { a: 2, b: 3 }); // The objects have different values
+ * check_is_deep_equal({ a: 1, b: 2 }, { a: 2, b: 3 }); // The objects have different values
  */
-export const checkIsDeepEqual = <T1 extends object, T2 extends T1>(
-  obj1: T1,
-  obj2: T2,
+export const check_is_deep_equal = <T1 extends object, T2 extends T1>(
+	obj1: T1,
+	obj2: T2
 ): obj1 is T2 => {
-  return JSON.stringify(obj1) === JSON.stringify(obj2);
+	return JSON.stringify(obj1) === JSON.stringify(obj2);
 };
 
 /**
  * Checks if two objects are not deeply equal.
  *
- * This is the inverse of `checkIsDeepEqual`.
+ * This is the inverse of `check_is_deep_equal`.
  *
  * @param {object} obj1 - The first object to compare.
  * @param {object} obj2 - The second object to compare.
@@ -35,12 +35,15 @@ export const checkIsDeepEqual = <T1 extends object, T2 extends T1>(
  *
  * @example
  * // Returns true
- * checkIsNotDeepEqual({ a: 1, b: 2 }, { a: 2, b: 3 }); // The objects have different values
+ * check_is_not_deep_equal({ a: 1, b: 2 }, { a: 2, b: 3 }); // The objects have different values
  *
  * @example
  * // Returns false
- * checkIsNotDeepEqual({ a: 1, b: 2 }, { a: 1, b: 2 }); // The objects have the same structure and values
+ * check_is_not_deep_equal({ a: 1, b: 2 }, { a: 1, b: 2 }); // The objects have the same structure and values
  */
-export const checkIsNotDeepEqual = (obj1: object, obj2: object): boolean => {
-  return !checkIsDeepEqual(obj1, obj2);
+export const check_is_not_deep_equal = (
+	obj1: object,
+	obj2: object
+): boolean => {
+	return !check_is_deep_equal(obj1, obj2);
 };

--- a/packages/object/src/checkDeepEqual/main.ts
+++ b/packages/object/src/checkDeepEqual/main.ts
@@ -18,10 +18,10 @@
  * check_is_deep_equal({ a: 1, b: 2 }, { a: 2, b: 3 }); // The objects have different values
  */
 export const check_is_deep_equal = <T1 extends object, T2 extends T1>(
-	obj1: T1,
-	obj2: T2
+  obj1: T1,
+  obj2: T2,
 ): obj1 is T2 => {
-	return JSON.stringify(obj1) === JSON.stringify(obj2);
+  return JSON.stringify(obj1) === JSON.stringify(obj2);
 };
 
 /**
@@ -42,8 +42,8 @@ export const check_is_deep_equal = <T1 extends object, T2 extends T1>(
  * check_is_not_deep_equal({ a: 1, b: 2 }, { a: 1, b: 2 }); // The objects have the same structure and values
  */
 export const check_is_not_deep_equal = (
-	obj1: object,
-	obj2: object
+  obj1: object,
+  obj2: object,
 ): boolean => {
-	return !check_is_deep_equal(obj1, obj2);
+  return !check_is_deep_equal(obj1, obj2);
 };

--- a/packages/object/src/checkDeepEqual/test.ts
+++ b/packages/object/src/checkDeepEqual/test.ts
@@ -2,50 +2,50 @@ import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import { check_is_deep_equal, check_is_not_deep_equal } from "./main.ts";
 
 Deno.test("check_is_deep_equal", async (t) => {
-	await t.step("should return true for deeply equal objects", () => {
-		assertEquals(check_is_deep_equal({ a: 1, b: 2 }, { a: 1, b: 2 }), true);
-		assertEquals(check_is_deep_equal({}, {}), true); // Empty objects
-	});
+  await t.step("should return true for deeply equal objects", () => {
+    assertEquals(check_is_deep_equal({ a: 1, b: 2 }, { a: 1, b: 2 }), true);
+    assertEquals(check_is_deep_equal({}, {}), true); // Empty objects
+  });
 
-	await t.step("should return false for objects with different values", () => {
-		assertEquals(check_is_deep_equal({ a: 1, b: 2 }, { a: 1, b: 3 }), false);
-		assertEquals(check_is_deep_equal({ a: 1 }, { a: 1, b: 2 }), false); // Different keys
-	});
+  await t.step("should return false for objects with different values", () => {
+    assertEquals(check_is_deep_equal({ a: 1, b: 2 }, { a: 1, b: 3 }), false);
+    assertEquals(check_is_deep_equal({ a: 1 }, { a: 1, b: 2 }), false); // Different keys
+  });
 
-	await t.step(
-		"should return false for objects with different key order",
-		() => {
-			assertEquals(check_is_deep_equal({ a: 1, b: 2 }, { b: 2, a: 1 }), false); // Different key order
-		}
-	);
+  await t.step(
+    "should return false for objects with different key order",
+    () => {
+      assertEquals(check_is_deep_equal({ a: 1, b: 2 }, { b: 2, a: 1 }), false); // Different key order
+    },
+  );
 
-	await t.step("should obj1 type narrow obj2 type", () => {
-		const obj1: Record<string, unknown> = { a: 1, b: 2 };
-		const obj2: Record<string, boolean> = { c: true, d: false };
+  await t.step("should obj1 type narrow obj2 type", () => {
+    const obj1: Record<string, unknown> = { a: 1, b: 2 };
+    const obj2: Record<string, boolean> = { c: true, d: false };
 
-		if (check_is_deep_equal(obj1, obj2)) {
-			assertType<IsExact<typeof obj1, typeof obj2>>(true);
-		}
-	});
+    if (check_is_deep_equal(obj1, obj2)) {
+      assertType<IsExact<typeof obj1, typeof obj2>>(true);
+    }
+  });
 });
 
 Deno.test("check_is_not_deep_equal", async (t) => {
-	await t.step(
-		"should return true for objects that are not deeply equal",
-		() => {
-			assertEquals(
-				check_is_not_deep_equal({ a: 1, b: 2 }, { a: 1, b: 3 }),
-				true
-			);
-			assertEquals(check_is_not_deep_equal({ a: 1 }, { a: 1, b: 2 }), true); // Different keys
-		}
-	);
+  await t.step(
+    "should return true for objects that are not deeply equal",
+    () => {
+      assertEquals(
+        check_is_not_deep_equal({ a: 1, b: 2 }, { a: 1, b: 3 }),
+        true,
+      );
+      assertEquals(check_is_not_deep_equal({ a: 1 }, { a: 1, b: 2 }), true); // Different keys
+    },
+  );
 
-	await t.step("should return false for deeply equal objects", () => {
-		assertEquals(
-			check_is_not_deep_equal({ a: 1, b: 2 }, { a: 1, b: 2 }),
-			false
-		);
-		assertEquals(check_is_not_deep_equal({}, {}), false); // Empty objects
-	});
+  await t.step("should return false for deeply equal objects", () => {
+    assertEquals(
+      check_is_not_deep_equal({ a: 1, b: 2 }, { a: 1, b: 2 }),
+      false,
+    );
+    assertEquals(check_is_not_deep_equal({}, {}), false); // Empty objects
+  });
 });

--- a/packages/object/src/checkDeepEqual/test.ts
+++ b/packages/object/src/checkDeepEqual/test.ts
@@ -1,45 +1,51 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkIsDeepEqual, checkIsNotDeepEqual } from "./main.ts";
+import { check_is_deep_equal, check_is_not_deep_equal } from "./main.ts";
 
-Deno.test("checkIsDeepEqual", async (t) => {
-  await t.step("should return true for deeply equal objects", () => {
-    assertEquals(checkIsDeepEqual({ a: 1, b: 2 }, { a: 1, b: 2 }), true);
-    assertEquals(checkIsDeepEqual({}, {}), true); // Empty objects
-  });
+Deno.test("check_is_deep_equal", async (t) => {
+	await t.step("should return true for deeply equal objects", () => {
+		assertEquals(check_is_deep_equal({ a: 1, b: 2 }, { a: 1, b: 2 }), true);
+		assertEquals(check_is_deep_equal({}, {}), true); // Empty objects
+	});
 
-  await t.step("should return false for objects with different values", () => {
-    assertEquals(checkIsDeepEqual({ a: 1, b: 2 }, { a: 1, b: 3 }), false);
-    assertEquals(checkIsDeepEqual({ a: 1 }, { a: 1, b: 2 }), false); // Different keys
-  });
+	await t.step("should return false for objects with different values", () => {
+		assertEquals(check_is_deep_equal({ a: 1, b: 2 }, { a: 1, b: 3 }), false);
+		assertEquals(check_is_deep_equal({ a: 1 }, { a: 1, b: 2 }), false); // Different keys
+	});
 
-  await t.step(
-    "should return false for objects with different key order",
-    () => {
-      assertEquals(checkIsDeepEqual({ a: 1, b: 2 }, { b: 2, a: 1 }), false); // Different key order
-    },
-  );
+	await t.step(
+		"should return false for objects with different key order",
+		() => {
+			assertEquals(check_is_deep_equal({ a: 1, b: 2 }, { b: 2, a: 1 }), false); // Different key order
+		}
+	);
 
-  await t.step("should obj1 type narrow obj2 type", () => {
-    const obj1: Record<string, unknown> = { a: 1, b: 2 };
-    const obj2: Record<string, boolean> = { c: true, d: false };
+	await t.step("should obj1 type narrow obj2 type", () => {
+		const obj1: Record<string, unknown> = { a: 1, b: 2 };
+		const obj2: Record<string, boolean> = { c: true, d: false };
 
-    if (checkIsDeepEqual(obj1, obj2)) {
-      assertType<IsExact<typeof obj1, typeof obj2>>(true);
-    }
-  });
+		if (check_is_deep_equal(obj1, obj2)) {
+			assertType<IsExact<typeof obj1, typeof obj2>>(true);
+		}
+	});
 });
 
-Deno.test("checkIsNotDeepEqual", async (t) => {
-  await t.step(
-    "should return true for objects that are not deeply equal",
-    () => {
-      assertEquals(checkIsNotDeepEqual({ a: 1, b: 2 }, { a: 1, b: 3 }), true);
-      assertEquals(checkIsNotDeepEqual({ a: 1 }, { a: 1, b: 2 }), true); // Different keys
-    },
-  );
+Deno.test("check_is_not_deep_equal", async (t) => {
+	await t.step(
+		"should return true for objects that are not deeply equal",
+		() => {
+			assertEquals(
+				check_is_not_deep_equal({ a: 1, b: 2 }, { a: 1, b: 3 }),
+				true
+			);
+			assertEquals(check_is_not_deep_equal({ a: 1 }, { a: 1, b: 2 }), true); // Different keys
+		}
+	);
 
-  await t.step("should return false for deeply equal objects", () => {
-    assertEquals(checkIsNotDeepEqual({ a: 1, b: 2 }, { a: 1, b: 2 }), false);
-    assertEquals(checkIsNotDeepEqual({}, {}), false); // Empty objects
-  });
+	await t.step("should return false for deeply equal objects", () => {
+		assertEquals(
+			check_is_not_deep_equal({ a: 1, b: 2 }, { a: 1, b: 2 }),
+			false
+		);
+		assertEquals(check_is_not_deep_equal({}, {}), false); // Empty objects
+	});
 });

--- a/packages/object/src/checkEmptyObject/main.ts
+++ b/packages/object/src/checkEmptyObject/main.ts
@@ -23,12 +23,12 @@ import type { EmptyObject } from "../types.ts";
  * check_is_empty_object(new Date()); // A Date instance is not a plain object
  */
 export const check_is_empty_object = (obj: object): obj is EmptyObject => {
-	// Check if the object is a plain object
-	// This was added because new Date() objects were returning true
-	if (Object.prototype.toString.call(obj) !== "[object Object]") {
-		return false;
-	}
-	return Object.keys(obj).length === 0;
+  // Check if the object is a plain object
+  // This was added because new Date() objects were returning true
+  if (Object.prototype.toString.call(obj) !== "[object Object]") {
+    return false;
+  }
+  return Object.keys(obj).length === 0;
 };
 
 /**
@@ -52,7 +52,7 @@ export const check_is_empty_object = (obj: object): obj is EmptyObject => {
  * check_is_not_empty_object(new Date()); // A Date instance is not a plain object
  */
 export const check_is_not_empty_object = <T extends object>(
-	obj: T
+  obj: T,
 ): obj is Exclude<T, EmptyObject> => {
-	return !check_is_empty_object(obj);
+  return !check_is_empty_object(obj);
 };

--- a/packages/object/src/checkEmptyObject/main.ts
+++ b/packages/object/src/checkEmptyObject/main.ts
@@ -12,47 +12,47 @@ import type { EmptyObject } from "../types.ts";
  *
  * @example
  * // Returns true
- * checkIsEmptyObject({}); // The object has no properties
+ * check_is_empty_object({}); // The object has no properties
  *
  * @example
  * // Returns false
- * checkIsEmptyObject({ key: 'value' }); // The object has a property
+ * check_is_empty_object({ key: 'value' }); // The object has a property
  *
  * @example
  * // Returns false
- * checkIsEmptyObject(new Date()); // A Date instance is not a plain object
+ * check_is_empty_object(new Date()); // A Date instance is not a plain object
  */
-export const checkIsEmptyObject = (obj: object): obj is EmptyObject => {
-  // Check if the object is a plain object
-  // This was added because new Date() objects were returning true
-  if (Object.prototype.toString.call(obj) !== "[object Object]") {
-    return false;
-  }
-  return Object.keys(obj).length === 0;
+export const check_is_empty_object = (obj: object): obj is EmptyObject => {
+	// Check if the object is a plain object
+	// This was added because new Date() objects were returning true
+	if (Object.prototype.toString.call(obj) !== "[object Object]") {
+		return false;
+	}
+	return Object.keys(obj).length === 0;
 };
 
 /**
  * Checks if a given object is not an empty plain object.
  *
- * This is the inverse of `checkIsEmptyObject`.
+ * This is the inverse of `check_is_empty_object`.
  *
  * @param {T extends object} obj - The object to check.
  * @returns {obj is Exclude<T, EmptyObject>} True if the object is not an empty plain object, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotEmptyObject({ key: 'value' }); // The object has a property
+ * check_is_not_empty_object({ key: 'value' }); // The object has a property
  *
  * @example
  * // Returns false
- * checkIsNotEmptyObject({}); // The object has no properties
+ * check_is_not_empty_object({}); // The object has no properties
  *
  * @example
  * // Returns true
- * checkIsNotEmptyObject(new Date()); // A Date instance is not a plain object
+ * check_is_not_empty_object(new Date()); // A Date instance is not a plain object
  */
-export const checkIsNotEmptyObject = <T extends object>(
-  obj: T,
+export const check_is_not_empty_object = <T extends object>(
+	obj: T
 ): obj is Exclude<T, EmptyObject> => {
-  return !checkIsEmptyObject(obj);
+	return !check_is_empty_object(obj);
 };

--- a/packages/object/src/checkEmptyObject/test.ts
+++ b/packages/object/src/checkEmptyObject/test.ts
@@ -3,40 +3,40 @@ import type { EmptyObject } from "../types.ts";
 import { check_is_empty_object, check_is_not_empty_object } from "./main.ts";
 
 Deno.test("check_is_empty_object", async (t) => {
-	await t.step("should return true for empty objects", () => {
-		assertEquals(check_is_empty_object({}), true); // Regular empty object
-		assertEquals(check_is_empty_object(Object.create(null)), true); // Object with no prototype
-	});
+  await t.step("should return true for empty objects", () => {
+    assertEquals(check_is_empty_object({}), true); // Regular empty object
+    assertEquals(check_is_empty_object(Object.create(null)), true); // Object with no prototype
+  });
 
-	await t.step("should return false for non-empty objects", () => {
-		assertEquals(check_is_empty_object({ key: "value" }), false); // Object with a key-value pair
-		assertEquals(check_is_empty_object({ a: 1 }), false); // Another non-empty object
-		assertEquals(check_is_empty_object(new Date()), false); // Date instance, considered non-empty
-	});
+  await t.step("should return false for non-empty objects", () => {
+    assertEquals(check_is_empty_object({ key: "value" }), false); // Object with a key-value pair
+    assertEquals(check_is_empty_object({ a: 1 }), false); // Another non-empty object
+    assertEquals(check_is_empty_object(new Date()), false); // Date instance, considered non-empty
+  });
 
-	await t.step("should narrow non-empty object type", () => {
-		const value: object = {};
-		if (check_is_empty_object(value)) {
-			assertType<IsExact<typeof value, EmptyObject>>(true);
-		}
-	});
+  await t.step("should narrow non-empty object type", () => {
+    const value: object = {};
+    if (check_is_empty_object(value)) {
+      assertType<IsExact<typeof value, EmptyObject>>(true);
+    }
+  });
 });
 
 Deno.test("check_is_not_empty_object", async (t) => {
-	await t.step("should return true for non-empty objects", () => {
-		assertEquals(check_is_not_empty_object({ key: "value" }), true); // Object with a key-value pair
-		assertEquals(check_is_not_empty_object({ a: 1 }), true); // Another non-empty object
-		assertEquals(check_is_not_empty_object(new Date()), true); // Date instance, considered non-empty
-	});
+  await t.step("should return true for non-empty objects", () => {
+    assertEquals(check_is_not_empty_object({ key: "value" }), true); // Object with a key-value pair
+    assertEquals(check_is_not_empty_object({ a: 1 }), true); // Another non-empty object
+    assertEquals(check_is_not_empty_object(new Date()), true); // Date instance, considered non-empty
+  });
 
-	await t.step("should return false for empty objects", () => {
-		assertEquals(check_is_not_empty_object({}), false); // Regular empty object
-		assertEquals(check_is_not_empty_object(Object.create(null)), false); // Object with no prototype
-	});
+  await t.step("should return false for empty objects", () => {
+    assertEquals(check_is_not_empty_object({}), false); // Regular empty object
+    assertEquals(check_is_not_empty_object(Object.create(null)), false); // Object with no prototype
+  });
 
-	await t.step("should exclude non-empty object", () => {
-		type Value = Record<string, string> | EmptyObject;
-		const value = {} as Value;
-		assertType<IsExact<typeof value, Record<string, string>>>(true);
-	});
+  await t.step("should exclude non-empty object", () => {
+    type Value = Record<string, string> | EmptyObject;
+    const value = {} as Value;
+    assertType<IsExact<typeof value, Record<string, string>>>(true);
+  });
 });

--- a/packages/object/src/checkEmptyObject/test.ts
+++ b/packages/object/src/checkEmptyObject/test.ts
@@ -1,42 +1,42 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import type { EmptyObject } from "../types.ts";
-import { checkIsEmptyObject, checkIsNotEmptyObject } from "./main.ts";
+import { check_is_empty_object, check_is_not_empty_object } from "./main.ts";
 
-Deno.test("checkIsEmptyObject", async (t) => {
-  await t.step("should return true for empty objects", () => {
-    assertEquals(checkIsEmptyObject({}), true); // Regular empty object
-    assertEquals(checkIsEmptyObject(Object.create(null)), true); // Object with no prototype
-  });
+Deno.test("check_is_empty_object", async (t) => {
+	await t.step("should return true for empty objects", () => {
+		assertEquals(check_is_empty_object({}), true); // Regular empty object
+		assertEquals(check_is_empty_object(Object.create(null)), true); // Object with no prototype
+	});
 
-  await t.step("should return false for non-empty objects", () => {
-    assertEquals(checkIsEmptyObject({ key: "value" }), false); // Object with a key-value pair
-    assertEquals(checkIsEmptyObject({ a: 1 }), false); // Another non-empty object
-    assertEquals(checkIsEmptyObject(new Date()), false); // Date instance, considered non-empty
-  });
+	await t.step("should return false for non-empty objects", () => {
+		assertEquals(check_is_empty_object({ key: "value" }), false); // Object with a key-value pair
+		assertEquals(check_is_empty_object({ a: 1 }), false); // Another non-empty object
+		assertEquals(check_is_empty_object(new Date()), false); // Date instance, considered non-empty
+	});
 
-  await t.step("should narrow non-empty object type", () => {
-    const value: object = {};
-    if (checkIsEmptyObject(value)) {
-      assertType<IsExact<typeof value, EmptyObject>>(true);
-    }
-  });
+	await t.step("should narrow non-empty object type", () => {
+		const value: object = {};
+		if (check_is_empty_object(value)) {
+			assertType<IsExact<typeof value, EmptyObject>>(true);
+		}
+	});
 });
 
-Deno.test("checkIsNotEmptyObject", async (t) => {
-  await t.step("should return true for non-empty objects", () => {
-    assertEquals(checkIsNotEmptyObject({ key: "value" }), true); // Object with a key-value pair
-    assertEquals(checkIsNotEmptyObject({ a: 1 }), true); // Another non-empty object
-    assertEquals(checkIsNotEmptyObject(new Date()), true); // Date instance, considered non-empty
-  });
+Deno.test("check_is_not_empty_object", async (t) => {
+	await t.step("should return true for non-empty objects", () => {
+		assertEquals(check_is_not_empty_object({ key: "value" }), true); // Object with a key-value pair
+		assertEquals(check_is_not_empty_object({ a: 1 }), true); // Another non-empty object
+		assertEquals(check_is_not_empty_object(new Date()), true); // Date instance, considered non-empty
+	});
 
-  await t.step("should return false for empty objects", () => {
-    assertEquals(checkIsNotEmptyObject({}), false); // Regular empty object
-    assertEquals(checkIsNotEmptyObject(Object.create(null)), false); // Object with no prototype
-  });
+	await t.step("should return false for empty objects", () => {
+		assertEquals(check_is_not_empty_object({}), false); // Regular empty object
+		assertEquals(check_is_not_empty_object(Object.create(null)), false); // Object with no prototype
+	});
 
-  await t.step("should exclude non-empty object", () => {
-    type Value = Record<string, string> | EmptyObject;
-    const value = {} as Value;
-    assertType<IsExact<typeof value, Record<string, string>>>(true);
-  });
+	await t.step("should exclude non-empty object", () => {
+		type Value = Record<string, string> | EmptyObject;
+		const value = {} as Value;
+		assertType<IsExact<typeof value, Record<string, string>>>(true);
+	});
 });

--- a/packages/object/src/checkExistKey/main.ts
+++ b/packages/object/src/checkExistKey/main.ts
@@ -9,23 +9,23 @@
  *
  * @example
  * // Returns true
- * checkKeyExistsInObject({a: 1, b: 2}, 'a'); // The key 'a' exists in the object
+ * check_key_exists_in_object({a: 1, b: 2}, 'a'); // The key 'a' exists in the object
  *
  * @example
  * // Returns false
- * checkKeyExistsInObject({a: 1, b: 2}, 'c'); // The key 'c' does not exist in the object
+ * check_key_exists_in_object({a: 1, b: 2}, 'c'); // The key 'c' does not exist in the object
  */
-export const checkKeyExistsInObject = (
-  obj: object,
-  key: PropertyKey,
+export const check_key_exists_in_object = (
+	obj: object,
+	key: PropertyKey
 ): boolean => {
-  return key in obj;
+	return key in obj;
 };
 
 /**
  * Checks if a given key does not exist in an object.
  *
- * This is the inverse of `checkKeyExistsInObject`.
+ * This is the inverse of `check_key_exists_in_object`.
  *
  * @param {object} obj - The object to check.
  * @param {PropertyKey} key - The key to check for in the object.
@@ -33,15 +33,15 @@ export const checkKeyExistsInObject = (
  *
  * @example
  * // Returns true
- * checkKeyDoesNotExistInObject({a: 1, b: 2}, 'c'); // The key 'c' does not exist in the object
+ * check_key_does_not_exist_in_object({a: 1, b: 2}, 'c'); // The key 'c' does not exist in the object
  *
  * @example
  * // Returns false
- * checkKeyDoesNotExistInObject({a: 1, b: 2}, 'a'); // The key 'a' exists in the object
+ * check_key_does_not_exist_in_object({a: 1, b: 2}, 'a'); // The key 'a' exists in the object
  */
-export const checkKeyDoesNotExistInObject = (
-  obj: object,
-  key: PropertyKey,
+export const check_key_does_not_exist_in_object = (
+	obj: object,
+	key: PropertyKey
 ): boolean => {
-  return !checkKeyExistsInObject(obj, key);
+	return !check_key_exists_in_object(obj, key);
 };

--- a/packages/object/src/checkExistKey/main.ts
+++ b/packages/object/src/checkExistKey/main.ts
@@ -16,10 +16,10 @@
  * check_key_exists_in_object({a: 1, b: 2}, 'c'); // The key 'c' does not exist in the object
  */
 export const check_key_exists_in_object = (
-	obj: object,
-	key: PropertyKey
+  obj: object,
+  key: PropertyKey,
 ): boolean => {
-	return key in obj;
+  return key in obj;
 };
 
 /**
@@ -40,8 +40,8 @@ export const check_key_exists_in_object = (
  * check_key_does_not_exist_in_object({a: 1, b: 2}, 'a'); // The key 'a' exists in the object
  */
 export const check_key_does_not_exist_in_object = (
-	obj: object,
-	key: PropertyKey
+  obj: object,
+  key: PropertyKey,
 ): boolean => {
-	return !check_key_exists_in_object(obj, key);
+  return !check_key_exists_in_object(obj, key);
 };

--- a/packages/object/src/checkExistKey/test.ts
+++ b/packages/object/src/checkExistKey/test.ts
@@ -1,54 +1,54 @@
 import { assertEquals } from "../../deps.ts";
 import {
-	check_key_does_not_exist_in_object,
-	check_key_exists_in_object,
+  check_key_does_not_exist_in_object,
+  check_key_exists_in_object,
 } from "./main.ts";
 
 Deno.test("check_key_exists_in_object", async (t) => {
-	await t.step("should return true if object has the key", () => {
-		assertEquals(check_key_exists_in_object({ key: "value" }, "key"), true);
-		assertEquals(check_key_exists_in_object({ a: 1, b: 2 }, "b"), true);
-	});
+  await t.step("should return true if object has the key", () => {
+    assertEquals(check_key_exists_in_object({ key: "value" }, "key"), true);
+    assertEquals(check_key_exists_in_object({ a: 1, b: 2 }, "b"), true);
+  });
 
-	await t.step("should return false if object does not have the key", () => {
-		assertEquals(
-			check_key_exists_in_object({ key: "value" }, "nonExistentKey"),
-			false
-		);
-		assertEquals(check_key_exists_in_object({}, "anyKey"), false); // Empty object
-	});
+  await t.step("should return false if object does not have the key", () => {
+    assertEquals(
+      check_key_exists_in_object({ key: "value" }, "nonExistentKey"),
+      false,
+    );
+    assertEquals(check_key_exists_in_object({}, "anyKey"), false); // Empty object
+  });
 
-	await t.step("should return true for inherited keys", () => {
-		const obj = Object.create({ inheritedKey: "value" });
-		assertEquals(check_key_exists_in_object(obj, "inheritedKey"), true); // Inherited key
-	});
+  await t.step("should return true for inherited keys", () => {
+    const obj = Object.create({ inheritedKey: "value" });
+    assertEquals(check_key_exists_in_object(obj, "inheritedKey"), true); // Inherited key
+  });
 });
 
 Deno.test("check_key_does_not_exist_in_object", async (t) => {
-	await t.step("should return true if object does not have the key", () => {
-		assertEquals(
-			check_key_does_not_exist_in_object({ key: "value" }, "nonExistentKey"),
-			true
-		);
-		assertEquals(check_key_does_not_exist_in_object({}, "anyKey"), true); // Empty object
-	});
+  await t.step("should return true if object does not have the key", () => {
+    assertEquals(
+      check_key_does_not_exist_in_object({ key: "value" }, "nonExistentKey"),
+      true,
+    );
+    assertEquals(check_key_does_not_exist_in_object({}, "anyKey"), true); // Empty object
+  });
 
-	await t.step("should return false if object has the key", () => {
-		assertEquals(
-			check_key_does_not_exist_in_object({ key: "value" }, "key"),
-			false
-		);
-		assertEquals(
-			check_key_does_not_exist_in_object({ a: 1, b: 2 }, "a"),
-			false
-		);
-	});
+  await t.step("should return false if object has the key", () => {
+    assertEquals(
+      check_key_does_not_exist_in_object({ key: "value" }, "key"),
+      false,
+    );
+    assertEquals(
+      check_key_does_not_exist_in_object({ a: 1, b: 2 }, "a"),
+      false,
+    );
+  });
 
-	await t.step("should return false for inherited keys", () => {
-		const obj = Object.create({ inheritedKey: "value" });
-		assertEquals(
-			check_key_does_not_exist_in_object(obj, "inheritedKey"),
-			false
-		); // Inherited key
-	});
+  await t.step("should return false for inherited keys", () => {
+    const obj = Object.create({ inheritedKey: "value" });
+    assertEquals(
+      check_key_does_not_exist_in_object(obj, "inheritedKey"),
+      false,
+    ); // Inherited key
+  });
 });

--- a/packages/object/src/checkExistKey/test.ts
+++ b/packages/object/src/checkExistKey/test.ts
@@ -1,45 +1,54 @@
 import { assertEquals } from "../../deps.ts";
 import {
-  checkKeyDoesNotExistInObject,
-  checkKeyExistsInObject,
+	check_key_does_not_exist_in_object,
+	check_key_exists_in_object,
 } from "./main.ts";
 
-Deno.test("checkHasKey", async (t) => {
-  await t.step("should return true if object has the key", () => {
-    assertEquals(checkKeyExistsInObject({ key: "value" }, "key"), true);
-    assertEquals(checkKeyExistsInObject({ a: 1, b: 2 }, "b"), true);
-  });
+Deno.test("check_key_exists_in_object", async (t) => {
+	await t.step("should return true if object has the key", () => {
+		assertEquals(check_key_exists_in_object({ key: "value" }, "key"), true);
+		assertEquals(check_key_exists_in_object({ a: 1, b: 2 }, "b"), true);
+	});
 
-  await t.step("should return false if object does not have the key", () => {
-    assertEquals(
-      checkKeyExistsInObject({ key: "value" }, "nonExistentKey"),
-      false,
-    );
-    assertEquals(checkKeyExistsInObject({}, "anyKey"), false); // Empty object
-  });
+	await t.step("should return false if object does not have the key", () => {
+		assertEquals(
+			check_key_exists_in_object({ key: "value" }, "nonExistentKey"),
+			false
+		);
+		assertEquals(check_key_exists_in_object({}, "anyKey"), false); // Empty object
+	});
 
-  await t.step("should return true for inherited keys", () => {
-    const obj = Object.create({ inheritedKey: "value" });
-    assertEquals(checkKeyExistsInObject(obj, "inheritedKey"), true); // Inherited key
-  });
+	await t.step("should return true for inherited keys", () => {
+		const obj = Object.create({ inheritedKey: "value" });
+		assertEquals(check_key_exists_in_object(obj, "inheritedKey"), true); // Inherited key
+	});
 });
 
-Deno.test("checkNotHaveKey", async (t) => {
-  await t.step("should return true if object does not have the key", () => {
-    assertEquals(
-      checkKeyDoesNotExistInObject({ key: "value" }, "nonExistentKey"),
-      true,
-    );
-    assertEquals(checkKeyDoesNotExistInObject({}, "anyKey"), true); // Empty object
-  });
+Deno.test("check_key_does_not_exist_in_object", async (t) => {
+	await t.step("should return true if object does not have the key", () => {
+		assertEquals(
+			check_key_does_not_exist_in_object({ key: "value" }, "nonExistentKey"),
+			true
+		);
+		assertEquals(check_key_does_not_exist_in_object({}, "anyKey"), true); // Empty object
+	});
 
-  await t.step("should return false if object has the key", () => {
-    assertEquals(checkKeyDoesNotExistInObject({ key: "value" }, "key"), false);
-    assertEquals(checkKeyDoesNotExistInObject({ a: 1, b: 2 }, "a"), false);
-  });
+	await t.step("should return false if object has the key", () => {
+		assertEquals(
+			check_key_does_not_exist_in_object({ key: "value" }, "key"),
+			false
+		);
+		assertEquals(
+			check_key_does_not_exist_in_object({ a: 1, b: 2 }, "a"),
+			false
+		);
+	});
 
-  await t.step("should return false for inherited keys", () => {
-    const obj = Object.create({ inheritedKey: "value" });
-    assertEquals(checkKeyDoesNotExistInObject(obj, "inheritedKey"), false); // Inherited key
-  });
+	await t.step("should return false for inherited keys", () => {
+		const obj = Object.create({ inheritedKey: "value" });
+		assertEquals(
+			check_key_does_not_exist_in_object(obj, "inheritedKey"),
+			false
+		); // Inherited key
+	});
 });

--- a/packages/object/src/checkExistValue/main.ts
+++ b/packages/object/src/checkExistValue/main.ts
@@ -1,13 +1,13 @@
-export const checkValueExistsInObject = <T extends object>(
-  obj: T,
-  value: T[keyof T],
+export const check_value_exists_in_object = <T extends object>(
+	obj: T,
+	value: T[keyof T]
 ): boolean => {
-  return Object.values(obj).includes(value);
+	return Object.values(obj).includes(value);
 };
 
-export const checkValueDoesNotExistInObject = <T extends object>(
-  obj: T,
-  value: T[keyof T],
+export const check_value_does_not_exist_in_object = <T extends object>(
+	obj: T,
+	value: T[keyof T]
 ): boolean => {
-  return !checkValueExistsInObject(obj, value);
+	return !check_value_exists_in_object(obj, value);
 };

--- a/packages/object/src/checkExistValue/main.ts
+++ b/packages/object/src/checkExistValue/main.ts
@@ -1,3 +1,20 @@
+/**
+ * Checks if a given value exists in the provided object.
+ *
+ * This function searches the values of the given object to determine if the specified value exists.
+ *
+ * @param {T} obj - The object to search in.
+ * @param {T[keyof T]} value - The value to look for.
+ * @returns {boolean} True if the value exists in the object, otherwise false.
+ *
+ * @example
+ * // Returns true
+ * check_value_exists_in_object({a: 1, b: 2, c: 3}, 2); // 2 is a value in the object
+ *
+ * @example
+ * // Returns false
+ * check_value_exists_in_object({a: 1, b: 2, c: 3}, 4); // 4 is not a value in the object
+ */
 export const check_value_exists_in_object = <T extends object>(
 	obj: T,
 	value: T[keyof T]
@@ -5,6 +22,23 @@ export const check_value_exists_in_object = <T extends object>(
 	return Object.values(obj).includes(value);
 };
 
+/**
+ * Checks if a given value does not exist in the provided object.
+ *
+ * This is the inverse of `check_value_exists_in_object`.
+ *
+ * @param {T} obj - The object to search in.
+ * @param {T[keyof T]} value - The value to check.
+ * @returns {boolean} True if the value does not exist in the object, otherwise false.
+ *
+ * @example
+ * // Returns true
+ * check_value_does_not_exist_in_object({a: 1, b: 2, c: 3}, 4); // 4 is not a value in the object
+ *
+ * @example
+ * // Returns false
+ * check_value_does_not_exist_in_object({a: 1, b: 2, c: 3}, 2); // 2 is a value in the object
+ */
 export const check_value_does_not_exist_in_object = <T extends object>(
 	obj: T,
 	value: T[keyof T]

--- a/packages/object/src/checkExistValue/main.ts
+++ b/packages/object/src/checkExistValue/main.ts
@@ -16,10 +16,10 @@
  * check_value_exists_in_object({a: 1, b: 2, c: 3}, 4); // 4 is not a value in the object
  */
 export const check_value_exists_in_object = <T extends object>(
-	obj: T,
-	value: T[keyof T]
+  obj: T,
+  value: T[keyof T],
 ): boolean => {
-	return Object.values(obj).includes(value);
+  return Object.values(obj).includes(value);
 };
 
 /**
@@ -40,8 +40,8 @@ export const check_value_exists_in_object = <T extends object>(
  * check_value_does_not_exist_in_object({a: 1, b: 2, c: 3}, 2); // 2 is a value in the object
  */
 export const check_value_does_not_exist_in_object = <T extends object>(
-	obj: T,
-	value: T[keyof T]
+  obj: T,
+  value: T[keyof T],
 ): boolean => {
-	return !check_value_exists_in_object(obj, value);
+  return !check_value_exists_in_object(obj, value);
 };

--- a/packages/object/src/checkExistValue/test.ts
+++ b/packages/object/src/checkExistValue/test.ts
@@ -1,46 +1,55 @@
 import { assertEquals } from "../../deps.ts";
 import {
-  checkValueDoesNotExistInObject,
-  checkValueExistsInObject,
+	check_value_does_not_exist_in_object,
+	check_value_exists_in_object,
 } from "./main.ts";
 
-Deno.test("checkObjectHasValue", async (t) => {
-  await t.step("should return true if object has the value", () => {
-    assertEquals(checkValueExistsInObject({ key: "value" }, "value"), true);
-    assertEquals(checkValueExistsInObject({ a: 1, b: 2 }, 2), true);
-  });
+Deno.test("check_value_exists_in_object", async (t) => {
+	await t.step("should return true if object has the value", () => {
+		assertEquals(check_value_exists_in_object({ key: "value" }, "value"), true);
+		assertEquals(check_value_exists_in_object({ a: 1, b: 2 }, 2), true);
+	});
 
-  await t.step("should return false if object does not have the value", () => {
-    assertEquals(
-      checkValueExistsInObject({ key: "value" }, "nonExistentValue"),
-      false,
-    );
-    assertEquals(checkValueExistsInObject({ a: 1, b: 2 }, 3), false);
-  });
+	await t.step("should return false if object does not have the value", () => {
+		assertEquals(
+			check_value_exists_in_object({ key: "value" }, "nonExistentValue"),
+			false
+		);
+		assertEquals(check_value_exists_in_object({ a: 1, b: 2 }, 3), false);
+	});
 
-  await t.step("should handle objects with multiple identical values", () => {
-    assertEquals(checkValueExistsInObject({ a: 1, b: 1 }, 1), true); // Multiple keys with the same value
-  });
+	await t.step("should handle objects with multiple identical values", () => {
+		assertEquals(check_value_exists_in_object({ a: 1, b: 1 }, 1), true); // Multiple keys with the same value
+	});
 });
 
-Deno.test("checkObjectNotHaveValue", async (t) => {
-  await t.step("should return true if object does not have the value", () => {
-    assertEquals(
-      checkValueDoesNotExistInObject({ key: "value" }, "nonExistentValue"),
-      true,
-    );
-    assertEquals(checkValueDoesNotExistInObject({ a: 1, b: 2 }, 3), true);
-  });
+Deno.test("check_value_does_not_exist_in_object", async (t) => {
+	await t.step("should return true if object does not have the value", () => {
+		assertEquals(
+			check_value_does_not_exist_in_object(
+				{ key: "value" },
+				"nonExistentValue"
+			),
+			true
+		);
+		assertEquals(check_value_does_not_exist_in_object({ a: 1, b: 2 }, 3), true);
+	});
 
-  await t.step("should return false if object has the value", () => {
-    assertEquals(
-      checkValueDoesNotExistInObject({ key: "value" }, "value"),
-      false,
-    );
-    assertEquals(checkValueDoesNotExistInObject({ a: 1, b: 2 }, 2), false);
-  });
+	await t.step("should return false if object has the value", () => {
+		assertEquals(
+			check_value_does_not_exist_in_object({ key: "value" }, "value"),
+			false
+		);
+		assertEquals(
+			check_value_does_not_exist_in_object({ a: 1, b: 2 }, 2),
+			false
+		);
+	});
 
-  await t.step("should handle objects with multiple identical values", () => {
-    assertEquals(checkValueDoesNotExistInObject({ a: 1, b: 1 }, 1), false); // Multiple keys with the same value
-  });
+	await t.step("should handle objects with multiple identical values", () => {
+		assertEquals(
+			check_value_does_not_exist_in_object({ a: 1, b: 1 }, 1),
+			false
+		); // Multiple keys with the same value
+	});
 });

--- a/packages/object/src/checkExistValue/test.ts
+++ b/packages/object/src/checkExistValue/test.ts
@@ -1,55 +1,55 @@
 import { assertEquals } from "../../deps.ts";
 import {
-	check_value_does_not_exist_in_object,
-	check_value_exists_in_object,
+  check_value_does_not_exist_in_object,
+  check_value_exists_in_object,
 } from "./main.ts";
 
 Deno.test("check_value_exists_in_object", async (t) => {
-	await t.step("should return true if object has the value", () => {
-		assertEquals(check_value_exists_in_object({ key: "value" }, "value"), true);
-		assertEquals(check_value_exists_in_object({ a: 1, b: 2 }, 2), true);
-	});
+  await t.step("should return true if object has the value", () => {
+    assertEquals(check_value_exists_in_object({ key: "value" }, "value"), true);
+    assertEquals(check_value_exists_in_object({ a: 1, b: 2 }, 2), true);
+  });
 
-	await t.step("should return false if object does not have the value", () => {
-		assertEquals(
-			check_value_exists_in_object({ key: "value" }, "nonExistentValue"),
-			false
-		);
-		assertEquals(check_value_exists_in_object({ a: 1, b: 2 }, 3), false);
-	});
+  await t.step("should return false if object does not have the value", () => {
+    assertEquals(
+      check_value_exists_in_object({ key: "value" }, "nonExistentValue"),
+      false,
+    );
+    assertEquals(check_value_exists_in_object({ a: 1, b: 2 }, 3), false);
+  });
 
-	await t.step("should handle objects with multiple identical values", () => {
-		assertEquals(check_value_exists_in_object({ a: 1, b: 1 }, 1), true); // Multiple keys with the same value
-	});
+  await t.step("should handle objects with multiple identical values", () => {
+    assertEquals(check_value_exists_in_object({ a: 1, b: 1 }, 1), true); // Multiple keys with the same value
+  });
 });
 
 Deno.test("check_value_does_not_exist_in_object", async (t) => {
-	await t.step("should return true if object does not have the value", () => {
-		assertEquals(
-			check_value_does_not_exist_in_object(
-				{ key: "value" },
-				"nonExistentValue"
-			),
-			true
-		);
-		assertEquals(check_value_does_not_exist_in_object({ a: 1, b: 2 }, 3), true);
-	});
+  await t.step("should return true if object does not have the value", () => {
+    assertEquals(
+      check_value_does_not_exist_in_object(
+        { key: "value" },
+        "nonExistentValue",
+      ),
+      true,
+    );
+    assertEquals(check_value_does_not_exist_in_object({ a: 1, b: 2 }, 3), true);
+  });
 
-	await t.step("should return false if object has the value", () => {
-		assertEquals(
-			check_value_does_not_exist_in_object({ key: "value" }, "value"),
-			false
-		);
-		assertEquals(
-			check_value_does_not_exist_in_object({ a: 1, b: 2 }, 2),
-			false
-		);
-	});
+  await t.step("should return false if object has the value", () => {
+    assertEquals(
+      check_value_does_not_exist_in_object({ key: "value" }, "value"),
+      false,
+    );
+    assertEquals(
+      check_value_does_not_exist_in_object({ a: 1, b: 2 }, 2),
+      false,
+    );
+  });
 
-	await t.step("should handle objects with multiple identical values", () => {
-		assertEquals(
-			check_value_does_not_exist_in_object({ a: 1, b: 1 }, 1),
-			false
-		); // Multiple keys with the same value
-	});
+  await t.step("should handle objects with multiple identical values", () => {
+    assertEquals(
+      check_value_does_not_exist_in_object({ a: 1, b: 1 }, 1),
+      false,
+    ); // Multiple keys with the same value
+  });
 });

--- a/packages/object/src/checkFrozen/main.ts
+++ b/packages/object/src/checkFrozen/main.ts
@@ -18,7 +18,7 @@
  * check_is_frozen(regularObj); // The object is not frozen
  */
 export const check_is_frozen = (obj: object): boolean => {
-	return Object.isFrozen(obj);
+  return Object.isFrozen(obj);
 };
 
 /**
@@ -40,5 +40,5 @@ export const check_is_frozen = (obj: object): boolean => {
  * check_is_not_frozen(frozenObj); // The object is frozen
  */
 export const check_is_not_frozen = (obj: object): boolean => {
-	return !check_is_frozen(obj);
+  return !check_is_frozen(obj);
 };

--- a/packages/object/src/checkFrozen/main.ts
+++ b/packages/object/src/checkFrozen/main.ts
@@ -10,21 +10,21 @@
  * @example
  * // Returns true
  * const frozenObj = Object.freeze({ a: 1 });
- * checkIsFrozen(frozenObj); // The object is frozen
+ * check_is_frozen(frozenObj); // The object is frozen
  *
  * @example
  * // Returns false
  * const regularObj = { a: 1 };
- * checkIsFrozen(regularObj); // The object is not frozen
+ * check_is_frozen(regularObj); // The object is not frozen
  */
-export const checkIsFrozen = (obj: object): boolean => {
-  return Object.isFrozen(obj);
+export const check_is_frozen = (obj: object): boolean => {
+	return Object.isFrozen(obj);
 };
 
 /**
  * Checks if a given object is not frozen.
  *
- * This is the inverse of `checkIsFrozen`.
+ * This is the inverse of `check_is_frozen`.
  *
  * @param {object} obj - The object to check.
  * @returns {boolean} True if the object is not frozen, otherwise false.
@@ -32,13 +32,13 @@ export const checkIsFrozen = (obj: object): boolean => {
  * @example
  * // Returns true
  * const regularObj = { a: 1 };
- * checkIsNotFrozen(regularObj); // The object is not frozen
+ * check_is_not_frozen(regularObj); // The object is not frozen
  *
  * @example
  * // Returns false
  * const frozenObj = Object.freeze({ a: 1 });
- * checkIsNotFrozen(frozenObj); // The object is frozen
+ * check_is_not_frozen(frozenObj); // The object is frozen
  */
-export const checkIsNotFrozen = (obj: object): boolean => {
-  return !checkIsFrozen(obj);
+export const check_is_not_frozen = (obj: object): boolean => {
+	return !check_is_frozen(obj);
 };

--- a/packages/object/src/checkFrozen/test.ts
+++ b/packages/object/src/checkFrozen/test.ts
@@ -1,36 +1,36 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsFrozen, checkIsNotFrozen } from "./main.ts";
+import { check_is_frozen, check_is_not_frozen } from "./main.ts";
 
-Deno.test("checkIsFrozen", async (t) => {
-  await t.step("should return true for frozen objects", () => {
-    const frozenObj = Object.freeze({ key: "value" });
-    assertEquals(checkIsFrozen(frozenObj), true);
-  });
+Deno.test("check_is_frozen", async (t) => {
+	await t.step("should return true for frozen objects", () => {
+		const frozenObj = Object.freeze({ key: "value" });
+		assertEquals(check_is_frozen(frozenObj), true);
+	});
 
-  await t.step("should return false for non-frozen objects", () => {
-    const obj = { key: "value" };
-    assertEquals(checkIsFrozen(obj), false);
-  });
+	await t.step("should return false for non-frozen objects", () => {
+		const obj = { key: "value" };
+		assertEquals(check_is_frozen(obj), false);
+	});
 
-  await t.step("should return true for frozen empty objects", () => {
-    const frozenEmptyObj = Object.freeze({});
-    assertEquals(checkIsFrozen(frozenEmptyObj), true); // Frozen empty object
-  });
+	await t.step("should return true for frozen empty objects", () => {
+		const frozenEmptyObj = Object.freeze({});
+		assertEquals(check_is_frozen(frozenEmptyObj), true); // Frozen empty object
+	});
 });
 
-Deno.test("checkIsNotFrozen", async (t) => {
-  await t.step("should return true for non-frozen objects", () => {
-    const obj = { key: "value" };
-    assertEquals(checkIsNotFrozen(obj), true);
-  });
+Deno.test("check_is_not_frozen", async (t) => {
+	await t.step("should return true for non-frozen objects", () => {
+		const obj = { key: "value" };
+		assertEquals(check_is_not_frozen(obj), true);
+	});
 
-  await t.step("should return false for frozen objects", () => {
-    const frozenObj = Object.freeze({ key: "value" });
-    assertEquals(checkIsNotFrozen(frozenObj), false);
-  });
+	await t.step("should return false for frozen objects", () => {
+		const frozenObj = Object.freeze({ key: "value" });
+		assertEquals(check_is_not_frozen(frozenObj), false);
+	});
 
-  await t.step("should return false for frozen empty objects", () => {
-    const frozenEmptyObj = Object.freeze({});
-    assertEquals(checkIsNotFrozen(frozenEmptyObj), false); // Frozen empty object
-  });
+	await t.step("should return false for frozen empty objects", () => {
+		const frozenEmptyObj = Object.freeze({});
+		assertEquals(check_is_not_frozen(frozenEmptyObj), false); // Frozen empty object
+	});
 });

--- a/packages/object/src/checkFrozen/test.ts
+++ b/packages/object/src/checkFrozen/test.ts
@@ -2,35 +2,35 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_frozen, check_is_not_frozen } from "./main.ts";
 
 Deno.test("check_is_frozen", async (t) => {
-	await t.step("should return true for frozen objects", () => {
-		const frozenObj = Object.freeze({ key: "value" });
-		assertEquals(check_is_frozen(frozenObj), true);
-	});
+  await t.step("should return true for frozen objects", () => {
+    const frozenObj = Object.freeze({ key: "value" });
+    assertEquals(check_is_frozen(frozenObj), true);
+  });
 
-	await t.step("should return false for non-frozen objects", () => {
-		const obj = { key: "value" };
-		assertEquals(check_is_frozen(obj), false);
-	});
+  await t.step("should return false for non-frozen objects", () => {
+    const obj = { key: "value" };
+    assertEquals(check_is_frozen(obj), false);
+  });
 
-	await t.step("should return true for frozen empty objects", () => {
-		const frozenEmptyObj = Object.freeze({});
-		assertEquals(check_is_frozen(frozenEmptyObj), true); // Frozen empty object
-	});
+  await t.step("should return true for frozen empty objects", () => {
+    const frozenEmptyObj = Object.freeze({});
+    assertEquals(check_is_frozen(frozenEmptyObj), true); // Frozen empty object
+  });
 });
 
 Deno.test("check_is_not_frozen", async (t) => {
-	await t.step("should return true for non-frozen objects", () => {
-		const obj = { key: "value" };
-		assertEquals(check_is_not_frozen(obj), true);
-	});
+  await t.step("should return true for non-frozen objects", () => {
+    const obj = { key: "value" };
+    assertEquals(check_is_not_frozen(obj), true);
+  });
 
-	await t.step("should return false for frozen objects", () => {
-		const frozenObj = Object.freeze({ key: "value" });
-		assertEquals(check_is_not_frozen(frozenObj), false);
-	});
+  await t.step("should return false for frozen objects", () => {
+    const frozenObj = Object.freeze({ key: "value" });
+    assertEquals(check_is_not_frozen(frozenObj), false);
+  });
 
-	await t.step("should return false for frozen empty objects", () => {
-		const frozenEmptyObj = Object.freeze({});
-		assertEquals(check_is_not_frozen(frozenEmptyObj), false); // Frozen empty object
-	});
+  await t.step("should return false for frozen empty objects", () => {
+    const frozenEmptyObj = Object.freeze({});
+    assertEquals(check_is_not_frozen(frozenEmptyObj), false); // Frozen empty object
+  });
 });

--- a/packages/object/src/checkInstance/main.ts
+++ b/packages/object/src/checkInstance/main.ts
@@ -18,10 +18,10 @@ import type { Constructor } from "../types.ts";
  * check_is_instace({}, Date); // The object is not an instance of Date
  */
 export const check_is_instace = <T extends Constructor>(
-	value: unknown,
-	constructor: T
+  value: unknown,
+  constructor: T,
 ): value is InstanceType<Constructor> => {
-	return value instanceof constructor;
+  return value instanceof constructor;
 };
 
 /**
@@ -42,11 +42,11 @@ export const check_is_instace = <T extends Constructor>(
  * check_is_not_instance(new Date(), Date); // The object is an instance of Date
  */
 export const check_is_not_instance = <
-	T1 extends unknown,
-	T2 extends Constructor
+  T1 extends unknown,
+  T2 extends Constructor,
 >(
-	value: T1,
-	constructor: T2
+  value: T1,
+  constructor: T2,
 ): value is Exclude<T1, T2> => {
-	return !check_is_instace(value, constructor);
+  return !check_is_instace(value, constructor);
 };

--- a/packages/object/src/checkInstance/main.ts
+++ b/packages/object/src/checkInstance/main.ts
@@ -11,23 +11,23 @@ import type { Constructor } from "../types.ts";
  *
  * @example
  * // Returns true
- * checkIsInstance(new Date(), Date); // The object is an instance of Date
+ * check_is_instace(new Date(), Date); // The object is an instance of Date
  *
  * @example
  * // Returns false
- * checkIsInstance({}, Date); // The object is not an instance of Date
+ * check_is_instace({}, Date); // The object is not an instance of Date
  */
-export const checkIsInstance = <T extends Constructor>(
-  value: unknown,
-  constructor: T,
+export const check_is_instace = <T extends Constructor>(
+	value: unknown,
+	constructor: T
 ): value is InstanceType<Constructor> => {
-  return value instanceof constructor;
+	return value instanceof constructor;
 };
 
 /**
  * Checks if a given object is not an instance of a specified constructor.
  *
- * This is the inverse of `checkIsInstance`.
+ * This is the inverse of `check_is_instace`.
  *
  * @param {unknown} value - The object to check.
  * @param {Constructor} constructor - The constructor function or class to check against.
@@ -35,15 +35,18 @@ export const checkIsInstance = <T extends Constructor>(
  *
  * @example
  * // Returns true
- * checkIsNotInstance({}, Date); // The object is not an instance of Date
+ * check_is_not_instance({}, Date); // The object is not an instance of Date
  *
  * @example
  * // Returns false
- * checkIsNotInstance(new Date(), Date); // The object is an instance of Date
+ * check_is_not_instance(new Date(), Date); // The object is an instance of Date
  */
-export const checkIsNotInstance = <T1 extends unknown, T2 extends Constructor>(
-  value: T1,
-  constructor: T2,
+export const check_is_not_instance = <
+	T1 extends unknown,
+	T2 extends Constructor
+>(
+	value: T1,
+	constructor: T2
 ): value is Exclude<T1, T2> => {
-  return !checkIsInstance(value, constructor);
+	return !check_is_instace(value, constructor);
 };

--- a/packages/object/src/checkInstance/test.ts
+++ b/packages/object/src/checkInstance/test.ts
@@ -2,68 +2,68 @@ import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import { check_is_instace, check_is_not_instance } from "./main.ts";
 
 Deno.test("check_is_instace", async (t) => {
-	await t.step("should return true for valid instances", () => {
-		class MyClass {}
-		const instance = new MyClass();
-		assertEquals(check_is_instace(instance, MyClass), true);
-	});
+  await t.step("should return true for valid instances", () => {
+    class MyClass {}
+    const instance = new MyClass();
+    assertEquals(check_is_instace(instance, MyClass), true);
+  });
 
-	await t.step("should return false for invalid instances", () => {
-		class MyClass {}
-		const instance = new MyClass();
-		class AnotherClass {}
-		assertEquals(check_is_instace(instance, AnotherClass), false);
-	});
+  await t.step("should return false for invalid instances", () => {
+    class MyClass {}
+    const instance = new MyClass();
+    class AnotherClass {}
+    assertEquals(check_is_instace(instance, AnotherClass), false);
+  });
 
-	await t.step("should return true for instances of built-in types", () => {
-		const date = new Date();
-		assertEquals(check_is_instace(date, Date), true); // Date instance
-		const array: unknown[] = [];
-		assertEquals(check_is_instace(array, Array), true); // Array instance
-	});
+  await t.step("should return true for instances of built-in types", () => {
+    const date = new Date();
+    assertEquals(check_is_instace(date, Date), true); // Date instance
+    const array: unknown[] = [];
+    assertEquals(check_is_instace(array, Array), true); // Array instance
+  });
 
-	await t.step("should narrow class type", () => {
-		class MyClass1 {}
-		// deno-lint-ignore no-unused-vars
-		class MyClass2 {}
-		type Value = MyClass1 | MyClass2;
-		const value = {} as Value;
-		if (check_is_instace(value, MyClass1)) {
-			assertType<IsExact<typeof value, MyClass1>>(true);
-		}
-	});
+  await t.step("should narrow class type", () => {
+    class MyClass1 {}
+    // deno-lint-ignore no-unused-vars
+    class MyClass2 {}
+    type Value = MyClass1 | MyClass2;
+    const value = {} as Value;
+    if (check_is_instace(value, MyClass1)) {
+      assertType<IsExact<typeof value, MyClass1>>(true);
+    }
+  });
 });
 
 Deno.test("check_is_not_instance", async (t) => {
-	await t.step("should return true for non-instances", () => {
-		class MyClass {}
-		const instance = new MyClass();
-		class AnotherClass {}
-		assertEquals(check_is_not_instance(instance, AnotherClass), true);
-	});
+  await t.step("should return true for non-instances", () => {
+    class MyClass {}
+    const instance = new MyClass();
+    class AnotherClass {}
+    assertEquals(check_is_not_instance(instance, AnotherClass), true);
+  });
 
-	await t.step("should return false for valid instances", () => {
-		class MyClass {}
-		const instance = new MyClass();
-		assertEquals(check_is_not_instance(instance, MyClass), false);
-	});
+  await t.step("should return false for valid instances", () => {
+    class MyClass {}
+    const instance = new MyClass();
+    assertEquals(check_is_not_instance(instance, MyClass), false);
+  });
 
-	await t.step("should return false for instances of built-in types", () => {
-		const date = new Date();
-		assertEquals(check_is_not_instance(date, Date), false); // Date instance
-		const array: unknown[] = [];
-		assertEquals(check_is_not_instance(array, Array), false); // Array instance
-	});
+  await t.step("should return false for instances of built-in types", () => {
+    const date = new Date();
+    assertEquals(check_is_not_instance(date, Date), false); // Date instance
+    const array: unknown[] = [];
+    assertEquals(check_is_not_instance(array, Array), false); // Array instance
+  });
 
-	await t.step("should exclude class type", () => {
-		class MyClass1 {}
-		// deno-lint-ignore no-unused-vars
-		class MyClass2 {}
-		type Value = MyClass1 | MyClass2;
-		const value = {} as Value;
-		if (check_is_not_instance(value, MyClass1)) {
-			value;
-			assertType<IsExact<typeof value, MyClass2>>(true);
-		}
-	});
+  await t.step("should exclude class type", () => {
+    class MyClass1 {}
+    // deno-lint-ignore no-unused-vars
+    class MyClass2 {}
+    type Value = MyClass1 | MyClass2;
+    const value = {} as Value;
+    if (check_is_not_instance(value, MyClass1)) {
+      value;
+      assertType<IsExact<typeof value, MyClass2>>(true);
+    }
+  });
 });

--- a/packages/object/src/checkInstance/test.ts
+++ b/packages/object/src/checkInstance/test.ts
@@ -1,69 +1,69 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkIsInstance, checkIsNotInstance } from "./main.ts";
+import { check_is_instace, check_is_not_instance } from "./main.ts";
 
-Deno.test("checkIsInstanceOf", async (t) => {
-  await t.step("should return true for valid instances", () => {
-    class MyClass {}
-    const instance = new MyClass();
-    assertEquals(checkIsInstance(instance, MyClass), true);
-  });
+Deno.test("check_is_instace", async (t) => {
+	await t.step("should return true for valid instances", () => {
+		class MyClass {}
+		const instance = new MyClass();
+		assertEquals(check_is_instace(instance, MyClass), true);
+	});
 
-  await t.step("should return false for invalid instances", () => {
-    class MyClass {}
-    const instance = new MyClass();
-    class AnotherClass {}
-    assertEquals(checkIsInstance(instance, AnotherClass), false);
-  });
+	await t.step("should return false for invalid instances", () => {
+		class MyClass {}
+		const instance = new MyClass();
+		class AnotherClass {}
+		assertEquals(check_is_instace(instance, AnotherClass), false);
+	});
 
-  await t.step("should return true for instances of built-in types", () => {
-    const date = new Date();
-    assertEquals(checkIsInstance(date, Date), true); // Date instance
-    const array: unknown[] = [];
-    assertEquals(checkIsInstance(array, Array), true); // Array instance
-  });
+	await t.step("should return true for instances of built-in types", () => {
+		const date = new Date();
+		assertEquals(check_is_instace(date, Date), true); // Date instance
+		const array: unknown[] = [];
+		assertEquals(check_is_instace(array, Array), true); // Array instance
+	});
 
-  await t.step("should narrow class type", () => {
-    class MyClass1 {}
-    // deno-lint-ignore no-unused-vars
-    class MyClass2 {}
-    type Value = MyClass1 | MyClass2;
-    const value = {} as Value;
-    if (checkIsInstance(value, MyClass1)) {
-      assertType<IsExact<typeof value, MyClass1>>(true);
-    }
-  });
+	await t.step("should narrow class type", () => {
+		class MyClass1 {}
+		// deno-lint-ignore no-unused-vars
+		class MyClass2 {}
+		type Value = MyClass1 | MyClass2;
+		const value = {} as Value;
+		if (check_is_instace(value, MyClass1)) {
+			assertType<IsExact<typeof value, MyClass1>>(true);
+		}
+	});
 });
 
-Deno.test("checkIsNotInstanceOf", async (t) => {
-  await t.step("should return true for non-instances", () => {
-    class MyClass {}
-    const instance = new MyClass();
-    class AnotherClass {}
-    assertEquals(checkIsNotInstance(instance, AnotherClass), true);
-  });
+Deno.test("check_is_not_instance", async (t) => {
+	await t.step("should return true for non-instances", () => {
+		class MyClass {}
+		const instance = new MyClass();
+		class AnotherClass {}
+		assertEquals(check_is_not_instance(instance, AnotherClass), true);
+	});
 
-  await t.step("should return false for valid instances", () => {
-    class MyClass {}
-    const instance = new MyClass();
-    assertEquals(checkIsNotInstance(instance, MyClass), false);
-  });
+	await t.step("should return false for valid instances", () => {
+		class MyClass {}
+		const instance = new MyClass();
+		assertEquals(check_is_not_instance(instance, MyClass), false);
+	});
 
-  await t.step("should return false for instances of built-in types", () => {
-    const date = new Date();
-    assertEquals(checkIsNotInstance(date, Date), false); // Date instance
-    const array: unknown[] = [];
-    assertEquals(checkIsNotInstance(array, Array), false); // Array instance
-  });
+	await t.step("should return false for instances of built-in types", () => {
+		const date = new Date();
+		assertEquals(check_is_not_instance(date, Date), false); // Date instance
+		const array: unknown[] = [];
+		assertEquals(check_is_not_instance(array, Array), false); // Array instance
+	});
 
-  await t.step("should exclude class type", () => {
-    class MyClass1 {}
-    // deno-lint-ignore no-unused-vars
-    class MyClass2 {}
-    type Value = MyClass1 | MyClass2;
-    const value = {} as Value;
-    if (checkIsNotInstance(value, MyClass1)) {
-      value;
-      assertType<IsExact<typeof value, MyClass2>>(true);
-    }
-  });
+	await t.step("should exclude class type", () => {
+		class MyClass1 {}
+		// deno-lint-ignore no-unused-vars
+		class MyClass2 {}
+		type Value = MyClass1 | MyClass2;
+		const value = {} as Value;
+		if (check_is_not_instance(value, MyClass1)) {
+			value;
+			assertType<IsExact<typeof value, MyClass2>>(true);
+		}
+	});
 });

--- a/packages/object/src/checkObject/main.ts
+++ b/packages/object/src/checkObject/main.ts
@@ -8,40 +8,42 @@
  *
  * @example
  * // Returns true
- * checkIsObject({a: 1, b: 2}); // The value is an object
+ * check_is_object({a: 1, b: 2}); // The value is an object
  *
  * @example
  * // Returns false
- * checkIsObject(null); // The value is null, not an object
+ * check_is_object(null); // The value is null, not an object
  *
  * @example
  * // Returns false
- * checkIsObject([1, 2, 3]); // The value is an array, not an object
+ * check_is_object([1, 2, 3]); // The value is an array, not an object
  */
-export const checkIsObject = <T>(value: T): value is T & object => {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
+export const check_is_object = <T>(value: T): value is T & object => {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
 };
 
 /**
  * Checks if a given value is not an object.
  *
- * This is the inverse of `checkIsObject`.
+ * This is the inverse of `check_is_object`.
  *
  * @param {T} value - The value to check.
  * @returns {value is Exclude<T, object>} True if the value is not an object, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotObject(42); // The value is a number, not an object
+ * check_is_not_object(42); // The value is a number, not an object
  *
  * @example
  * // Returns false
- * checkIsNotObject({a: 1, b: 2}); // The value is an object
+ * check_is_not_object({a: 1, b: 2}); // The value is an object
  *
  * @example
  * // Returns true
- * checkIsNotObject(null); // The value is null, not an object
+ * check_is_not_object(null); // The value is null, not an object
  */
-export const checkIsNotObject = <T>(value: T): value is Exclude<T, object> => {
-  return !(checkIsObject(value));
+export const check_is_not_object = <T>(
+	value: T
+): value is Exclude<T, object> => {
+	return !check_is_object(value);
 };

--- a/packages/object/src/checkObject/main.ts
+++ b/packages/object/src/checkObject/main.ts
@@ -19,7 +19,7 @@
  * check_is_object([1, 2, 3]); // The value is an array, not an object
  */
 export const check_is_object = <T>(value: T): value is T & object => {
-	return value !== null && typeof value === "object" && !Array.isArray(value);
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 };
 
 /**
@@ -43,7 +43,7 @@ export const check_is_object = <T>(value: T): value is T & object => {
  * check_is_not_object(null); // The value is null, not an object
  */
 export const check_is_not_object = <T>(
-	value: T
+  value: T,
 ): value is Exclude<T, object> => {
-	return !check_is_object(value);
+  return !check_is_object(value);
 };

--- a/packages/object/src/checkObject/test.ts
+++ b/packages/object/src/checkObject/test.ts
@@ -1,60 +1,60 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkIsNotObject, checkIsObject } from "./main.ts";
+import { check_is_not_object, check_is_object } from "./main.ts";
 
 Deno.test("checkIsObject", async (t) => {
-  await t.step("should return true for objects", () => {
-    assertEquals(checkIsObject({}), true); // Regular object
-    assertEquals(checkIsObject({ key: "value" }), true); // Object with properties
-    assertEquals(checkIsObject(Object.create(null)), true); // Object with no prototype
-  });
+	await t.step("should return true for objects", () => {
+		assertEquals(check_is_object({}), true); // Regular object
+		assertEquals(check_is_object({ key: "value" }), true); // Object with properties
+		assertEquals(check_is_object(Object.create(null)), true); // Object with no prototype
+	});
 
-  await t.step("should return false for non-objects", () => {
-    assertEquals(checkIsObject(null), false); // Null should not be considered an object
-    assertEquals(checkIsObject(undefined), false);
-    assertEquals(checkIsObject(123), false);
-    assertEquals(checkIsObject("string"), false);
-    assertEquals(checkIsObject([1, 2, 3]), false);
-    // Function is not considered an object
-    assertEquals(
-      checkIsObject(() => {}),
-      false,
-    );
-  });
+	await t.step("should return false for non-objects", () => {
+		assertEquals(check_is_object(null), false); // Null should not be considered an object
+		assertEquals(check_is_object(undefined), false);
+		assertEquals(check_is_object(123), false);
+		assertEquals(check_is_object("string"), false);
+		assertEquals(check_is_object([1, 2, 3]), false);
+		// Function is not considered an object
+		assertEquals(
+			check_is_object(() => {}),
+			false
+		);
+	});
 
-  await t.step("should narrow object type", () => {
-    type Value = string | object;
-    const value = {} as Value;
-    if (checkIsObject(value)) {
-      assertType<IsExact<typeof value, object>>(true);
-    }
-  });
+	await t.step("should narrow object type", () => {
+		type Value = string | object;
+		const value = {} as Value;
+		if (check_is_object(value)) {
+			assertType<IsExact<typeof value, object>>(true);
+		}
+	});
 });
 
 Deno.test("checkIsNotObject", async (t) => {
-  await t.step("should return true for non-objects", () => {
-    assertEquals(checkIsNotObject(null), true); // Null should be true
-    assertEquals(checkIsNotObject(undefined), true);
-    assertEquals(checkIsNotObject(123), true);
-    assertEquals(checkIsNotObject("string"), true);
-    assertEquals(checkIsNotObject([1, 2, 3]), true); // Array should return true
-    // Function should return true
-    assertEquals(
-      checkIsNotObject(() => {}),
-      true,
-    );
-  });
+	await t.step("should return true for non-objects", () => {
+		assertEquals(check_is_not_object(null), true); // Null should be true
+		assertEquals(check_is_not_object(undefined), true);
+		assertEquals(check_is_not_object(123), true);
+		assertEquals(check_is_not_object("string"), true);
+		assertEquals(check_is_not_object([1, 2, 3]), true); // Array should return true
+		// Function should return true
+		assertEquals(
+			check_is_not_object(() => {}),
+			true
+		);
+	});
 
-  await t.step("should return false for objects", () => {
-    assertEquals(checkIsNotObject({}), false);
-    assertEquals(checkIsNotObject({ key: "value" }), false);
-    assertEquals(checkIsNotObject(Object.create(null)), false);
-  });
+	await t.step("should return false for objects", () => {
+		assertEquals(check_is_not_object({}), false);
+		assertEquals(check_is_not_object({ key: "value" }), false);
+		assertEquals(check_is_not_object(Object.create(null)), false);
+	});
 
-  await t.step("should exclude object type", () => {
-    type Value = string | object;
-    const value = {} as Value;
-    if (checkIsNotObject(value)) {
-      assertType<IsExact<typeof value, string>>(true);
-    }
-  });
+	await t.step("should exclude object type", () => {
+		type Value = string | object;
+		const value = {} as Value;
+		if (check_is_not_object(value)) {
+			assertType<IsExact<typeof value, string>>(true);
+		}
+	});
 });

--- a/packages/object/src/checkObject/test.ts
+++ b/packages/object/src/checkObject/test.ts
@@ -2,59 +2,59 @@ import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import { check_is_not_object, check_is_object } from "./main.ts";
 
 Deno.test("checkIsObject", async (t) => {
-	await t.step("should return true for objects", () => {
-		assertEquals(check_is_object({}), true); // Regular object
-		assertEquals(check_is_object({ key: "value" }), true); // Object with properties
-		assertEquals(check_is_object(Object.create(null)), true); // Object with no prototype
-	});
+  await t.step("should return true for objects", () => {
+    assertEquals(check_is_object({}), true); // Regular object
+    assertEquals(check_is_object({ key: "value" }), true); // Object with properties
+    assertEquals(check_is_object(Object.create(null)), true); // Object with no prototype
+  });
 
-	await t.step("should return false for non-objects", () => {
-		assertEquals(check_is_object(null), false); // Null should not be considered an object
-		assertEquals(check_is_object(undefined), false);
-		assertEquals(check_is_object(123), false);
-		assertEquals(check_is_object("string"), false);
-		assertEquals(check_is_object([1, 2, 3]), false);
-		// Function is not considered an object
-		assertEquals(
-			check_is_object(() => {}),
-			false
-		);
-	});
+  await t.step("should return false for non-objects", () => {
+    assertEquals(check_is_object(null), false); // Null should not be considered an object
+    assertEquals(check_is_object(undefined), false);
+    assertEquals(check_is_object(123), false);
+    assertEquals(check_is_object("string"), false);
+    assertEquals(check_is_object([1, 2, 3]), false);
+    // Function is not considered an object
+    assertEquals(
+      check_is_object(() => {}),
+      false,
+    );
+  });
 
-	await t.step("should narrow object type", () => {
-		type Value = string | object;
-		const value = {} as Value;
-		if (check_is_object(value)) {
-			assertType<IsExact<typeof value, object>>(true);
-		}
-	});
+  await t.step("should narrow object type", () => {
+    type Value = string | object;
+    const value = {} as Value;
+    if (check_is_object(value)) {
+      assertType<IsExact<typeof value, object>>(true);
+    }
+  });
 });
 
 Deno.test("checkIsNotObject", async (t) => {
-	await t.step("should return true for non-objects", () => {
-		assertEquals(check_is_not_object(null), true); // Null should be true
-		assertEquals(check_is_not_object(undefined), true);
-		assertEquals(check_is_not_object(123), true);
-		assertEquals(check_is_not_object("string"), true);
-		assertEquals(check_is_not_object([1, 2, 3]), true); // Array should return true
-		// Function should return true
-		assertEquals(
-			check_is_not_object(() => {}),
-			true
-		);
-	});
+  await t.step("should return true for non-objects", () => {
+    assertEquals(check_is_not_object(null), true); // Null should be true
+    assertEquals(check_is_not_object(undefined), true);
+    assertEquals(check_is_not_object(123), true);
+    assertEquals(check_is_not_object("string"), true);
+    assertEquals(check_is_not_object([1, 2, 3]), true); // Array should return true
+    // Function should return true
+    assertEquals(
+      check_is_not_object(() => {}),
+      true,
+    );
+  });
 
-	await t.step("should return false for objects", () => {
-		assertEquals(check_is_not_object({}), false);
-		assertEquals(check_is_not_object({ key: "value" }), false);
-		assertEquals(check_is_not_object(Object.create(null)), false);
-	});
+  await t.step("should return false for objects", () => {
+    assertEquals(check_is_not_object({}), false);
+    assertEquals(check_is_not_object({ key: "value" }), false);
+    assertEquals(check_is_not_object(Object.create(null)), false);
+  });
 
-	await t.step("should exclude object type", () => {
-		type Value = string | object;
-		const value = {} as Value;
-		if (check_is_not_object(value)) {
-			assertType<IsExact<typeof value, string>>(true);
-		}
-	});
+  await t.step("should exclude object type", () => {
+    type Value = string | object;
+    const value = {} as Value;
+    if (check_is_not_object(value)) {
+      assertType<IsExact<typeof value, string>>(true);
+    }
+  });
 });

--- a/packages/object/src/checkSealed/main.ts
+++ b/packages/object/src/checkSealed/main.ts
@@ -9,21 +9,21 @@
  * @example
  * // Returns true
  * const sealedObj = Object.seal({a: 1});
- * checkIsSealed(sealedObj); // The object is sealed
+ * check_is_sealed(sealedObj); // The object is sealed
  *
  * @example
  * // Returns false
  * const obj = {a: 1};
- * checkIsSealed(obj); // The object is not sealed
+ * check_is_sealed(obj); // The object is not sealed
  */
-export const checkIsSealed = (obj: object): boolean => {
-  return Object.isSealed(obj);
+export const check_is_sealed = (obj: object): boolean => {
+	return Object.isSealed(obj);
 };
 
 /**
  * Checks if a given object is not sealed.
  *
- * This is the inverse of `checkIsSealed`.
+ * This is the inverse of `check_is_sealed`.
  *
  * @param {object} obj - The object to check.
  * @returns {boolean} True if the object is not sealed, otherwise false.
@@ -31,13 +31,13 @@ export const checkIsSealed = (obj: object): boolean => {
  * @example
  * // Returns true
  * const obj = {a: 1};
- * checkIsNotSealed(obj); // The object is not sealed
+ * check_is_not_sealed(obj); // The object is not sealed
  *
  * @example
  * // Returns false
  * const sealedObj = Object.seal({a: 1});
- * checkIsNotSealed(sealedObj); // The object is sealed
+ * check_is_not_sealed(sealedObj); // The object is sealed
  */
-export const checkIsNotSealed = (obj: object): boolean => {
-  return !checkIsSealed(obj);
+export const check_is_not_sealed = (obj: object): boolean => {
+	return !check_is_sealed(obj);
 };

--- a/packages/object/src/checkSealed/main.ts
+++ b/packages/object/src/checkSealed/main.ts
@@ -17,7 +17,7 @@
  * check_is_sealed(obj); // The object is not sealed
  */
 export const check_is_sealed = (obj: object): boolean => {
-	return Object.isSealed(obj);
+  return Object.isSealed(obj);
 };
 
 /**
@@ -39,5 +39,5 @@ export const check_is_sealed = (obj: object): boolean => {
  * check_is_not_sealed(sealedObj); // The object is sealed
  */
 export const check_is_not_sealed = (obj: object): boolean => {
-	return !check_is_sealed(obj);
+  return !check_is_sealed(obj);
 };

--- a/packages/object/src/checkSealed/test.ts
+++ b/packages/object/src/checkSealed/test.ts
@@ -1,36 +1,36 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsNotSealed, checkIsSealed } from "./main.ts";
+import { check_is_not_sealed, check_is_sealed } from "./main.ts";
 
-Deno.test("checkIsSealed", async (t) => {
-  await t.step("should return true for sealed objects", () => {
-    const sealedObj = Object.seal({ key: "value" });
-    assertEquals(checkIsSealed(sealedObj), true);
-  });
+Deno.test("check_is_sealed", async (t) => {
+	await t.step("should return true for sealed objects", () => {
+		const sealedObj = Object.seal({ key: "value" });
+		assertEquals(check_is_sealed(sealedObj), true);
+	});
 
-  await t.step("should return false for non-sealed objects", () => {
-    const obj = { key: "value" };
-    assertEquals(checkIsSealed(obj), false);
-  });
+	await t.step("should return false for non-sealed objects", () => {
+		const obj = { key: "value" };
+		assertEquals(check_is_sealed(obj), false);
+	});
 
-  await t.step("should return true for sealed empty objects", () => {
-    const sealedEmptyObj = Object.seal({});
-    assertEquals(checkIsSealed(sealedEmptyObj), true); // Sealed empty object
-  });
+	await t.step("should return true for sealed empty objects", () => {
+		const sealedEmptyObj = Object.seal({});
+		assertEquals(check_is_sealed(sealedEmptyObj), true); // Sealed empty object
+	});
 });
 
-Deno.test("checkIsNotSealed", async (t) => {
-  await t.step("should return true for non-sealed objects", () => {
-    const obj = { key: "value" };
-    assertEquals(checkIsNotSealed(obj), true);
-  });
+Deno.test("check_is_not_sealed", async (t) => {
+	await t.step("should return true for non-sealed objects", () => {
+		const obj = { key: "value" };
+		assertEquals(check_is_not_sealed(obj), true);
+	});
 
-  await t.step("should return false for sealed objects", () => {
-    const sealedObj = Object.seal({ key: "value" });
-    assertEquals(checkIsNotSealed(sealedObj), false);
-  });
+	await t.step("should return false for sealed objects", () => {
+		const sealedObj = Object.seal({ key: "value" });
+		assertEquals(check_is_not_sealed(sealedObj), false);
+	});
 
-  await t.step("should return false for sealed empty objects", () => {
-    const sealedEmptyObj = Object.seal({});
-    assertEquals(checkIsNotSealed(sealedEmptyObj), false); // Sealed empty object
-  });
+	await t.step("should return false for sealed empty objects", () => {
+		const sealedEmptyObj = Object.seal({});
+		assertEquals(check_is_not_sealed(sealedEmptyObj), false); // Sealed empty object
+	});
 });

--- a/packages/object/src/checkSealed/test.ts
+++ b/packages/object/src/checkSealed/test.ts
@@ -2,35 +2,35 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_not_sealed, check_is_sealed } from "./main.ts";
 
 Deno.test("check_is_sealed", async (t) => {
-	await t.step("should return true for sealed objects", () => {
-		const sealedObj = Object.seal({ key: "value" });
-		assertEquals(check_is_sealed(sealedObj), true);
-	});
+  await t.step("should return true for sealed objects", () => {
+    const sealedObj = Object.seal({ key: "value" });
+    assertEquals(check_is_sealed(sealedObj), true);
+  });
 
-	await t.step("should return false for non-sealed objects", () => {
-		const obj = { key: "value" };
-		assertEquals(check_is_sealed(obj), false);
-	});
+  await t.step("should return false for non-sealed objects", () => {
+    const obj = { key: "value" };
+    assertEquals(check_is_sealed(obj), false);
+  });
 
-	await t.step("should return true for sealed empty objects", () => {
-		const sealedEmptyObj = Object.seal({});
-		assertEquals(check_is_sealed(sealedEmptyObj), true); // Sealed empty object
-	});
+  await t.step("should return true for sealed empty objects", () => {
+    const sealedEmptyObj = Object.seal({});
+    assertEquals(check_is_sealed(sealedEmptyObj), true); // Sealed empty object
+  });
 });
 
 Deno.test("check_is_not_sealed", async (t) => {
-	await t.step("should return true for non-sealed objects", () => {
-		const obj = { key: "value" };
-		assertEquals(check_is_not_sealed(obj), true);
-	});
+  await t.step("should return true for non-sealed objects", () => {
+    const obj = { key: "value" };
+    assertEquals(check_is_not_sealed(obj), true);
+  });
 
-	await t.step("should return false for sealed objects", () => {
-		const sealedObj = Object.seal({ key: "value" });
-		assertEquals(check_is_not_sealed(sealedObj), false);
-	});
+  await t.step("should return false for sealed objects", () => {
+    const sealedObj = Object.seal({ key: "value" });
+    assertEquals(check_is_not_sealed(sealedObj), false);
+  });
 
-	await t.step("should return false for sealed empty objects", () => {
-		const sealedEmptyObj = Object.seal({});
-		assertEquals(check_is_not_sealed(sealedEmptyObj), false); // Sealed empty object
-	});
+  await t.step("should return false for sealed empty objects", () => {
+    const sealedEmptyObj = Object.seal({});
+    assertEquals(check_is_not_sealed(sealedEmptyObj), false); // Sealed empty object
+  });
 });

--- a/packages/string/README.md
+++ b/packages/string/README.md
@@ -40,226 +40,226 @@ bunx jsr add @checker/string
 
 ## Functions
 
-### `checkIsAlphanumeric`
+### `check_is_alphanumeric`
 
 Checks if a given string is alphanumeric.
 
 ```ts
-checkIsAlphanumeric("abc123"); // true, The string contains only letters and numbers
-checkIsAlphanumeric("abc123!"); // false, The string contains a special character '!'
+check_is_alphanumeric("abc123"); // true, The string contains only letters and numbers
+check_is_alphanumeric("abc123!"); // false, The string contains a special character '!'
 ```
 
-### `checkIsNotAlphanumeric`
+### `check_is_not_alphanumeric`
 
 Checks if a given string is not alphanumeric.
 
 ```ts
-checkIsNotAlphanumeric("abc123!"); // true, The string contains a special character '!'
-checkIsNotAlphanumeric("abc123"); // false
+check_is_not_alphanumeric("abc123!"); // true, The string contains a special character '!'
+check_is_not_alphanumeric("abc123"); // false
 ```
 
-### `checkIsAnyNumeric`
+### `check_is_any_numeric`
 
 Checks if a given string is numeric.
 
 ```ts
-checkIsAnyNumeric("123"); // true
-checkIsAnyNumeric("3.14"); // true
-checkIsAnyNumeric("Infinity"); // true
-checkIsAnyNumeric(""); // true
+check_is_any_numeric("123"); // true
+check_is_any_numeric("3.14"); // true
+check_is_any_numeric("Infinity"); // true
+check_is_any_numeric(""); // true
 
-checkIsAnyNumeric("abc"); // false
+check_is_any_numeric("abc"); // false
 ```
 
-### `checkIsNotAnyNumeric`
+### `check_is_not_any_numeric`
 
 Checks if a given string is not numeric.
 
 ```ts
-checkIsAnyNumeric("abc"); // true
+check_is_not_any_numeric("abc"); // true
 
-checkIsAnyNumeric("123"); // false
-checkIsAnyNumeric("3.14"); // false
-checkIsAnyNumeric("Infinity"); // false
-checkIsAnyNumeric(""); // false
+check_is_not_any_numeric("123"); // false
+check_is_not_any_numeric("3.14"); // false
+check_is_not_any_numeric("Infinity"); // false
+check_is_not_any_numeric(""); // false
 ```
 
-### `checkIsBinary`
+### `check_is_binary`
 
 Checks if a given string represents a binary number.
 
 ```ts
-checkIsBinary("0b1010"); // true
+check_is_binary("0b1010"); // true
 
-checkIsBinary("hello"); // false
-checkIsBinary("1010"); // false
+check_is_binary("hello"); // false
+check_is_binary("1010"); // false
 ```
 
-### `checkIsEmailFormat`
+### `check_is_email_format`
 
 Checks if a given string is in email format.
 
 ```ts
-checkIsEmailFormat("example@test.com"); // true
+check_is_email_format("example@test.com"); // true
 
-checkIsEmailFormat("invalid-email"); // false
-checkIsEmailFormat("example@.com"); // false
+check_is_email_format("invalid-email"); // false
+check_is_email_format("example@.com"); // false
 ```
 
-### `checkIsNotEmailFormat`
+### `check_is_not_email_format`
 
 Checks if a given string is not in email format.
 
 ```ts
-checkIsNotEmailFormat("invalid-email"); // true
-checkIsNotEmailFormat("example@.com"); // true
+check_is_not_email_format("invalid-email"); // true
+check_is_not_email_format("example@.com"); // true
 
-checkIsNotEmailFormat("example@test.com"); // false
+check_is_not_email_format("example@test.com"); // false
 ```
 
-### `checkIsEmptyString`
+### `check_is_empty_string`
 
 Checks if a given string is empty.
 
 ```ts
-checkIsEmptyString(""); // true
+check_is_empty_string(""); // true
 
-checkIsEmptyString("hello"); // false
+check_is_empty_string("hello"); // false
 ```
 
-### `checkIsNotEmptyString`
+### `check_is_not_empty_string`
 
 Checks if a given string is not empty.
 
 ```ts
-checkIsNotEmptyString("hello"); // true
+check_is_not_empty_string("hello"); // true
 
-checkIsNotEmptyString(""); // false
+check_is_not_empty_string(""); // false
 ```
 
-### `checkIsEnterKey`
+### `check_is_enter_key`
 
 Checks if a given string represents the "Enter" key.
 
 This was created to check if the event.key of a DOM event is Enter.
 
 ```ts
-checkIsEnterKey("Enter"); // true
+check_is_enter_key("Enter"); // true
 
-checkIsEnterKey("enter"); // false
-checkIsEnterKey("invalid-key"); // false
+check_is_enter_key("enter"); // false
+check_is_enter_key("invalid-key"); // false
 ```
 
 ```ts
 inputElement.addEventListener("keydown", (event) => {
-  if (checkIsEnterKey(event.key)) {
-    // When the Enter key is pressed
-  }
+	if (check_is_enter_key(event.key)) {
+		// When the Enter key is pressed
+	}
 });
 ```
 
-### `checkIsNotEnterKey`
+### `check_is_not_enter_key`
 
 Checks if a given string does not represent the "Enter" key.
 
 ```ts
-checkIsEnterKey("enter"); // true
-checkIsEnterKey("invalid-key"); // true
+check_is_not_enter_key("enter"); // true
+check_is_not_enter_key("invalid-key"); // true
 
-checkIsEnterKey("Enter"); // false
+check_is_not_enter_key("Enter"); // false
 ```
 
-### `checkIsExponentialNotation`
+### `check_is_exponential_notation`
 
 Checks if a given string is in exponential notation format.
 
 ```ts
-checkIsExponentialNotation("1e5"); // true
-checkIsExponentialNotation("3.14E-10"); // true
+check_is_exponential_notation("1e5"); // true
+check_is_exponential_notation("3.14E-10"); // true
 
-checkIsExponentialNotation("123"); // false
+check_is_exponential_notation("123"); // false
 ```
 
-### `checkIsNotExponentialNotation`
+### `check_is_not_exponential_notation`
 
 Checks if a given string is not in exponential notation format.
 
 ```ts
-checkIsNotExponentialNotation("123"); // true
+check_is_not_exponential_notation("123"); // true
 
-checkIsNotExponentialNotation("1e5"); // false
-checkIsNotExponentialNotation("3.14E-10"); // false
+check_is_not_exponential_notation("1e5"); // false
+check_is_not_exponential_notation("3.14E-10"); // false
 ```
 
-### `checkHasSubstring`
+### `check_has_substring`
 
 Checks if a given string has a specific substring.
 
 ```ts
-checkHasSubstring("hello world", "world"); // true
-checkHasSubstring("hello world", "planet"); // false
+check_has_substring("hello world", "world"); // true
+check_has_substring("hello world", "planet"); // false
 ```
 
-### `checkDoesNotHaveSubstring`
+### `check_does_not_have_substring`
 
 Checks if a given string does not have a specific substring.
 
 ```ts
-checkDoesNotHaveSubstring("hello world", "planet"); // true
-checkDoesNotHaveSubstring("hello world", "world"); // false
+check_does_not_have_substring("hello world", "planet"); // true
+check_does_not_have_substring("hello world", "world"); // false
 ```
 
-### `checkIsIndexFound`
+### `check_is_index_found`
 
 Checks if a given string includes a specific substring.
 
 ```ts
 const words = "hello world";
 const index = words.indexOf("world");
-checkIsIndexFound(index); // true
+check_is_index_found(index); // true
 
 const anotherIndex = words.indexOf("planet");
-checkIsIndexFound(anotherIndex); // false
+check_is_index_found(anotherIndex); // false
 ```
 
-### `checkIsIndexNotFound`
+### `check_is_not_index_found`
 
 Checks if a given index is not found.
 
 ```ts
 const words = "hello world";
 const index = words.indexOf("planet");
-checkIsIndexNotFound(index); // true
+check_is_not_index_found(index); // true
 
 const anotherIndex = words.indexOf("world");
-checkIsIndexFound(anotherIndex); // false
+check_is_index_found(anotherIndex); // false
 ```
 
-### `checkIsInfinityString`
+### `check_is_infinity_string`
 
 Checks if a given string represents infinity.
 
 ```ts
-checkIsInfinityString("Infinity"); // true
-checkIsInfinityString("-Infinity"); // true
+check_is_infinity_string("Infinity"); // true
+check_is_infinity_string("-Infinity"); // true
 
-checkIsInfinityString("infinity"); // false, the string is not exactly "Infinity" or "-Infinity"
-checkIsInfinityString("123"); // false
+check_is_infinity_string("infinity"); // false, the string is not exactly "Infinity" or "-Infinity"
+check_is_infinity_string("123"); // false
 ```
 
-### `checkIsNotInfinityString`
+### `check_is_not_infinity_string`
 
 Checks if a given string does not represent infinity.
 
 ```ts
-checkIsInfinityString("infinity"); // true
-checkIsInfinityString("123"); // true
+check_is_not_infinity_string("infinity"); // true
+check_is_not_infinity_string("123"); // true
 
-checkIsInfinityString("Infinity"); // false
-checkIsInfinityString("-Infinity"); // false
+check_is_not_infinity_string("Infinity"); // false
+check_is_not_infinity_string("-Infinity"); // false
 ```
 
-### `checkIsIntegerOrDecimalString`
+### `check_is_integer_or_decimal_string`
 
 Checks if a given string is a numeric value.
 
@@ -268,193 +268,205 @@ optional negative signs and decimal points. The string can represent an integer
 or a floating-point number.
 
 ```ts
-checkIsIntegerOrDecimalString("123"); // true
-checkIsIntegerOrDecimalString("1.1"); // true
+check_is_integer_or_decimal_string("123"); // true
+check_is_integer_or_decimal_string("1.1"); // true
 
-checkIsIntegerOrDecimalString("123abc"); // false
-checkIsIntegerOrDecimalString("hello"); // false
+check_is_integer_or_decimal_string("123abc"); // false
+check_is_integer_or_decimal_string("hello"); // false
 ```
 
-### `checkIsNotIntegerOrDecimalString`
+### `check_is_not_integer_or_decimal_string`
 
 Checks if a given string is not a numeric value.
 
 ```ts
-checkIsNotIntegerOrDecimalString("123abc"); // true
-checkIsNotIntegerOrDecimalString("hello"); // true
+check_is_not_integer_or_decimal_string("123abc"); // true
+check_is_not_integer_or_decimal_string("hello"); // true
 
-checkIsNotIntegerOrDecimalString("123"); // false
-checkIsNotIntegerOrDecimalString("1.1"); // false
+check_is_not_integer_or_decimal_string("123"); // false
+check_is_not_integer_or_decimal_string("1.1"); // false
 ```
 
-### `checkIsISO8601Format`
+### `check_is_ISO8601_format`
 
 Checks if a given string is in ISO 8601 format.
 
 ```ts
-checkIsISO8601Format("2023-08-30T10:30:00Z"); // true
-checkIsISO8601Format("2023-08-30T10:30:00+02:00"); // true
+check_is_ISO8601_format("2023-08-30T10:30:00Z"); // true
+check_is_ISO8601_format("2023-08-30T10:30:00+02:00"); // true
 
-checkIsISO8601Format("invalid-date"); // false
-checkIsISO8601Format("08/30/2023"); // false
+check_is_ISO8601_format("invalid-date"); // false
+check_is_ISO8601_format("08/30/2023"); // false
 ```
 
-### `checkHasPrefix`
+### `check_is_not_ISO8601_format`
+
+Checks if a given string is not in ISO 8601 format.
+
+```ts
+check_is_not_ISO8601_format("2023-08-30T10:30:00Z"); // true
+check_is_not_ISO8601_format("2023-08-30T10:30:00+02:00"); // true
+
+check_is_not_ISO8601_format("invalid-date"); // false
+check_is_Inot_SO8601_format("08/30/2023"); // false
+```
+
+### `check_has_prefix`
 
 Checks if a given string has a specific prefix.
 
 ```ts
-checkHasPrefix("hello world", "hello"); // true
+check_has_prefix("hello world", "hello"); // true
 
-checkHasPrefix("hello world", "world"); // false
+check_has_prefix("hello world", "world"); // false
 ```
 
-### `checkDoesNotHavePrefix`
+### `check_does_not_have_prefix`
 
 Checks if a given string does not have a specific prefix.
 
 ```ts
-checkDoesNotHavePrefix("hello world", "world"); // true
+check_does_not_have_prefix("hello world", "world"); // true
 
-checkDoesNotHavePrefix("hello world", "hello"); // false
+check_does_not_have_prefix("hello world", "hello"); // false
 ```
 
-### `checkHasSpecialCharacter`
+### `check_has_special_character`
 
 Checks if a given string contains any special characters.
 
 ```ts
-checkHasSpecialCharacter("hello@world"); // true
-checkHasSpecialCharacter("password123!"); // true
+check_has_special_character("hello@world"); // true
+check_has_special_character("password123!"); // true
 
-checkHasSpecialCharacter("hello world"); // false
-checkHasSpecialCharacter("123456"); // false
+check_has_special_character("hello world"); // false
+check_has_special_character("123456"); // false
 ```
 
-### `checkDoesNotHaveSpecialCharacter`
+### `check_does_not_have_special_character`
 
 Checks if a given string does not contain any special characters.
 
 ```ts
-checkDoesNotHasSpecialCharacter("hello world"); // true
-checkDoesNotHasSpecialCharacter("123456"); // true
+check_does_not_have_special_character("hello world"); // true
+check_does_not_have_special_character("123456"); // true
 
-checkDoesNotHaveSpecialCharacter("hello@world"); // false
-checkDoesNotHaveSpecialCharacter("password123!"); // false
+check_does_not_have_special_character("hello@world"); // false
+check_does_not_have_special_character("password123!"); // false
 ```
 
-### `checkIsSpecialNumeric`
+### `check_is_special_numeric`
 
 Checks if a given string is a special numeric value.
 
 ```ts
-checkIsSpecialNumeric("1e5"); // true
-checkIsSpecialNumeric("0b1010"); // true
-checkIsSpecialNumeric("Infinity"); // true
+check_is_special_numeric("1e5"); // true
+check_is_special_numeric("0b1010"); // true
+check_is_special_numeric("Infinity"); // true
 
-checkIsSpecialNumeric("123"); // false
-checkIsSpecialNumeric("hello"); // false
+check_is_special_numeric("123"); // false
+check_is_special_numeric("hello"); // false
 ```
 
-### `checkIsNotSpecialNumeric`
+### `check_is_not_special_numeric`
 
 Checks if a given string is not a special numeric value.
 
 ```ts
-checkIsNotSpecialNumeric("123"); // true
-checkIsNotSpecialNumeric("hello"); // true
+check_is_not_special_numeric("123"); // true
+check_is_not_special_numeric("hello"); // true
 
-checkIsNotSpecialNumeric("1e5"); // false
-checkIsNotSpecialNumeric("0b1010"); // false
-checkIsNotSpecialNumeric("Infinity"); // false
+check_is_not_special_numeric("1e5"); // false
+check_is_not_special_numeric("0b1010"); // false
+check_is_not_special_numeric("Infinity"); // false
 ```
 
-### `checkIsString`
+### `check_is_string`
 
 Checks if a given value is a string.
 
 ```ts
-checkIsString("hello world"); // true
+check_is_string("hello world"); // true
 
-checkIsString(123); // false
-checkIsString(true); // false
+check_is_string(123); // false
+check_is_string(true); // false
 ```
 
-### `checkIsNotString`
+### `check_is_not_string`
 
 Checks if a given value is not a string.
 
 ```ts
-checkIsNotString(123); // true
-checkIsNotString(true); // true
+check_is_not_string(123); // true
+check_is_not_string(true); // true
 
-checkIsNotString("hello world"); // false
+check_is_not_string("hello world"); // false
 ```
 
-### `checkHasSuffix`
+### `check_has_suffix`
 
 Checks if a given string ends with a specific suffix.
 
 ```ts
-checkHasSuffix("hello world", "world"); // true
-checkHasSuffix("hello world", "hello"); // false
+check_has_suffix("hello world", "world"); // true
+check_has_suffix("hello world", "hello"); // false
 ```
 
-### `checkDoesNotHaveSuffix`
+### `check_does_not_have_suffix`
 
 Checks if a given string does not end with a specific suffix.
 
 ```ts
-checkDoesNotHaveSuffix("hello world", "hello"); // true
-checkDoesNotHaveSuffix("hello world", "world"); // false
+check_does_not_have_suffix("hello world", "hello"); // true
+check_does_not_have_suffix("hello world", "world"); // false
 ```
 
-### `checkIsURLFormat`
+### `check_is_URL_format`
 
 Checks if a given string is in URL format.
 
 ```ts
-checkIsURLFormat("http://example.com"); // true
-checkIsURLFormat("https://example.com"); // true
-checkIsURLFormat("ftp://example.com"); // true
+check_is_URL_format("http://example.com"); // true
+check_is_URL_format("https://example.com"); // true
+check_is_URL_format("ftp://example.com"); // true
 
-checkIsURLFormat("invalid-url"); // false
-checkIsURLFormat("http://"); // false
+check_is_URL_format("invalid-url"); // false
+check_is_URL_format("http://"); // false
 ```
 
-### `checkIsNotURLFormat`
+### `check_is_not_URL_format`
 
 Checks if a given string is not in URL format.
 
 ```ts
-checkIsNotURLFormat("invalid-url"); // true
-checkIsNotURLFormat("http://"); // true
+check_is_not_URL_format("invalid-url"); // true
+check_is_not_URL_format("http://"); // true
 
-checkIsNotURLFormat("http://example.com"); // false
-checkIsNotURLFormat("https://example.com"); // false
-checkIsNotURLFormat("ftp://example.com"); // false
+check_is_not_URL_format("http://example.com"); // false
+check_is_not_URL_format("https://example.com"); // false
+check_is_not_URL_format("ftp://example.com"); // false
 ```
 
-### `checkIsUUIDFormat`
+### `check_is_UUID_format`
 
 Checks if a given string is in UUID format.
 
 ```ts
-checkIsUUIDFormat("123e4567-e89b-12d3-a456-426614174000"); // true
+check_is_UUID_format("123e4567-e89b-12d3-a456-426614174000"); // true
 
-checkIsUUIDFormat("invalid-uuid"); // false
-checkIsUUIDFormat("123e4567-e89b-12d3-a456-426614"); // false, this string is short.
+check_is_UUID_format("invalid-uuid"); // false
+check_is_UUID_format("123e4567-e89b-12d3-a456-426614"); // false, this string is short.
 ```
 
-### `checkIsNotUUIDFormat`
+### `check_is_not_UUID_format`
 
 Checks if a given string is not in UUID format.
 
 ```ts
-checkIsUUIDFormat("invalid-uuid"); // true
-checkIsUUIDFormat("123e4567-e89b-12d3-a456-42661417400"); // true
+check_is_not_UUID_format("invalid-uuid"); // true
+check_is_not_UUID_format("123e4567-e89b-12d3-a456-42661417400"); // true
 
-checkIsUUIDFormat("123e4567-e89b-12d3-a456-426614174000"); // false
+check_is_not_UUID_format("123e4567-e89b-12d3-a456-426614174000"); // false
 ```
 
 ### Licence

--- a/packages/string/README.md
+++ b/packages/string/README.md
@@ -152,9 +152,9 @@ check_is_enter_key("invalid-key"); // false
 
 ```ts
 inputElement.addEventListener("keydown", (event) => {
-	if (check_is_enter_key(event.key)) {
-		// When the Enter key is pressed
-	}
+  if (check_is_enter_key(event.key)) {
+    // When the Enter key is pressed
+  }
 });
 ```
 

--- a/packages/string/mod.ts
+++ b/packages/string/mod.ts
@@ -1,111 +1,117 @@
-import { checkIsNotString, checkIsString } from "./src/checkString/main.ts";
 import {
-  checkIsAlphanumeric,
-  checkIsNotAlphanumeric,
+	check_is_not_string,
+	check_is_string,
+} from "./src/checkString/main.ts";
+import {
+	check_is_alphanumeric,
+	check_is_not_alphanumeric,
 } from "./src/checkAlphanumeric/main.ts";
 import {
-  checkIsEmptryString,
-  checkIsNotEmptyString,
+	check_is_empty_string,
+	check_is_not_empty_string,
 } from "./src/checkEmptyString/main.ts";
 import {
-  checkDoesNotHaveSuffix,
-  checkHasSuffix,
+	check_does_not_have_suffix,
+	check_has_suffix,
 } from "./src/checkSuffix/main.ts";
 import {
-  checkDoesNotHaveSubstring,
-  checkHasSubstring,
+	check_does_not_have_substring,
+	check_has_substring,
 } from "./src/checkHasSubstring/main.ts";
 import {
-  checkIsIntegerOrDecimalString,
-  checkIsNotIntegerOrDecimalString,
+	check_is_integer_or_decimal_string,
+	check_is_not_integer_or_decimal_string,
 } from "./src/checkIntegerOrDecimalString/main.ts";
 import {
-  checkDoesNotHaveSpecialCharacter,
-  checkHasSpecialCharacter,
+	check_does_not_have_special_character,
+	check_has_special_character,
 } from "./src/checkSpecialCharacter/main.ts";
 import {
-  checkDoesNotHavePrefix,
-  checkHasPrefix,
+	check_does_not_have_prefix,
+	check_has_prefix,
 } from "./src/checkPrefix/main.ts";
 import {
-  checkIsAnyNumeric,
-  checkIsNotAnyNumeric,
+	check_is_any_numeric,
+	check_is_not_any_numeric,
 } from "./src/checkAnyNumeric/main.ts";
 import {
-  checkIsExponentialNotation,
-  checkIsNotExponentialNotation,
+	check_is_exponential_notation,
+	check_is_not_exponential_notation,
 } from "./src/checkExponentialNotation/main.ts";
 import {
-  checkIsIndexFound,
-  checkIsIndexNotFound,
+	check_is_index_found,
+	check_is_index_not_found,
 } from "./src/checkIndex/main.ts";
-import { checkIsBinary, checkIsNotBinary } from "./src/checkBinary/main.ts";
 import {
-  checkIsNotSpecialNumeric,
-  checkIsSpecialNumeric,
+	check_is_binary,
+	check_is_not_binary,
+} from "./src/checkBinary/main.ts";
+import {
+	check_is_not_special_numeric,
+	check_is_special_numeric,
 } from "./src/checkSpecialNumeric/main.ts";
 import {
-  checkIsInfinityString,
-  checkIsNotInfinityString,
+	check_is_infinity_string,
+	check_is_not_infinity_string,
 } from "./src/checkInfinityString/main.ts";
 import {
-  checkIsEmailFormat,
-  checkIsNotEmailFormat,
+	check_is_email_format,
+	check_is_not_email_format,
 } from "./src/checkEmailFormat/main.ts";
 import {
-  checkIsEnterKey,
-  checkIsNotEnterKey,
+	check_is_enter_key,
+	check_is_not_enter_key,
 } from "./src/checkEnterKey/main.ts";
 import {
-  checkIsISO8601Format,
-  checkIsNotISO8601Format,
+	check_is_ISO8601_format,
+	check_is_not_ISO8601_format,
 } from "./src/checkISO8601Format/main.ts";
 import {
-  checkIsNotURLFormat,
-  checkIsURLFormat,
+	check_is_not_URL_format,
+	check_is_URL_format,
 } from "./src/checkURLFormat/main.ts";
 import {
-  checkIsNotUUIDFormat,
-  checkIsUUIDFormat,
+	check_is_not_UUID_format,
+	check_is_UUID_format,
 } from "./src/checkUUIDFormat/main.ts";
 
 export {
-  checkDoesNotHavePrefix,
-  checkDoesNotHaveSpecialCharacter,
-  checkDoesNotHaveSubstring,
-  checkDoesNotHaveSuffix,
-  checkHasPrefix,
-  checkHasSpecialCharacter,
-  checkHasSubstring,
-  checkHasSuffix,
-  checkIsAlphanumeric,
-  checkIsAnyNumeric,
-  checkIsBinary,
-  checkIsEmailFormat,
-  checkIsEmptryString,
-  checkIsEnterKey,
-  checkIsExponentialNotation,
-  checkIsIndexFound,
-  checkIsIndexNotFound,
-  checkIsInfinityString,
-  checkIsIntegerOrDecimalString,
-  checkIsISO8601Format,
-  checkIsNotAlphanumeric,
-  checkIsNotAnyNumeric,
-  checkIsNotBinary,
-  checkIsNotEmailFormat,
-  checkIsNotEmptyString,
-  checkIsNotEnterKey,
-  checkIsNotExponentialNotation,
-  checkIsNotInfinityString,
-  checkIsNotIntegerOrDecimalString,
-  checkIsNotISO8601Format,
-  checkIsNotSpecialNumeric,
-  checkIsNotString,
-  checkIsNotURLFormat,
-  checkIsNotUUIDFormat,
-  checkIsSpecialNumeric,
-  checkIsString,
-  checkIsURLFormat,
-  checkIsUUIDFormat,
+	check_does_not_have_prefix,
+	check_does_not_have_special_character,
+	check_does_not_have_substring,
+	check_does_not_have_suffix,
+	check_has_prefix,
+	check_has_special_character,
+	check_has_substring,
+	check_has_suffix,
+	check_is_alphanumeric,
+	check_is_any_numeric,
+	check_is_binary,
+	check_is_email_format,
+	check_is_empty_string,
+	check_is_enter_key,
+	check_is_exponential_notation,
+	check_is_index_found,
+	check_is_index_not_found,
+	check_is_infinity_string,
+	check_is_integer_or_decimal_string,
+	check_is_ISO8601_format,
+	check_is_not_alphanumeric,
+	check_is_not_any_numeric,
+	check_is_not_binary,
+	check_is_not_email_format,
+	check_is_not_empty_string,
+	check_is_not_enter_key,
+	check_is_not_exponential_notation,
+	check_is_not_infinity_string,
+	check_is_not_integer_or_decimal_string,
+	check_is_not_ISO8601_format,
+	check_is_not_special_numeric,
+	check_is_not_string,
+	check_is_not_URL_format,
+	check_is_not_UUID_format,
+	check_is_special_numeric,
+	check_is_string,
+	check_is_URL_format,
+	check_is_UUID_format,
 };

--- a/packages/string/mod.ts
+++ b/packages/string/mod.ts
@@ -1,117 +1,117 @@
 import {
-	check_is_not_string,
-	check_is_string,
+  check_is_not_string,
+  check_is_string,
 } from "./src/checkString/main.ts";
 import {
-	check_is_alphanumeric,
-	check_is_not_alphanumeric,
+  check_is_alphanumeric,
+  check_is_not_alphanumeric,
 } from "./src/checkAlphanumeric/main.ts";
 import {
-	check_is_empty_string,
-	check_is_not_empty_string,
+  check_is_empty_string,
+  check_is_not_empty_string,
 } from "./src/checkEmptyString/main.ts";
 import {
-	check_does_not_have_suffix,
-	check_has_suffix,
+  check_does_not_have_suffix,
+  check_has_suffix,
 } from "./src/checkSuffix/main.ts";
 import {
-	check_does_not_have_substring,
-	check_has_substring,
+  check_does_not_have_substring,
+  check_has_substring,
 } from "./src/checkHasSubstring/main.ts";
 import {
-	check_is_integer_or_decimal_string,
-	check_is_not_integer_or_decimal_string,
+  check_is_integer_or_decimal_string,
+  check_is_not_integer_or_decimal_string,
 } from "./src/checkIntegerOrDecimalString/main.ts";
 import {
-	check_does_not_have_special_character,
-	check_has_special_character,
+  check_does_not_have_special_character,
+  check_has_special_character,
 } from "./src/checkSpecialCharacter/main.ts";
 import {
-	check_does_not_have_prefix,
-	check_has_prefix,
+  check_does_not_have_prefix,
+  check_has_prefix,
 } from "./src/checkPrefix/main.ts";
 import {
-	check_is_any_numeric,
-	check_is_not_any_numeric,
+  check_is_any_numeric,
+  check_is_not_any_numeric,
 } from "./src/checkAnyNumeric/main.ts";
 import {
-	check_is_exponential_notation,
-	check_is_not_exponential_notation,
+  check_is_exponential_notation,
+  check_is_not_exponential_notation,
 } from "./src/checkExponentialNotation/main.ts";
 import {
-	check_is_index_found,
-	check_is_index_not_found,
+  check_is_index_found,
+  check_is_index_not_found,
 } from "./src/checkIndex/main.ts";
 import {
-	check_is_binary,
-	check_is_not_binary,
+  check_is_binary,
+  check_is_not_binary,
 } from "./src/checkBinary/main.ts";
 import {
-	check_is_not_special_numeric,
-	check_is_special_numeric,
+  check_is_not_special_numeric,
+  check_is_special_numeric,
 } from "./src/checkSpecialNumeric/main.ts";
 import {
-	check_is_infinity_string,
-	check_is_not_infinity_string,
+  check_is_infinity_string,
+  check_is_not_infinity_string,
 } from "./src/checkInfinityString/main.ts";
 import {
-	check_is_email_format,
-	check_is_not_email_format,
+  check_is_email_format,
+  check_is_not_email_format,
 } from "./src/checkEmailFormat/main.ts";
 import {
-	check_is_enter_key,
-	check_is_not_enter_key,
+  check_is_enter_key,
+  check_is_not_enter_key,
 } from "./src/checkEnterKey/main.ts";
 import {
-	check_is_ISO8601_format,
-	check_is_not_ISO8601_format,
+  check_is_ISO8601_format,
+  check_is_not_ISO8601_format,
 } from "./src/checkISO8601Format/main.ts";
 import {
-	check_is_not_URL_format,
-	check_is_URL_format,
+  check_is_not_URL_format,
+  check_is_URL_format,
 } from "./src/checkURLFormat/main.ts";
 import {
-	check_is_not_UUID_format,
-	check_is_UUID_format,
+  check_is_not_UUID_format,
+  check_is_UUID_format,
 } from "./src/checkUUIDFormat/main.ts";
 
 export {
-	check_does_not_have_prefix,
-	check_does_not_have_special_character,
-	check_does_not_have_substring,
-	check_does_not_have_suffix,
-	check_has_prefix,
-	check_has_special_character,
-	check_has_substring,
-	check_has_suffix,
-	check_is_alphanumeric,
-	check_is_any_numeric,
-	check_is_binary,
-	check_is_email_format,
-	check_is_empty_string,
-	check_is_enter_key,
-	check_is_exponential_notation,
-	check_is_index_found,
-	check_is_index_not_found,
-	check_is_infinity_string,
-	check_is_integer_or_decimal_string,
-	check_is_ISO8601_format,
-	check_is_not_alphanumeric,
-	check_is_not_any_numeric,
-	check_is_not_binary,
-	check_is_not_email_format,
-	check_is_not_empty_string,
-	check_is_not_enter_key,
-	check_is_not_exponential_notation,
-	check_is_not_infinity_string,
-	check_is_not_integer_or_decimal_string,
-	check_is_not_ISO8601_format,
-	check_is_not_special_numeric,
-	check_is_not_string,
-	check_is_not_URL_format,
-	check_is_not_UUID_format,
-	check_is_special_numeric,
-	check_is_string,
-	check_is_URL_format,
-	check_is_UUID_format,
+  check_does_not_have_prefix,
+  check_does_not_have_special_character,
+  check_does_not_have_substring,
+  check_does_not_have_suffix,
+  check_has_prefix,
+  check_has_special_character,
+  check_has_substring,
+  check_has_suffix,
+  check_is_alphanumeric,
+  check_is_any_numeric,
+  check_is_binary,
+  check_is_email_format,
+  check_is_empty_string,
+  check_is_enter_key,
+  check_is_exponential_notation,
+  check_is_index_found,
+  check_is_index_not_found,
+  check_is_infinity_string,
+  check_is_integer_or_decimal_string,
+  check_is_ISO8601_format,
+  check_is_not_alphanumeric,
+  check_is_not_any_numeric,
+  check_is_not_binary,
+  check_is_not_email_format,
+  check_is_not_empty_string,
+  check_is_not_enter_key,
+  check_is_not_exponential_notation,
+  check_is_not_infinity_string,
+  check_is_not_integer_or_decimal_string,
+  check_is_not_ISO8601_format,
+  check_is_not_special_numeric,
+  check_is_not_string,
+  check_is_not_URL_format,
+  check_is_not_UUID_format,
+  check_is_special_numeric,
+  check_is_string,
+  check_is_URL_format,
+  check_is_UUID_format,
 };

--- a/packages/string/src/checkAlphanumeric/main.ts
+++ b/packages/string/src/checkAlphanumeric/main.ts
@@ -15,8 +15,8 @@
  * check_is_alphanumeric('abc123!'); // The string contains a special character '!'
  */
 export const check_is_alphanumeric = (str: string): boolean => {
-	const alphanumericRegex = /^[a-z0-9]+$/i;
-	return alphanumericRegex.test(str);
+  const alphanumericRegex = /^[a-z0-9]+$/i;
+  return alphanumericRegex.test(str);
 };
 
 /**
@@ -36,5 +36,5 @@ export const check_is_alphanumeric = (str: string): boolean => {
  * check_is_not_alphanumeric('abc123'); // The string contains only letters and numbers
  */
 export const check_is_not_alphanumeric = (str: string): boolean => {
-	return !check_is_alphanumeric(str);
+  return !check_is_alphanumeric(str);
 };

--- a/packages/string/src/checkAlphanumeric/main.ts
+++ b/packages/string/src/checkAlphanumeric/main.ts
@@ -8,33 +8,33 @@
  *
  * @example
  * // Returns true
- * checkIsAlphanumeric('abc123'); // The string contains only letters and numbers
+ * check_is_alphanumeric('abc123'); // The string contains only letters and numbers
  *
  * @example
  * // Returns false
- * checkIsAlphanumeric('abc123!'); // The string contains a special character '!'
+ * check_is_alphanumeric('abc123!'); // The string contains a special character '!'
  */
-export const checkIsAlphanumeric = (str: string): boolean => {
-  const alphanumericRegex = /^[a-z0-9]+$/i;
-  return alphanumericRegex.test(str);
+export const check_is_alphanumeric = (str: string): boolean => {
+	const alphanumericRegex = /^[a-z0-9]+$/i;
+	return alphanumericRegex.test(str);
 };
 
 /**
  * Checks if a given string is not alphanumeric.
  *
- * This is the inverse of `checkIsAlphanumeric`.
+ * This is the inverse of `check_is_alphanumeric`.
  *
  * @param {string} str - The string to check.
  * @returns {boolean} True if the string is not alphanumeric, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotAlphanumeric('abc123!'); // The string contains a special character '!'
+ * check_is_not_alphanumeric('abc123!'); // The string contains a special character '!'
  *
  * @example
  * // Returns false
- * checkIsNotAlphanumeric('abc123'); // The string contains only letters and numbers
+ * check_is_not_alphanumeric('abc123'); // The string contains only letters and numbers
  */
-export const checkIsNotAlphanumeric = (str: string): boolean => {
-  return !checkIsAlphanumeric(str);
+export const check_is_not_alphanumeric = (str: string): boolean => {
+	return !check_is_alphanumeric(str);
 };

--- a/packages/string/src/checkAlphanumeric/test.ts
+++ b/packages/string/src/checkAlphanumeric/test.ts
@@ -1,42 +1,42 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsAlphanumeric, checkIsNotAlphanumeric } from "./main.ts";
+import { check_is_alphanumeric, check_is_not_alphanumeric } from "./main.ts";
 
-Deno.test("checkIsAlphanumeric", async (t) => {
-  await t.step("should return true for alphanumeric strings", () => {
-    assertEquals(checkIsAlphanumeric("abc123"), true);
-    assertEquals(checkIsAlphanumeric("ABC123"), true);
-    assertEquals(checkIsAlphanumeric("a1b2c3"), true);
-    assertEquals(checkIsAlphanumeric("123456"), true);
-    assertEquals(checkIsAlphanumeric("abcdef"), true);
-    assertEquals(checkIsAlphanumeric("ABCDEF"), true);
-  });
+Deno.test("check_is_alphanumeric", async (t) => {
+	await t.step("should return true for alphanumeric strings", () => {
+		assertEquals(check_is_alphanumeric("abc123"), true);
+		assertEquals(check_is_alphanumeric("ABC123"), true);
+		assertEquals(check_is_alphanumeric("a1b2c3"), true);
+		assertEquals(check_is_alphanumeric("123456"), true);
+		assertEquals(check_is_alphanumeric("abcdef"), true);
+		assertEquals(check_is_alphanumeric("ABCDEF"), true);
+	});
 
-  await t.step("should return false for non-alphanumeric strings", () => {
-    assertEquals(checkIsAlphanumeric("abc!123"), false);
-    assertEquals(checkIsAlphanumeric("abc 123"), false); // space is not alphanumeric
-    assertEquals(checkIsAlphanumeric("abc-123"), false);
-    assertEquals(checkIsAlphanumeric("abc123@"), false);
-    assertEquals(checkIsAlphanumeric("!@#"), false);
-    assertEquals(checkIsAlphanumeric(" "), false);
-  });
+	await t.step("should return false for non-alphanumeric strings", () => {
+		assertEquals(check_is_alphanumeric("abc!123"), false);
+		assertEquals(check_is_alphanumeric("abc 123"), false); // space is not alphanumeric
+		assertEquals(check_is_alphanumeric("abc-123"), false);
+		assertEquals(check_is_alphanumeric("abc123@"), false);
+		assertEquals(check_is_alphanumeric("!@#"), false);
+		assertEquals(check_is_alphanumeric(" "), false);
+	});
 });
 
-Deno.test("checkIsNotAlphanumeric", async (t) => {
-  await t.step("should return true for non-alphanumeric strings", () => {
-    assertEquals(checkIsNotAlphanumeric("abc!123"), true);
-    assertEquals(checkIsNotAlphanumeric("abc 123"), true); // space is not alphanumeric
-    assertEquals(checkIsNotAlphanumeric("abc-123"), true);
-    assertEquals(checkIsNotAlphanumeric("abc123@"), true);
-    assertEquals(checkIsNotAlphanumeric("!@#"), true);
-    assertEquals(checkIsNotAlphanumeric(" "), true);
-  });
+Deno.test("check_is_not_alphanumeric", async (t) => {
+	await t.step("should return true for non-alphanumeric strings", () => {
+		assertEquals(check_is_not_alphanumeric("abc!123"), true);
+		assertEquals(check_is_not_alphanumeric("abc 123"), true); // space is not alphanumeric
+		assertEquals(check_is_not_alphanumeric("abc-123"), true);
+		assertEquals(check_is_not_alphanumeric("abc123@"), true);
+		assertEquals(check_is_not_alphanumeric("!@#"), true);
+		assertEquals(check_is_not_alphanumeric(" "), true);
+	});
 
-  await t.step("should return false for alphanumeric strings", () => {
-    assertEquals(checkIsNotAlphanumeric("abc123"), false);
-    assertEquals(checkIsNotAlphanumeric("ABC123"), false);
-    assertEquals(checkIsNotAlphanumeric("a1b2c3"), false);
-    assertEquals(checkIsNotAlphanumeric("123456"), false);
-    assertEquals(checkIsNotAlphanumeric("abcdef"), false);
-    assertEquals(checkIsNotAlphanumeric("ABCDEF"), false);
-  });
+	await t.step("should return false for alphanumeric strings", () => {
+		assertEquals(check_is_not_alphanumeric("abc123"), false);
+		assertEquals(check_is_not_alphanumeric("ABC123"), false);
+		assertEquals(check_is_not_alphanumeric("a1b2c3"), false);
+		assertEquals(check_is_not_alphanumeric("123456"), false);
+		assertEquals(check_is_not_alphanumeric("abcdef"), false);
+		assertEquals(check_is_not_alphanumeric("ABCDEF"), false);
+	});
 });

--- a/packages/string/src/checkAlphanumeric/test.ts
+++ b/packages/string/src/checkAlphanumeric/test.ts
@@ -2,41 +2,41 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_alphanumeric, check_is_not_alphanumeric } from "./main.ts";
 
 Deno.test("check_is_alphanumeric", async (t) => {
-	await t.step("should return true for alphanumeric strings", () => {
-		assertEquals(check_is_alphanumeric("abc123"), true);
-		assertEquals(check_is_alphanumeric("ABC123"), true);
-		assertEquals(check_is_alphanumeric("a1b2c3"), true);
-		assertEquals(check_is_alphanumeric("123456"), true);
-		assertEquals(check_is_alphanumeric("abcdef"), true);
-		assertEquals(check_is_alphanumeric("ABCDEF"), true);
-	});
+  await t.step("should return true for alphanumeric strings", () => {
+    assertEquals(check_is_alphanumeric("abc123"), true);
+    assertEquals(check_is_alphanumeric("ABC123"), true);
+    assertEquals(check_is_alphanumeric("a1b2c3"), true);
+    assertEquals(check_is_alphanumeric("123456"), true);
+    assertEquals(check_is_alphanumeric("abcdef"), true);
+    assertEquals(check_is_alphanumeric("ABCDEF"), true);
+  });
 
-	await t.step("should return false for non-alphanumeric strings", () => {
-		assertEquals(check_is_alphanumeric("abc!123"), false);
-		assertEquals(check_is_alphanumeric("abc 123"), false); // space is not alphanumeric
-		assertEquals(check_is_alphanumeric("abc-123"), false);
-		assertEquals(check_is_alphanumeric("abc123@"), false);
-		assertEquals(check_is_alphanumeric("!@#"), false);
-		assertEquals(check_is_alphanumeric(" "), false);
-	});
+  await t.step("should return false for non-alphanumeric strings", () => {
+    assertEquals(check_is_alphanumeric("abc!123"), false);
+    assertEquals(check_is_alphanumeric("abc 123"), false); // space is not alphanumeric
+    assertEquals(check_is_alphanumeric("abc-123"), false);
+    assertEquals(check_is_alphanumeric("abc123@"), false);
+    assertEquals(check_is_alphanumeric("!@#"), false);
+    assertEquals(check_is_alphanumeric(" "), false);
+  });
 });
 
 Deno.test("check_is_not_alphanumeric", async (t) => {
-	await t.step("should return true for non-alphanumeric strings", () => {
-		assertEquals(check_is_not_alphanumeric("abc!123"), true);
-		assertEquals(check_is_not_alphanumeric("abc 123"), true); // space is not alphanumeric
-		assertEquals(check_is_not_alphanumeric("abc-123"), true);
-		assertEquals(check_is_not_alphanumeric("abc123@"), true);
-		assertEquals(check_is_not_alphanumeric("!@#"), true);
-		assertEquals(check_is_not_alphanumeric(" "), true);
-	});
+  await t.step("should return true for non-alphanumeric strings", () => {
+    assertEquals(check_is_not_alphanumeric("abc!123"), true);
+    assertEquals(check_is_not_alphanumeric("abc 123"), true); // space is not alphanumeric
+    assertEquals(check_is_not_alphanumeric("abc-123"), true);
+    assertEquals(check_is_not_alphanumeric("abc123@"), true);
+    assertEquals(check_is_not_alphanumeric("!@#"), true);
+    assertEquals(check_is_not_alphanumeric(" "), true);
+  });
 
-	await t.step("should return false for alphanumeric strings", () => {
-		assertEquals(check_is_not_alphanumeric("abc123"), false);
-		assertEquals(check_is_not_alphanumeric("ABC123"), false);
-		assertEquals(check_is_not_alphanumeric("a1b2c3"), false);
-		assertEquals(check_is_not_alphanumeric("123456"), false);
-		assertEquals(check_is_not_alphanumeric("abcdef"), false);
-		assertEquals(check_is_not_alphanumeric("ABCDEF"), false);
-	});
+  await t.step("should return false for alphanumeric strings", () => {
+    assertEquals(check_is_not_alphanumeric("abc123"), false);
+    assertEquals(check_is_not_alphanumeric("ABC123"), false);
+    assertEquals(check_is_not_alphanumeric("a1b2c3"), false);
+    assertEquals(check_is_not_alphanumeric("123456"), false);
+    assertEquals(check_is_not_alphanumeric("abcdef"), false);
+    assertEquals(check_is_not_alphanumeric("ABCDEF"), false);
+  });
 });

--- a/packages/string/src/checkAnyNumeric/main.ts
+++ b/packages/string/src/checkAnyNumeric/main.ts
@@ -29,7 +29,7 @@
  * check_is_any_numeric('abc'); // The string cannot be converted to a number
  */
 export const check_is_any_numeric = (str: string): boolean => {
-	return !isNaN(Number(str));
+  return !isNaN(Number(str));
 };
 
 /**
@@ -53,5 +53,5 @@ export const check_is_any_numeric = (str: string): boolean => {
  * check_is_not_any_numeric(''); // An empty string is evaluated as 0
  */
 export const check_is_not_any_numeric = (str: string): boolean => {
-	return !check_is_any_numeric(str);
+  return !check_is_any_numeric(str);
 };

--- a/packages/string/src/checkAnyNumeric/main.ts
+++ b/packages/string/src/checkAnyNumeric/main.ts
@@ -10,48 +10,48 @@
  *
  * @example
  * // Returns true
- * checkIsAnyNumeric('123'); // The string represents an integer number
+ * check_is_any_numeric('123'); // The string represents an integer number
  *
  * @example
  * // Returns true
- * checkIsAnyNumeric('3.14'); // The string represents a floating-point number
+ * check_is_any_numeric('3.14'); // The string represents a floating-point number
  *
  * @example
  * // Returns true
- * checkIsAnyNumeric('Infinity'); // The string represents a special numeric value
+ * check_is_any_numeric('Infinity'); // The string represents a special numeric value
  *
  * @example
  * // Returns true
- * checkIsAnyNumeric(''); // An empty string is evaluated as 0
+ * check_is_any_numeric(''); // An empty string is evaluated as 0
  *
  * @example
  * // Returns false
- * checkIsAnyNumeric('abc'); // The string cannot be converted to a number
+ * check_is_any_numeric('abc'); // The string cannot be converted to a number
  */
-export const checkIsAnyNumeric = (str: string): boolean => {
-  return !isNaN(Number(str));
+export const check_is_any_numeric = (str: string): boolean => {
+	return !isNaN(Number(str));
 };
 
 /**
  * Checks if a given string is not numeric.
  *
- * This is the inverse of `checkIsAnyNumeric`.
+ * This is the inverse of `check_is_any_numeric`.
  *
  * @param {string} str - The string to check.
  * @returns {boolean} True if the string is not numeric, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotAnyNumeric('abc'); // The string cannot be converted to a number
+ * check_is_not_any_numeric('abc'); // The string cannot be converted to a number
  *
  * @example
  * // Returns false
- * checkIsNotAnyNumeric('123'); // The string represents an integer number
+ * check_is_not_any_numeric('123'); // The string represents an integer number
  *
  * @example
  * // Returns false
- * checkIsNotAnyNumeric(''); // An empty string is evaluated as 0
+ * check_is_not_any_numeric(''); // An empty string is evaluated as 0
  */
-export const checkIsNotAnyNumeric = (str: string): boolean => {
-  return !checkIsAnyNumeric(str);
+export const check_is_not_any_numeric = (str: string): boolean => {
+	return !check_is_any_numeric(str);
 };

--- a/packages/string/src/checkAnyNumeric/test.ts
+++ b/packages/string/src/checkAnyNumeric/test.ts
@@ -2,43 +2,43 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_any_numeric, check_is_not_any_numeric } from "./main.ts";
 
 Deno.test("check_is_any_numeric", async (t) => {
-	await t.step("should return true for numeric strings", () => {
-		assertEquals(check_is_any_numeric("123"), true); // plain integer
-		assertEquals(check_is_any_numeric("0"), true); // zero
-		assertEquals(check_is_any_numeric("-123"), true); // negative integer
-		assertEquals(check_is_any_numeric("3.14"), true); // plain float
-		assertEquals(check_is_any_numeric("-3.14"), true); // negative float
-		assertEquals(check_is_any_numeric("1e5"), true); // exponential notation
-		assertEquals(check_is_any_numeric("Infinity"), true); // Infinity as a numeric value
-		assertEquals(check_is_any_numeric("0b101"), true); // binary notation
-		assertEquals(check_is_any_numeric(""), true); // empty string evaluate 0
-		assertEquals(check_is_any_numeric(" "), true); // space string evaluate 0
-	});
+  await t.step("should return true for numeric strings", () => {
+    assertEquals(check_is_any_numeric("123"), true); // plain integer
+    assertEquals(check_is_any_numeric("0"), true); // zero
+    assertEquals(check_is_any_numeric("-123"), true); // negative integer
+    assertEquals(check_is_any_numeric("3.14"), true); // plain float
+    assertEquals(check_is_any_numeric("-3.14"), true); // negative float
+    assertEquals(check_is_any_numeric("1e5"), true); // exponential notation
+    assertEquals(check_is_any_numeric("Infinity"), true); // Infinity as a numeric value
+    assertEquals(check_is_any_numeric("0b101"), true); // binary notation
+    assertEquals(check_is_any_numeric(""), true); // empty string evaluate 0
+    assertEquals(check_is_any_numeric(" "), true); // space string evaluate 0
+  });
 
-	await t.step("should return false for non-numeric strings", () => {
-		assertEquals(check_is_any_numeric("abc"), false); // alphabetic string
-		assertEquals(check_is_any_numeric("123abc"), false); // alphanumeric string
-		assertEquals(check_is_any_numeric("NaN"), false); // "NaN" as a string
-	});
+  await t.step("should return false for non-numeric strings", () => {
+    assertEquals(check_is_any_numeric("abc"), false); // alphabetic string
+    assertEquals(check_is_any_numeric("123abc"), false); // alphanumeric string
+    assertEquals(check_is_any_numeric("NaN"), false); // "NaN" as a string
+  });
 });
 
 Deno.test("check_is_not_any_numeric", async (t) => {
-	await t.step("should return true for non-numeric strings", () => {
-		assertEquals(check_is_not_any_numeric("abc"), true); // alphabetic string
-		assertEquals(check_is_not_any_numeric("123abc"), true); // alphanumeric string
-		assertEquals(check_is_not_any_numeric("NaN"), true); // "NaN" as a string
-	});
+  await t.step("should return true for non-numeric strings", () => {
+    assertEquals(check_is_not_any_numeric("abc"), true); // alphabetic string
+    assertEquals(check_is_not_any_numeric("123abc"), true); // alphanumeric string
+    assertEquals(check_is_not_any_numeric("NaN"), true); // "NaN" as a string
+  });
 
-	await t.step("should return false for numeric strings", () => {
-		assertEquals(check_is_not_any_numeric("123"), false); // plain integer
-		assertEquals(check_is_not_any_numeric("0"), false); // zero
-		assertEquals(check_is_not_any_numeric("-123"), false); // negative integer
-		assertEquals(check_is_not_any_numeric("3.14"), false); // plain float
-		assertEquals(check_is_not_any_numeric("-3.14"), false); // negative float
-		assertEquals(check_is_not_any_numeric("1e5"), false); // exponential notation
-		assertEquals(check_is_not_any_numeric("Infinity"), false); // Infinity as a numeric value
-		assertEquals(check_is_not_any_numeric("0b101"), false); // binary notation
-		assertEquals(check_is_not_any_numeric(""), false); // empty string evaluate 0
-		assertEquals(check_is_not_any_numeric(" "), false); // space string evaluate 0
-	});
+  await t.step("should return false for numeric strings", () => {
+    assertEquals(check_is_not_any_numeric("123"), false); // plain integer
+    assertEquals(check_is_not_any_numeric("0"), false); // zero
+    assertEquals(check_is_not_any_numeric("-123"), false); // negative integer
+    assertEquals(check_is_not_any_numeric("3.14"), false); // plain float
+    assertEquals(check_is_not_any_numeric("-3.14"), false); // negative float
+    assertEquals(check_is_not_any_numeric("1e5"), false); // exponential notation
+    assertEquals(check_is_not_any_numeric("Infinity"), false); // Infinity as a numeric value
+    assertEquals(check_is_not_any_numeric("0b101"), false); // binary notation
+    assertEquals(check_is_not_any_numeric(""), false); // empty string evaluate 0
+    assertEquals(check_is_not_any_numeric(" "), false); // space string evaluate 0
+  });
 });

--- a/packages/string/src/checkAnyNumeric/test.ts
+++ b/packages/string/src/checkAnyNumeric/test.ts
@@ -1,44 +1,44 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsAnyNumeric, checkIsNotAnyNumeric } from "./main.ts";
+import { check_is_any_numeric, check_is_not_any_numeric } from "./main.ts";
 
-Deno.test("checkIsAnyNumeric", async (t) => {
-  await t.step("should return true for numeric strings", () => {
-    assertEquals(checkIsAnyNumeric("123"), true); // plain integer
-    assertEquals(checkIsAnyNumeric("0"), true); // zero
-    assertEquals(checkIsAnyNumeric("-123"), true); // negative integer
-    assertEquals(checkIsAnyNumeric("3.14"), true); // plain float
-    assertEquals(checkIsAnyNumeric("-3.14"), true); // negative float
-    assertEquals(checkIsAnyNumeric("1e5"), true); // exponential notation
-    assertEquals(checkIsAnyNumeric("Infinity"), true); // Infinity as a numeric value
-    assertEquals(checkIsAnyNumeric("0b101"), true); // binary notation
-    assertEquals(checkIsAnyNumeric(""), true); // empty string evaluate 0
-    assertEquals(checkIsAnyNumeric(" "), true); // space string evaluate 0
-  });
+Deno.test("check_is_any_numeric", async (t) => {
+	await t.step("should return true for numeric strings", () => {
+		assertEquals(check_is_any_numeric("123"), true); // plain integer
+		assertEquals(check_is_any_numeric("0"), true); // zero
+		assertEquals(check_is_any_numeric("-123"), true); // negative integer
+		assertEquals(check_is_any_numeric("3.14"), true); // plain float
+		assertEquals(check_is_any_numeric("-3.14"), true); // negative float
+		assertEquals(check_is_any_numeric("1e5"), true); // exponential notation
+		assertEquals(check_is_any_numeric("Infinity"), true); // Infinity as a numeric value
+		assertEquals(check_is_any_numeric("0b101"), true); // binary notation
+		assertEquals(check_is_any_numeric(""), true); // empty string evaluate 0
+		assertEquals(check_is_any_numeric(" "), true); // space string evaluate 0
+	});
 
-  await t.step("should return false for non-numeric strings", () => {
-    assertEquals(checkIsAnyNumeric("abc"), false); // alphabetic string
-    assertEquals(checkIsAnyNumeric("123abc"), false); // alphanumeric string
-    assertEquals(checkIsAnyNumeric("NaN"), false); // "NaN" as a string
-  });
+	await t.step("should return false for non-numeric strings", () => {
+		assertEquals(check_is_any_numeric("abc"), false); // alphabetic string
+		assertEquals(check_is_any_numeric("123abc"), false); // alphanumeric string
+		assertEquals(check_is_any_numeric("NaN"), false); // "NaN" as a string
+	});
 });
 
-Deno.test("checkIsNotAnyNumeric", async (t) => {
-  await t.step("should return true for non-numeric strings", () => {
-    assertEquals(checkIsNotAnyNumeric("abc"), true); // alphabetic string
-    assertEquals(checkIsNotAnyNumeric("123abc"), true); // alphanumeric string
-    assertEquals(checkIsNotAnyNumeric("NaN"), true); // "NaN" as a string
-  });
+Deno.test("check_is_not_any_numeric", async (t) => {
+	await t.step("should return true for non-numeric strings", () => {
+		assertEquals(check_is_not_any_numeric("abc"), true); // alphabetic string
+		assertEquals(check_is_not_any_numeric("123abc"), true); // alphanumeric string
+		assertEquals(check_is_not_any_numeric("NaN"), true); // "NaN" as a string
+	});
 
-  await t.step("should return false for numeric strings", () => {
-    assertEquals(checkIsNotAnyNumeric("123"), false); // plain integer
-    assertEquals(checkIsNotAnyNumeric("0"), false); // zero
-    assertEquals(checkIsNotAnyNumeric("-123"), false); // negative integer
-    assertEquals(checkIsNotAnyNumeric("3.14"), false); // plain float
-    assertEquals(checkIsNotAnyNumeric("-3.14"), false); // negative float
-    assertEquals(checkIsNotAnyNumeric("1e5"), false); // exponential notation
-    assertEquals(checkIsNotAnyNumeric("Infinity"), false); // Infinity as a numeric value
-    assertEquals(checkIsNotAnyNumeric("0b101"), false); // binary notation
-    assertEquals(checkIsNotAnyNumeric(""), false); // empty string evaluate 0
-    assertEquals(checkIsNotAnyNumeric(" "), false); // space string evaluate 0
-  });
+	await t.step("should return false for numeric strings", () => {
+		assertEquals(check_is_not_any_numeric("123"), false); // plain integer
+		assertEquals(check_is_not_any_numeric("0"), false); // zero
+		assertEquals(check_is_not_any_numeric("-123"), false); // negative integer
+		assertEquals(check_is_not_any_numeric("3.14"), false); // plain float
+		assertEquals(check_is_not_any_numeric("-3.14"), false); // negative float
+		assertEquals(check_is_not_any_numeric("1e5"), false); // exponential notation
+		assertEquals(check_is_not_any_numeric("Infinity"), false); // Infinity as a numeric value
+		assertEquals(check_is_not_any_numeric("0b101"), false); // binary notation
+		assertEquals(check_is_not_any_numeric(""), false); // empty string evaluate 0
+		assertEquals(check_is_not_any_numeric(" "), false); // space string evaluate 0
+	});
 });

--- a/packages/string/src/checkBinary/main.ts
+++ b/packages/string/src/checkBinary/main.ts
@@ -19,8 +19,8 @@
  * check_is_binary('1010'); // The string does not start with '0b' or '0B'
  */
 export const check_is_binary = (str: string): boolean => {
-	const binaryRegex = /^0[bB][01]+$/;
-	return binaryRegex.test(str);
+  const binaryRegex = /^0[bB][01]+$/;
+  return binaryRegex.test(str);
 };
 
 /**
@@ -40,5 +40,5 @@ export const check_is_binary = (str: string): boolean => {
  * check_is_not_binary('0b1010'); // The string is a valid binary number
  */
 export const check_is_not_binary = (str: string): boolean => {
-	return !check_is_binary(str);
+  return !check_is_binary(str);
 };

--- a/packages/string/src/checkBinary/main.ts
+++ b/packages/string/src/checkBinary/main.ts
@@ -8,37 +8,37 @@
  *
  * @example
  * // Returns true
- * checkIsBinary('0b1010'); // The string is a valid binary number
+ * check_is_binary('0b1010'); // The string is a valid binary number
  *
  * @example
  * // Returns false
- * checkIsBinary('0b102'); // The string contains a digit '2', which is not valid in binary
+ * check_is_binary('0b102'); // The string contains a digit '2', which is not valid in binary
  *
  * @example
  * // Returns false
- * checkIsBinary('1010'); // The string does not start with '0b' or '0B'
+ * check_is_binary('1010'); // The string does not start with '0b' or '0B'
  */
-export const checkIsBinary = (str: string): boolean => {
-  const binaryRegex = /^0[bB][01]+$/;
-  return binaryRegex.test(str);
+export const check_is_binary = (str: string): boolean => {
+	const binaryRegex = /^0[bB][01]+$/;
+	return binaryRegex.test(str);
 };
 
 /**
  * Checks if a given string does not represent a binary number.
  *
- * This is the inverse of `checkIsBinary`.
+ * This is the inverse of `check_is_binary`.
  *
  * @param {string} str - The string to check.
  * @returns {boolean} True if the string does not represent a binary number, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotBinary('1010'); // The string does not start with '0b' or '0B'
+ * check_is_not_binary('1010'); // The string does not start with '0b' or '0B'
  *
  * @example
  * // Returns false
- * checkIsNotBinary('0b1010'); // The string is a valid binary number
+ * check_is_not_binary('0b1010'); // The string is a valid binary number
  */
-export const checkIsNotBinary = (str: string): boolean => {
-  return !checkIsBinary(str);
+export const check_is_not_binary = (str: string): boolean => {
+	return !check_is_binary(str);
 };

--- a/packages/string/src/checkBinary/test.ts
+++ b/packages/string/src/checkBinary/test.ts
@@ -2,37 +2,37 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_binary, check_is_not_binary } from "./main.ts";
 
 Deno.test("check_is_binary", async (t) => {
-	await t.step("should return true for binary strings", () => {
-		assertEquals(check_is_binary("0b101"), true); // simple binary
-		assertEquals(check_is_binary("0B1101"), true); // capital B
-		assertEquals(check_is_binary("0b0"), true); // single digit binary
-		assertEquals(check_is_binary("0b11111111"), true); // multiple digits binary
-	});
+  await t.step("should return true for binary strings", () => {
+    assertEquals(check_is_binary("0b101"), true); // simple binary
+    assertEquals(check_is_binary("0B1101"), true); // capital B
+    assertEquals(check_is_binary("0b0"), true); // single digit binary
+    assertEquals(check_is_binary("0b11111111"), true); // multiple digits binary
+  });
 
-	await t.step("should return false for non-binary strings", () => {
-		assertEquals(check_is_binary("101"), false); // missing binary prefix
-		assertEquals(check_is_binary("0b102"), false); // invalid binary digits
-		assertEquals(check_is_binary("0b"), false); // only prefix, no digits
-		assertEquals(check_is_binary("0b "), false); // space after prefix
-		assertEquals(check_is_binary(""), false); // empty string
-		assertEquals(check_is_binary("0bxyz"), false); // non-binary characters
-	});
+  await t.step("should return false for non-binary strings", () => {
+    assertEquals(check_is_binary("101"), false); // missing binary prefix
+    assertEquals(check_is_binary("0b102"), false); // invalid binary digits
+    assertEquals(check_is_binary("0b"), false); // only prefix, no digits
+    assertEquals(check_is_binary("0b "), false); // space after prefix
+    assertEquals(check_is_binary(""), false); // empty string
+    assertEquals(check_is_binary("0bxyz"), false); // non-binary characters
+  });
 });
 
 Deno.test("check_is_not_binary", async (t) => {
-	await t.step("should return true for non-binary strings", () => {
-		assertEquals(check_is_not_binary("101"), true); // missing binary prefix
-		assertEquals(check_is_not_binary("0b102"), true); // invalid binary digits
-		assertEquals(check_is_not_binary("0b"), true); // only prefix, no digits
-		assertEquals(check_is_not_binary("0b "), true); // space after prefix
-		assertEquals(check_is_not_binary(""), true); // empty string
-		assertEquals(check_is_not_binary("0bxyz"), true); // non-binary characters
-	});
+  await t.step("should return true for non-binary strings", () => {
+    assertEquals(check_is_not_binary("101"), true); // missing binary prefix
+    assertEquals(check_is_not_binary("0b102"), true); // invalid binary digits
+    assertEquals(check_is_not_binary("0b"), true); // only prefix, no digits
+    assertEquals(check_is_not_binary("0b "), true); // space after prefix
+    assertEquals(check_is_not_binary(""), true); // empty string
+    assertEquals(check_is_not_binary("0bxyz"), true); // non-binary characters
+  });
 
-	await t.step("should return false for binary strings", () => {
-		assertEquals(check_is_not_binary("0b101"), false); // simple binary
-		assertEquals(check_is_not_binary("0B1101"), false); // capital B
-		assertEquals(check_is_not_binary("0b0"), false); // single digit binary
-		assertEquals(check_is_not_binary("0b11111111"), false); // multiple digits binary
-	});
+  await t.step("should return false for binary strings", () => {
+    assertEquals(check_is_not_binary("0b101"), false); // simple binary
+    assertEquals(check_is_not_binary("0B1101"), false); // capital B
+    assertEquals(check_is_not_binary("0b0"), false); // single digit binary
+    assertEquals(check_is_not_binary("0b11111111"), false); // multiple digits binary
+  });
 });

--- a/packages/string/src/checkBinary/test.ts
+++ b/packages/string/src/checkBinary/test.ts
@@ -1,38 +1,38 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsBinary, checkIsNotBinary } from "./main.ts";
+import { check_is_binary, check_is_not_binary } from "./main.ts";
 
-Deno.test("checkStringIsBinary", async (t) => {
-  await t.step("should return true for binary strings", () => {
-    assertEquals(checkIsBinary("0b101"), true); // simple binary
-    assertEquals(checkIsBinary("0B1101"), true); // capital B
-    assertEquals(checkIsBinary("0b0"), true); // single digit binary
-    assertEquals(checkIsBinary("0b11111111"), true); // multiple digits binary
-  });
+Deno.test("check_is_binary", async (t) => {
+	await t.step("should return true for binary strings", () => {
+		assertEquals(check_is_binary("0b101"), true); // simple binary
+		assertEquals(check_is_binary("0B1101"), true); // capital B
+		assertEquals(check_is_binary("0b0"), true); // single digit binary
+		assertEquals(check_is_binary("0b11111111"), true); // multiple digits binary
+	});
 
-  await t.step("should return false for non-binary strings", () => {
-    assertEquals(checkIsBinary("101"), false); // missing binary prefix
-    assertEquals(checkIsBinary("0b102"), false); // invalid binary digits
-    assertEquals(checkIsBinary("0b"), false); // only prefix, no digits
-    assertEquals(checkIsBinary("0b "), false); // space after prefix
-    assertEquals(checkIsBinary(""), false); // empty string
-    assertEquals(checkIsBinary("0bxyz"), false); // non-binary characters
-  });
+	await t.step("should return false for non-binary strings", () => {
+		assertEquals(check_is_binary("101"), false); // missing binary prefix
+		assertEquals(check_is_binary("0b102"), false); // invalid binary digits
+		assertEquals(check_is_binary("0b"), false); // only prefix, no digits
+		assertEquals(check_is_binary("0b "), false); // space after prefix
+		assertEquals(check_is_binary(""), false); // empty string
+		assertEquals(check_is_binary("0bxyz"), false); // non-binary characters
+	});
 });
 
-Deno.test("checkStringIsNotBinary", async (t) => {
-  await t.step("should return true for non-binary strings", () => {
-    assertEquals(checkIsNotBinary("101"), true); // missing binary prefix
-    assertEquals(checkIsNotBinary("0b102"), true); // invalid binary digits
-    assertEquals(checkIsNotBinary("0b"), true); // only prefix, no digits
-    assertEquals(checkIsNotBinary("0b "), true); // space after prefix
-    assertEquals(checkIsNotBinary(""), true); // empty string
-    assertEquals(checkIsNotBinary("0bxyz"), true); // non-binary characters
-  });
+Deno.test("check_is_not_binary", async (t) => {
+	await t.step("should return true for non-binary strings", () => {
+		assertEquals(check_is_not_binary("101"), true); // missing binary prefix
+		assertEquals(check_is_not_binary("0b102"), true); // invalid binary digits
+		assertEquals(check_is_not_binary("0b"), true); // only prefix, no digits
+		assertEquals(check_is_not_binary("0b "), true); // space after prefix
+		assertEquals(check_is_not_binary(""), true); // empty string
+		assertEquals(check_is_not_binary("0bxyz"), true); // non-binary characters
+	});
 
-  await t.step("should return false for binary strings", () => {
-    assertEquals(checkIsNotBinary("0b101"), false); // simple binary
-    assertEquals(checkIsNotBinary("0B1101"), false); // capital B
-    assertEquals(checkIsNotBinary("0b0"), false); // single digit binary
-    assertEquals(checkIsNotBinary("0b11111111"), false); // multiple digits binary
-  });
+	await t.step("should return false for binary strings", () => {
+		assertEquals(check_is_not_binary("0b101"), false); // simple binary
+		assertEquals(check_is_not_binary("0B1101"), false); // capital B
+		assertEquals(check_is_not_binary("0b0"), false); // single digit binary
+		assertEquals(check_is_not_binary("0b11111111"), false); // multiple digits binary
+	});
 });

--- a/packages/string/src/checkEmailFormat/main.ts
+++ b/packages/string/src/checkEmailFormat/main.ts
@@ -15,8 +15,8 @@
  * check_is_email_format('invalid-email'); // The string is not a valid email format
  */
 export const check_is_email_format = (str: string): boolean => {
-	const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-	return emailRegex.test(str);
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(str);
 };
 
 /**
@@ -36,5 +36,5 @@ export const check_is_email_format = (str: string): boolean => {
  * check_is_not_email_format('example@example.com'); // Valid email address
  */
 export const check_is_not_email_format = (str: string): boolean => {
-	return !check_is_email_format(str);
+  return !check_is_email_format(str);
 };

--- a/packages/string/src/checkEmailFormat/main.ts
+++ b/packages/string/src/checkEmailFormat/main.ts
@@ -8,33 +8,33 @@
  *
  * @example
  * // Returns true
- * checkIsEmailFormat('example@example.com'); // Valid email address
+ * check_is_email_format('example@example.com'); // Valid email address
  *
  * @example
  * // Returns false
- * checkIsEmailFormat('invalid-email'); // The string is not a valid email format
+ * check_is_email_format('invalid-email'); // The string is not a valid email format
  */
-export const checkIsEmailFormat = (str: string): boolean => {
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  return emailRegex.test(str);
+export const check_is_email_format = (str: string): boolean => {
+	const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+	return emailRegex.test(str);
 };
 
 /**
  * Checks if a given string is not in email format.
  *
- * This is the inverse of `checkIsEmailFormat`.
+ * This is the inverse of `check_is_email_format`.
  *
  * @param {string} str - The string to check.
  * @returns {boolean} True if the string is not in email format, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotEmailFormat('invalid-email'); // The string is not a valid email format
+ * check_is_not_email_format('invalid-email'); // The string is not a valid email format
  *
  * @example
  * // Returns false
- * checkIsNotEmailFormat('example@example.com'); // Valid email address
+ * check_is_not_email_format('example@example.com'); // Valid email address
  */
-export const checkIsNotEmailFormat = (str: string): boolean => {
-  return !checkIsEmailFormat(str);
+export const check_is_not_email_format = (str: string): boolean => {
+	return !check_is_email_format(str);
 };

--- a/packages/string/src/checkEmailFormat/test.ts
+++ b/packages/string/src/checkEmailFormat/test.ts
@@ -2,31 +2,31 @@ import { check_is_email_format, check_is_not_email_format } from "./main.ts";
 import { assertEquals } from "../../deps.ts";
 
 Deno.test("check_is_email_format", async (t) => {
-	await t.step("should return true for valid email addresses", () => {
-		assertEquals(check_is_email_format("example@example.com"), true);
-		assertEquals(
-			check_is_email_format("user.name+tag+sorting@example.com"),
-			true
-		);
-	});
+  await t.step("should return true for valid email addresses", () => {
+    assertEquals(check_is_email_format("example@example.com"), true);
+    assertEquals(
+      check_is_email_format("user.name+tag+sorting@example.com"),
+      true,
+    );
+  });
 
-	await t.step("should return false for invalid email addresses", () => {
-		assertEquals(check_is_email_format("invalid-email"), false);
-		assertEquals(check_is_email_format("example@.com"), false);
-	});
+  await t.step("should return false for invalid email addresses", () => {
+    assertEquals(check_is_email_format("invalid-email"), false);
+    assertEquals(check_is_email_format("example@.com"), false);
+  });
 });
 
 Deno.test("check_is_not_email_format", async (t) => {
-	await t.step("should return true for invalid email addresses", () => {
-		assertEquals(check_is_not_email_format("invalid-email"), true);
-		assertEquals(check_is_not_email_format("example@.com"), true);
-	});
+  await t.step("should return true for invalid email addresses", () => {
+    assertEquals(check_is_not_email_format("invalid-email"), true);
+    assertEquals(check_is_not_email_format("example@.com"), true);
+  });
 
-	await t.step("should return false for valid email addresses", () => {
-		assertEquals(check_is_not_email_format("example@example.com"), false);
-		assertEquals(
-			check_is_not_email_format("user.name+tag+sorting@example.com"),
-			false
-		);
-	});
+  await t.step("should return false for valid email addresses", () => {
+    assertEquals(check_is_not_email_format("example@example.com"), false);
+    assertEquals(
+      check_is_not_email_format("user.name+tag+sorting@example.com"),
+      false,
+    );
+  });
 });

--- a/packages/string/src/checkEmailFormat/test.ts
+++ b/packages/string/src/checkEmailFormat/test.ts
@@ -1,29 +1,32 @@
-import { checkIsEmailFormat, checkIsNotEmailFormat } from "./main.ts";
+import { check_is_email_format, check_is_not_email_format } from "./main.ts";
 import { assertEquals } from "../../deps.ts";
 
-Deno.test("checkIsEmailFormat", async (t) => {
-  await t.step("should return true for valid email addresses", () => {
-    assertEquals(checkIsEmailFormat("example@example.com"), true);
-    assertEquals(checkIsEmailFormat("user.name+tag+sorting@example.com"), true);
-  });
+Deno.test("check_is_email_format", async (t) => {
+	await t.step("should return true for valid email addresses", () => {
+		assertEquals(check_is_email_format("example@example.com"), true);
+		assertEquals(
+			check_is_email_format("user.name+tag+sorting@example.com"),
+			true
+		);
+	});
 
-  await t.step("should return false for invalid email addresses", () => {
-    assertEquals(checkIsEmailFormat("invalid-email"), false);
-    assertEquals(checkIsEmailFormat("example@.com"), false);
-  });
+	await t.step("should return false for invalid email addresses", () => {
+		assertEquals(check_is_email_format("invalid-email"), false);
+		assertEquals(check_is_email_format("example@.com"), false);
+	});
 });
 
-Deno.test("checkIsNotEmailFormat", async (t) => {
-  await t.step("should return true for invalid email addresses", () => {
-    assertEquals(checkIsNotEmailFormat("invalid-email"), true);
-    assertEquals(checkIsNotEmailFormat("example@.com"), true);
-  });
+Deno.test("check_is_not_email_format", async (t) => {
+	await t.step("should return true for invalid email addresses", () => {
+		assertEquals(check_is_not_email_format("invalid-email"), true);
+		assertEquals(check_is_not_email_format("example@.com"), true);
+	});
 
-  await t.step("should return false for valid email addresses", () => {
-    assertEquals(checkIsNotEmailFormat("example@example.com"), false);
-    assertEquals(
-      checkIsNotEmailFormat("user.name+tag+sorting@example.com"),
-      false,
-    );
-  });
+	await t.step("should return false for valid email addresses", () => {
+		assertEquals(check_is_not_email_format("example@example.com"), false);
+		assertEquals(
+			check_is_not_email_format("user.name+tag+sorting@example.com"),
+			false
+		);
+	});
 });

--- a/packages/string/src/checkEmptyString/main.ts
+++ b/packages/string/src/checkEmptyString/main.ts
@@ -8,34 +8,34 @@
  *
  * @example
  * // Returns true
- * checkIsEmptryString(''); // The string is empty
+ * check_is_empty_string(''); // The string is empty
  *
  * @example
  * // Returns false
- * checkIsEmptryString(' '); // The string contains a space, so it is not empty
+ * check_is_empty_string(' '); // The string contains a space, so it is not empty
  */
-export const checkIsEmptryString = (str: string): str is "" => {
-  return str === "";
+export const check_is_empty_string = (str: string): str is "" => {
+	return str === "";
 };
 
 /**
  * Checks if a given string is not empty.
  *
- * This is the inverse of `checkIsEmptryString`.
+ * This is the inverse of `check_is_empty_string`.
  *
  * @param {T extends string} str - The string to check.
  * @returns {str is Exclude<T, "">} True if the string is not empty, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotEmptyString('hello'); // The string is not empty
+ * check_is_not_empty_string('hello'); // The string is not empty
  *
  * @example
  * // Returns false
- * checkIsNotEmptyString(''); // The string is empty
+ * check_is_not_empty_string(''); // The string is empty
  */
-export const checkIsNotEmptyString = <T extends string>(
-  str: T,
+export const check_is_not_empty_string = <T extends string>(
+	str: T
 ): str is Exclude<T, ""> => {
-  return !checkIsEmptryString(str);
+	return !check_is_empty_string(str);
 };

--- a/packages/string/src/checkEmptyString/main.ts
+++ b/packages/string/src/checkEmptyString/main.ts
@@ -15,7 +15,7 @@
  * check_is_empty_string(' '); // The string contains a space, so it is not empty
  */
 export const check_is_empty_string = (str: string): str is "" => {
-	return str === "";
+  return str === "";
 };
 
 /**
@@ -35,7 +35,7 @@ export const check_is_empty_string = (str: string): str is "" => {
  * check_is_not_empty_string(''); // The string is empty
  */
 export const check_is_not_empty_string = <T extends string>(
-	str: T
+  str: T,
 ): str is Exclude<T, ""> => {
-	return !check_is_empty_string(str);
+  return !check_is_empty_string(str);
 };

--- a/packages/string/src/checkEmptyString/test.ts
+++ b/packages/string/src/checkEmptyString/test.ts
@@ -1,33 +1,33 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkIsEmptryString, checkIsNotEmptyString } from "./main.ts";
+import { check_is_empty_string, check_is_not_empty_string } from "./main.ts";
 
-Deno.test("checkIsEmptryString", async (t) => {
-  await t.step("should return true for empty strings", () => {
-    assertEquals(checkIsEmptryString(""), true);
-  });
+Deno.test("check_is_empty_string", async (t) => {
+	await t.step("should return true for empty strings", () => {
+		assertEquals(check_is_empty_string(""), true);
+	});
 
-  await t.step("should return false for non-empty strings", () => {
-    assertEquals(checkIsEmptryString("hello"), false);
-    assertEquals(checkIsEmptryString(" "), false);
-    assertEquals(checkIsEmptryString("123"), false);
-  });
+	await t.step("should return false for non-empty strings", () => {
+		assertEquals(check_is_empty_string("hello"), false);
+		assertEquals(check_is_empty_string(" "), false);
+		assertEquals(check_is_empty_string("123"), false);
+	});
 
-  await t.step("should narrow empty-string type", () => {
-    const value: string = "some string";
-    if (checkIsEmptryString(value)) {
-      assertType<IsExact<typeof value, "">>(true);
-    }
-  });
+	await t.step("should narrow empty-string type", () => {
+		const value: string = "some string";
+		if (check_is_empty_string(value)) {
+			assertType<IsExact<typeof value, "">>(true);
+		}
+	});
 });
 
-Deno.test("checkIsNotEmptyString", async (t) => {
-  await t.step("should return true for non-empty strings", () => {
-    assertEquals(checkIsNotEmptyString("hello"), true);
-    assertEquals(checkIsNotEmptyString(" "), true);
-    assertEquals(checkIsNotEmptyString("123"), true);
-  });
+Deno.test("check_is_not_empty_string", async (t) => {
+	await t.step("should return true for non-empty strings", () => {
+		assertEquals(check_is_not_empty_string("hello"), true);
+		assertEquals(check_is_not_empty_string(" "), true);
+		assertEquals(check_is_not_empty_string("123"), true);
+	});
 
-  await t.step("should return false for empty strings", () => {
-    assertEquals(checkIsNotEmptyString(""), false);
-  });
+	await t.step("should return false for empty strings", () => {
+		assertEquals(check_is_not_empty_string(""), false);
+	});
 });

--- a/packages/string/src/checkEmptyString/test.ts
+++ b/packages/string/src/checkEmptyString/test.ts
@@ -2,32 +2,32 @@ import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import { check_is_empty_string, check_is_not_empty_string } from "./main.ts";
 
 Deno.test("check_is_empty_string", async (t) => {
-	await t.step("should return true for empty strings", () => {
-		assertEquals(check_is_empty_string(""), true);
-	});
+  await t.step("should return true for empty strings", () => {
+    assertEquals(check_is_empty_string(""), true);
+  });
 
-	await t.step("should return false for non-empty strings", () => {
-		assertEquals(check_is_empty_string("hello"), false);
-		assertEquals(check_is_empty_string(" "), false);
-		assertEquals(check_is_empty_string("123"), false);
-	});
+  await t.step("should return false for non-empty strings", () => {
+    assertEquals(check_is_empty_string("hello"), false);
+    assertEquals(check_is_empty_string(" "), false);
+    assertEquals(check_is_empty_string("123"), false);
+  });
 
-	await t.step("should narrow empty-string type", () => {
-		const value: string = "some string";
-		if (check_is_empty_string(value)) {
-			assertType<IsExact<typeof value, "">>(true);
-		}
-	});
+  await t.step("should narrow empty-string type", () => {
+    const value: string = "some string";
+    if (check_is_empty_string(value)) {
+      assertType<IsExact<typeof value, "">>(true);
+    }
+  });
 });
 
 Deno.test("check_is_not_empty_string", async (t) => {
-	await t.step("should return true for non-empty strings", () => {
-		assertEquals(check_is_not_empty_string("hello"), true);
-		assertEquals(check_is_not_empty_string(" "), true);
-		assertEquals(check_is_not_empty_string("123"), true);
-	});
+  await t.step("should return true for non-empty strings", () => {
+    assertEquals(check_is_not_empty_string("hello"), true);
+    assertEquals(check_is_not_empty_string(" "), true);
+    assertEquals(check_is_not_empty_string("123"), true);
+  });
 
-	await t.step("should return false for empty strings", () => {
-		assertEquals(check_is_not_empty_string(""), false);
-	});
+  await t.step("should return false for empty strings", () => {
+    assertEquals(check_is_not_empty_string(""), false);
+  });
 });

--- a/packages/string/src/checkEnterKey/main.ts
+++ b/packages/string/src/checkEnterKey/main.ts
@@ -17,7 +17,7 @@ import type { EnterKey } from "../types.ts";
  * check_is_enter_key('enter'); // The string is not exactly 'Enter'
  */
 export const check_is_enter_key = (str: string): str is EnterKey => {
-	return str === "Enter";
+  return str === "Enter";
 };
 
 /**
@@ -37,7 +37,7 @@ export const check_is_enter_key = (str: string): str is EnterKey => {
  * check_is_not_enter_key('Enter'); // The string is exactly 'Enter'
  */
 export const check_is_not_enter_key = <T extends string>(
-	str: T
+  str: T,
 ): str is Exclude<T, EnterKey> => {
-	return !check_is_enter_key(str);
+  return !check_is_enter_key(str);
 };

--- a/packages/string/src/checkEnterKey/main.ts
+++ b/packages/string/src/checkEnterKey/main.ts
@@ -10,32 +10,34 @@ import type { EnterKey } from "../types.ts";
  *
  * @example
  * // Returns true
- * checkIsEnterKey('Enter'); // The string is exactly 'Enter'
+ * check_is_enter_key('Enter'); // The string is exactly 'Enter'
  *
  * @example
  * // Returns false
- * checkIsEnterKey('enter'); // The string is not exactly 'Enter'
+ * check_is_enter_key('enter'); // The string is not exactly 'Enter'
  */
-export const checkIsEnterKey = (str: string): str is EnterKey => {
-  return str === "Enter";
+export const check_is_enter_key = (str: string): str is EnterKey => {
+	return str === "Enter";
 };
 
 /**
  * Checks if a given string does not represent the "Enter" key.
  *
- * This is the inverse of `checkIsEnterKey`.
+ * This is the inverse of `check_is_enter_key`.
  *
  * @param {string} str - The string to check.
  * @returns {boolean} True if the string is not 'Enter', otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotEnterKey('Space'); // The string is not 'Enter'
+ * check_is_not_enter_key('Space'); // The string is not 'Enter'
  *
  * @example
  * // Returns false
- * checkIsNotEnterKey('Enter'); // The string is exactly 'Enter'
+ * check_is_not_enter_key('Enter'); // The string is exactly 'Enter'
  */
-export const checkIsNotEnterKey = <T extends string>(str: T): str is Exclude<T, EnterKey> => {
-  return !checkIsEnterKey(str);
+export const check_is_not_enter_key = <T extends string>(
+	str: T
+): str is Exclude<T, EnterKey> => {
+	return !check_is_enter_key(str);
 };

--- a/packages/string/src/checkEnterKey/test.ts
+++ b/packages/string/src/checkEnterKey/test.ts
@@ -1,26 +1,26 @@
-import { checkIsEnterKey, checkIsNotEnterKey } from "./main.ts";
+import { check_is_enter_key, check_is_not_enter_key } from "./main.ts";
 import { assertEquals } from "../../deps.ts";
 
-Deno.test("checkIsEnterKey", async (t) => {
-  await t.step("should return true for 'Enter'", () => {
-    assertEquals(checkIsEnterKey("Enter"), true);
-  });
+Deno.test("check_is_enter_key", async (t) => {
+	await t.step("should return true for 'Enter'", () => {
+		assertEquals(check_is_enter_key("Enter"), true);
+	});
 
-  await t.step("should return false for other strings", () => {
-    assertEquals(checkIsEnterKey("Space"), false);
-    assertEquals(checkIsEnterKey("enter"), false);
-    assertEquals(checkIsEnterKey("EnterKey"), false);
-  });
+	await t.step("should return false for other strings", () => {
+		assertEquals(check_is_enter_key("Space"), false);
+		assertEquals(check_is_enter_key("enter"), false);
+		assertEquals(check_is_enter_key("EnterKey"), false);
+	});
 });
 
-Deno.test("checkIsNotEnterKey", async (t) => {
-  await t.step("should return true for strings other than 'Enter'", () => {
-    assertEquals(checkIsNotEnterKey("Space"), true);
-    assertEquals(checkIsNotEnterKey("enter"), true);
-    assertEquals(checkIsNotEnterKey("EnterKey"), true);
-  });
+Deno.test("check_is_not_enter_key", async (t) => {
+	await t.step("should return true for strings other than 'Enter'", () => {
+		assertEquals(check_is_not_enter_key("Space"), true);
+		assertEquals(check_is_not_enter_key("enter"), true);
+		assertEquals(check_is_not_enter_key("EnterKey"), true);
+	});
 
-  await t.step("should return false for 'Enter'", () => {
-    assertEquals(checkIsNotEnterKey("Enter"), false);
-  });
+	await t.step("should return false for 'Enter'", () => {
+		assertEquals(check_is_not_enter_key("Enter"), false);
+	});
 });

--- a/packages/string/src/checkEnterKey/test.ts
+++ b/packages/string/src/checkEnterKey/test.ts
@@ -2,25 +2,25 @@ import { check_is_enter_key, check_is_not_enter_key } from "./main.ts";
 import { assertEquals } from "../../deps.ts";
 
 Deno.test("check_is_enter_key", async (t) => {
-	await t.step("should return true for 'Enter'", () => {
-		assertEquals(check_is_enter_key("Enter"), true);
-	});
+  await t.step("should return true for 'Enter'", () => {
+    assertEquals(check_is_enter_key("Enter"), true);
+  });
 
-	await t.step("should return false for other strings", () => {
-		assertEquals(check_is_enter_key("Space"), false);
-		assertEquals(check_is_enter_key("enter"), false);
-		assertEquals(check_is_enter_key("EnterKey"), false);
-	});
+  await t.step("should return false for other strings", () => {
+    assertEquals(check_is_enter_key("Space"), false);
+    assertEquals(check_is_enter_key("enter"), false);
+    assertEquals(check_is_enter_key("EnterKey"), false);
+  });
 });
 
 Deno.test("check_is_not_enter_key", async (t) => {
-	await t.step("should return true for strings other than 'Enter'", () => {
-		assertEquals(check_is_not_enter_key("Space"), true);
-		assertEquals(check_is_not_enter_key("enter"), true);
-		assertEquals(check_is_not_enter_key("EnterKey"), true);
-	});
+  await t.step("should return true for strings other than 'Enter'", () => {
+    assertEquals(check_is_not_enter_key("Space"), true);
+    assertEquals(check_is_not_enter_key("enter"), true);
+    assertEquals(check_is_not_enter_key("EnterKey"), true);
+  });
 
-	await t.step("should return false for 'Enter'", () => {
-		assertEquals(check_is_not_enter_key("Enter"), false);
-	});
+  await t.step("should return false for 'Enter'", () => {
+    assertEquals(check_is_not_enter_key("Enter"), false);
+  });
 });

--- a/packages/string/src/checkExponentialNotation/main.ts
+++ b/packages/string/src/checkExponentialNotation/main.ts
@@ -9,33 +9,33 @@
  *
  * @example
  * // Returns true
- * checkIsExponentialNotation("1e5"); // The string "1e5" is in exponential notation
+ * check_is_exponential_notation("1e5"); // The string "1e5" is in exponential notation
  *
  * @example
  * // Returns false
- * checkIsExponentialNotation("123"); // The string "123" is not in exponential notation
+ * check_is_exponential_notation("123"); // The string "123" is not in exponential notation
  */
-export const checkIsExponentialNotation = (str: string): boolean => {
-  const exponentialRegex = /^[-+]?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+)$/;
-  return exponentialRegex.test(str);
+export const check_is_exponential_notation = (str: string): boolean => {
+	const exponentialRegex = /^[-+]?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+)$/;
+	return exponentialRegex.test(str);
 };
 
 /**
  * Checks if a given string is not in exponential notation format.
  *
- * This is the inverse of `checkIsExponentialNotation`.
+ * This is the inverse of `check_is_exponential_notation`.
  *
  * @param {string} str - The string to check.
  * @returns {boolean} True if the string is not in exponential notation, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotExponentialNotation("123"); // The string "123" is not in exponential notation
+ * check_is_not_exponential_notation("123"); // The string "123" is not in exponential notation
  *
  * @example
  * // Returns false
- * checkIsNotExponentialNotation("1e5"); // The string "1e5" is in exponential notation
+ * check_is_not_exponential_notation("1e5"); // The string "1e5" is in exponential notation
  */
-export const checkIsNotExponentialNotation = (str: string): boolean => {
-  return !checkIsExponentialNotation(str);
+export const check_is_not_exponential_notation = (str: string): boolean => {
+	return !check_is_exponential_notation(str);
 };

--- a/packages/string/src/checkExponentialNotation/main.ts
+++ b/packages/string/src/checkExponentialNotation/main.ts
@@ -16,8 +16,8 @@
  * check_is_exponential_notation("123"); // The string "123" is not in exponential notation
  */
 export const check_is_exponential_notation = (str: string): boolean => {
-	const exponentialRegex = /^[-+]?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+)$/;
-	return exponentialRegex.test(str);
+  const exponentialRegex = /^[-+]?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+)$/;
+  return exponentialRegex.test(str);
 };
 
 /**
@@ -37,5 +37,5 @@ export const check_is_exponential_notation = (str: string): boolean => {
  * check_is_not_exponential_notation("1e5"); // The string "1e5" is in exponential notation
  */
 export const check_is_not_exponential_notation = (str: string): boolean => {
-	return !check_is_exponential_notation(str);
+  return !check_is_exponential_notation(str);
 };

--- a/packages/string/src/checkExponentialNotation/test.ts
+++ b/packages/string/src/checkExponentialNotation/test.ts
@@ -1,43 +1,43 @@
 import { assertEquals } from "../../deps.ts";
 import {
-	check_is_exponential_notation,
-	check_is_not_exponential_notation,
+  check_is_exponential_notation,
+  check_is_not_exponential_notation,
 } from "./main.ts";
 
 Deno.test("check_is_exponential_notation", async (t) => {
-	await t.step("should return true for exponential strings", () => {
-		assertEquals(check_is_exponential_notation("1e5"), true); // positive exponent
-		assertEquals(check_is_exponential_notation("1E5"), true); // capital E
-		assertEquals(check_is_exponential_notation("-1e5"), true); // negative base
-		assertEquals(check_is_exponential_notation("1.23e-10"), true); // negative exponent
-		assertEquals(check_is_exponential_notation("3e+8"), true); // positive exponent with explicit '+'
-	});
+  await t.step("should return true for exponential strings", () => {
+    assertEquals(check_is_exponential_notation("1e5"), true); // positive exponent
+    assertEquals(check_is_exponential_notation("1E5"), true); // capital E
+    assertEquals(check_is_exponential_notation("-1e5"), true); // negative base
+    assertEquals(check_is_exponential_notation("1.23e-10"), true); // negative exponent
+    assertEquals(check_is_exponential_notation("3e+8"), true); // positive exponent with explicit '+'
+  });
 
-	await t.step("should return false for non-exponential strings", () => {
-		assertEquals(check_is_exponential_notation("123"), false); // plain integer
-		assertEquals(check_is_exponential_notation("3.14"), false); // plain float
-		assertEquals(check_is_exponential_notation("abc"), false); // non-numeric
-		assertEquals(check_is_exponential_notation("1e"), false); // incomplete exponential
-		assertEquals(check_is_exponential_notation("e10"), false); // missing base number
-		assertEquals(check_is_exponential_notation(""), false); // empty string
-	});
+  await t.step("should return false for non-exponential strings", () => {
+    assertEquals(check_is_exponential_notation("123"), false); // plain integer
+    assertEquals(check_is_exponential_notation("3.14"), false); // plain float
+    assertEquals(check_is_exponential_notation("abc"), false); // non-numeric
+    assertEquals(check_is_exponential_notation("1e"), false); // incomplete exponential
+    assertEquals(check_is_exponential_notation("e10"), false); // missing base number
+    assertEquals(check_is_exponential_notation(""), false); // empty string
+  });
 });
 
 Deno.test("check_is_not_exponential_notation", async (t) => {
-	await t.step("should return true for non-exponential strings", () => {
-		assertEquals(check_is_not_exponential_notation("123"), true); // plain integer
-		assertEquals(check_is_not_exponential_notation("3.14"), true); // plain float
-		assertEquals(check_is_not_exponential_notation("abc"), true); // non-numeric
-		assertEquals(check_is_not_exponential_notation("1e"), true); // incomplete exponential
-		assertEquals(check_is_not_exponential_notation("e10"), true); // missing base number
-		assertEquals(check_is_not_exponential_notation(""), true); // empty string
-	});
+  await t.step("should return true for non-exponential strings", () => {
+    assertEquals(check_is_not_exponential_notation("123"), true); // plain integer
+    assertEquals(check_is_not_exponential_notation("3.14"), true); // plain float
+    assertEquals(check_is_not_exponential_notation("abc"), true); // non-numeric
+    assertEquals(check_is_not_exponential_notation("1e"), true); // incomplete exponential
+    assertEquals(check_is_not_exponential_notation("e10"), true); // missing base number
+    assertEquals(check_is_not_exponential_notation(""), true); // empty string
+  });
 
-	await t.step("should return false for exponential strings", () => {
-		assertEquals(check_is_not_exponential_notation("1e5"), false); // positive exponent
-		assertEquals(check_is_not_exponential_notation("1E5"), false); // capital E
-		assertEquals(check_is_not_exponential_notation("-1e5"), false); // negative base
-		assertEquals(check_is_not_exponential_notation("1.23e-10"), false); // negative exponent
-		assertEquals(check_is_not_exponential_notation("3e+8"), false); // positive exponent with explicit '+'
-	});
+  await t.step("should return false for exponential strings", () => {
+    assertEquals(check_is_not_exponential_notation("1e5"), false); // positive exponent
+    assertEquals(check_is_not_exponential_notation("1E5"), false); // capital E
+    assertEquals(check_is_not_exponential_notation("-1e5"), false); // negative base
+    assertEquals(check_is_not_exponential_notation("1.23e-10"), false); // negative exponent
+    assertEquals(check_is_not_exponential_notation("3e+8"), false); // positive exponent with explicit '+'
+  });
 });

--- a/packages/string/src/checkExponentialNotation/test.ts
+++ b/packages/string/src/checkExponentialNotation/test.ts
@@ -1,43 +1,43 @@
 import { assertEquals } from "../../deps.ts";
 import {
-  checkIsExponentialNotation,
-  checkIsNotExponentialNotation,
+	check_is_exponential_notation,
+	check_is_not_exponential_notation,
 } from "./main.ts";
 
-Deno.test("checkStringIsExponential", async (t) => {
-  await t.step("should return true for exponential strings", () => {
-    assertEquals(checkIsExponentialNotation("1e5"), true); // positive exponent
-    assertEquals(checkIsExponentialNotation("1E5"), true); // capital E
-    assertEquals(checkIsExponentialNotation("-1e5"), true); // negative base
-    assertEquals(checkIsExponentialNotation("1.23e-10"), true); // negative exponent
-    assertEquals(checkIsExponentialNotation("3e+8"), true); // positive exponent with explicit '+'
-  });
+Deno.test("check_is_exponential_notation", async (t) => {
+	await t.step("should return true for exponential strings", () => {
+		assertEquals(check_is_exponential_notation("1e5"), true); // positive exponent
+		assertEquals(check_is_exponential_notation("1E5"), true); // capital E
+		assertEquals(check_is_exponential_notation("-1e5"), true); // negative base
+		assertEquals(check_is_exponential_notation("1.23e-10"), true); // negative exponent
+		assertEquals(check_is_exponential_notation("3e+8"), true); // positive exponent with explicit '+'
+	});
 
-  await t.step("should return false for non-exponential strings", () => {
-    assertEquals(checkIsExponentialNotation("123"), false); // plain integer
-    assertEquals(checkIsExponentialNotation("3.14"), false); // plain float
-    assertEquals(checkIsExponentialNotation("abc"), false); // non-numeric
-    assertEquals(checkIsExponentialNotation("1e"), false); // incomplete exponential
-    assertEquals(checkIsExponentialNotation("e10"), false); // missing base number
-    assertEquals(checkIsExponentialNotation(""), false); // empty string
-  });
+	await t.step("should return false for non-exponential strings", () => {
+		assertEquals(check_is_exponential_notation("123"), false); // plain integer
+		assertEquals(check_is_exponential_notation("3.14"), false); // plain float
+		assertEquals(check_is_exponential_notation("abc"), false); // non-numeric
+		assertEquals(check_is_exponential_notation("1e"), false); // incomplete exponential
+		assertEquals(check_is_exponential_notation("e10"), false); // missing base number
+		assertEquals(check_is_exponential_notation(""), false); // empty string
+	});
 });
 
-Deno.test("checkStringIsNotExponential", async (t) => {
-  await t.step("should return true for non-exponential strings", () => {
-    assertEquals(checkIsNotExponentialNotation("123"), true); // plain integer
-    assertEquals(checkIsNotExponentialNotation("3.14"), true); // plain float
-    assertEquals(checkIsNotExponentialNotation("abc"), true); // non-numeric
-    assertEquals(checkIsNotExponentialNotation("1e"), true); // incomplete exponential
-    assertEquals(checkIsNotExponentialNotation("e10"), true); // missing base number
-    assertEquals(checkIsNotExponentialNotation(""), true); // empty string
-  });
+Deno.test("check_is_not_exponential_notation", async (t) => {
+	await t.step("should return true for non-exponential strings", () => {
+		assertEquals(check_is_not_exponential_notation("123"), true); // plain integer
+		assertEquals(check_is_not_exponential_notation("3.14"), true); // plain float
+		assertEquals(check_is_not_exponential_notation("abc"), true); // non-numeric
+		assertEquals(check_is_not_exponential_notation("1e"), true); // incomplete exponential
+		assertEquals(check_is_not_exponential_notation("e10"), true); // missing base number
+		assertEquals(check_is_not_exponential_notation(""), true); // empty string
+	});
 
-  await t.step("should return false for exponential strings", () => {
-    assertEquals(checkIsNotExponentialNotation("1e5"), false); // positive exponent
-    assertEquals(checkIsNotExponentialNotation("1E5"), false); // capital E
-    assertEquals(checkIsNotExponentialNotation("-1e5"), false); // negative base
-    assertEquals(checkIsNotExponentialNotation("1.23e-10"), false); // negative exponent
-    assertEquals(checkIsNotExponentialNotation("3e+8"), false); // positive exponent with explicit '+'
-  });
+	await t.step("should return false for exponential strings", () => {
+		assertEquals(check_is_not_exponential_notation("1e5"), false); // positive exponent
+		assertEquals(check_is_not_exponential_notation("1E5"), false); // capital E
+		assertEquals(check_is_not_exponential_notation("-1e5"), false); // negative base
+		assertEquals(check_is_not_exponential_notation("1.23e-10"), false); // negative exponent
+		assertEquals(check_is_not_exponential_notation("3e+8"), false); // positive exponent with explicit '+'
+	});
 });

--- a/packages/string/src/checkHasSubstring/main.ts
+++ b/packages/string/src/checkHasSubstring/main.ts
@@ -16,10 +16,10 @@
  * check_has_substring('hello world', 'planet'); // The string does not contain the substring 'planet'
  */
 export const check_has_substring = (
-	str: string,
-	substring: string
+  str: string,
+  substring: string,
 ): boolean => {
-	return str.includes(substring);
+  return str.includes(substring);
 };
 
 /**
@@ -40,8 +40,8 @@ export const check_has_substring = (
  * check_does_not_have_substring('hello world', 'world'); // The string contains the substring 'world'
  */
 export const check_does_not_have_substring = (
-	str: string,
-	substring: string
+  str: string,
+  substring: string,
 ): boolean => {
-	return !check_has_substring(str, substring);
+  return !check_has_substring(str, substring);
 };

--- a/packages/string/src/checkHasSubstring/main.ts
+++ b/packages/string/src/checkHasSubstring/main.ts
@@ -9,20 +9,23 @@
  *
  * @example
  * // Returns true
- * checkHasSubstring('hello world', 'world'); // The string contains the substring 'world'
+ * check_has_substring('hello world', 'world'); // The string contains the substring 'world'
  *
  * @example
  * // Returns false
- * checkHasSubstring('hello world', 'planet'); // The string does not contain the substring 'planet'
+ * check_has_substring('hello world', 'planet'); // The string does not contain the substring 'planet'
  */
-export const checkHasSubstring = (str: string, substring: string): boolean => {
-  return str.includes(substring);
+export const check_has_substring = (
+	str: string,
+	substring: string
+): boolean => {
+	return str.includes(substring);
 };
 
 /**
  * Checks if a given string does not include a specific substring.
  *
- * This is the inverse of `checkIncludesSubstring`.
+ * This is the inverse of `check_has_substring`.
  *
  * @param {string} str - The string to check.
  * @param {string} substring - The substring to check against.
@@ -30,15 +33,15 @@ export const checkHasSubstring = (str: string, substring: string): boolean => {
  *
  * @example
  * // Returns true
- * checkDoesNotHaveSubstring('hello world', 'planet'); // The string does not contain the substring 'planet'
+ * check_does_not_have_substring('hello world', 'planet'); // The string does not contain the substring 'planet'
  *
  * @example
  * // Returns false
- * checkDoesNotHaveSubstring('hello world', 'world'); // The string contains the substring 'world'
+ * check_does_not_have_substring('hello world', 'world'); // The string contains the substring 'world'
  */
-export const checkDoesNotHaveSubstring = (
-  str: string,
-  substring: string,
+export const check_does_not_have_substring = (
+	str: string,
+	substring: string
 ): boolean => {
-  return !checkHasSubstring(str, substring);
+	return !check_has_substring(str, substring);
 };

--- a/packages/string/src/checkHasSubstring/test.ts
+++ b/packages/string/src/checkHasSubstring/test.ts
@@ -1,50 +1,59 @@
 import { assertEquals } from "../../deps.ts";
-import { checkDoesNotHaveSubstring, checkHasSubstring } from "./main.ts";
+import { check_does_not_have_substring, check_has_substring } from "./main.ts";
 
-Deno.test("checkHasSubstring", async (t) => {
-  await t.step(
-    "should return true if the string includes the substring",
-    () => {
-      assertEquals(checkHasSubstring("hello world", "world"), true);
-      assertEquals(checkHasSubstring("hello", "ell"), true);
-      assertEquals(checkHasSubstring("typescript", "script"), true);
-      assertEquals(checkHasSubstring("openai", "pen"), true);
-      assertEquals(checkHasSubstring("check", "check"), true);
-    },
-  );
+Deno.test("check_has_substring", async (t) => {
+	await t.step(
+		"should return true if the string includes the substring",
+		() => {
+			assertEquals(check_has_substring("hello world", "world"), true);
+			assertEquals(check_has_substring("hello", "ell"), true);
+			assertEquals(check_has_substring("typescript", "script"), true);
+			assertEquals(check_has_substring("openai", "pen"), true);
+			assertEquals(check_has_substring("check", "check"), true);
+		}
+	);
 
-  await t.step(
-    "should return false if the string does not include the substring",
-    () => {
-      assertEquals(checkHasSubstring("hello world", "universe"), false);
-      assertEquals(checkHasSubstring("hello", "world"), false);
-      assertEquals(checkHasSubstring("typescript", "java"), false);
-      assertEquals(checkHasSubstring("openai", "closedai"), false);
-      assertEquals(checkHasSubstring("check", "cross"), false);
-    },
-  );
+	await t.step(
+		"should return false if the string does not include the substring",
+		() => {
+			assertEquals(check_has_substring("hello world", "universe"), false);
+			assertEquals(check_has_substring("hello", "world"), false);
+			assertEquals(check_has_substring("typescript", "java"), false);
+			assertEquals(check_has_substring("openai", "closedai"), false);
+			assertEquals(check_has_substring("check", "cross"), false);
+		}
+	);
 });
 
-Deno.test("checkDoesNotHaveSubstring", async (t) => {
-  await t.step(
-    "should return true if the string does not include the substring",
-    () => {
-      assertEquals(checkDoesNotHaveSubstring("hello world", "universe"), true);
-      assertEquals(checkDoesNotHaveSubstring("hello", "world"), true);
-      assertEquals(checkDoesNotHaveSubstring("typescript", "java"), true);
-      assertEquals(checkDoesNotHaveSubstring("openai", "closedai"), true);
-      assertEquals(checkDoesNotHaveSubstring("check", "cross"), true);
-    },
-  );
+Deno.test("check_does_not_have_substring", async (t) => {
+	await t.step(
+		"should return true if the string does not include the substring",
+		() => {
+			assertEquals(
+				check_does_not_have_substring("hello world", "universe"),
+				true
+			);
+			assertEquals(check_does_not_have_substring("hello", "world"), true);
+			assertEquals(check_does_not_have_substring("typescript", "java"), true);
+			assertEquals(check_does_not_have_substring("openai", "closedai"), true);
+			assertEquals(check_does_not_have_substring("check", "cross"), true);
+		}
+	);
 
-  await t.step(
-    "should return false if the string includes the substring",
-    () => {
-      assertEquals(checkDoesNotHaveSubstring("hello world", "world"), false);
-      assertEquals(checkDoesNotHaveSubstring("hello", "ell"), false);
-      assertEquals(checkDoesNotHaveSubstring("typescript", "script"), false);
-      assertEquals(checkDoesNotHaveSubstring("openai", "pen"), false);
-      assertEquals(checkDoesNotHaveSubstring("check", "check"), false);
-    },
-  );
+	await t.step(
+		"should return false if the string includes the substring",
+		() => {
+			assertEquals(
+				check_does_not_have_substring("hello world", "world"),
+				false
+			);
+			assertEquals(check_does_not_have_substring("hello", "ell"), false);
+			assertEquals(
+				check_does_not_have_substring("typescript", "script"),
+				false
+			);
+			assertEquals(check_does_not_have_substring("openai", "pen"), false);
+			assertEquals(check_does_not_have_substring("check", "check"), false);
+		}
+	);
 });

--- a/packages/string/src/checkHasSubstring/test.ts
+++ b/packages/string/src/checkHasSubstring/test.ts
@@ -2,58 +2,58 @@ import { assertEquals } from "../../deps.ts";
 import { check_does_not_have_substring, check_has_substring } from "./main.ts";
 
 Deno.test("check_has_substring", async (t) => {
-	await t.step(
-		"should return true if the string includes the substring",
-		() => {
-			assertEquals(check_has_substring("hello world", "world"), true);
-			assertEquals(check_has_substring("hello", "ell"), true);
-			assertEquals(check_has_substring("typescript", "script"), true);
-			assertEquals(check_has_substring("openai", "pen"), true);
-			assertEquals(check_has_substring("check", "check"), true);
-		}
-	);
+  await t.step(
+    "should return true if the string includes the substring",
+    () => {
+      assertEquals(check_has_substring("hello world", "world"), true);
+      assertEquals(check_has_substring("hello", "ell"), true);
+      assertEquals(check_has_substring("typescript", "script"), true);
+      assertEquals(check_has_substring("openai", "pen"), true);
+      assertEquals(check_has_substring("check", "check"), true);
+    },
+  );
 
-	await t.step(
-		"should return false if the string does not include the substring",
-		() => {
-			assertEquals(check_has_substring("hello world", "universe"), false);
-			assertEquals(check_has_substring("hello", "world"), false);
-			assertEquals(check_has_substring("typescript", "java"), false);
-			assertEquals(check_has_substring("openai", "closedai"), false);
-			assertEquals(check_has_substring("check", "cross"), false);
-		}
-	);
+  await t.step(
+    "should return false if the string does not include the substring",
+    () => {
+      assertEquals(check_has_substring("hello world", "universe"), false);
+      assertEquals(check_has_substring("hello", "world"), false);
+      assertEquals(check_has_substring("typescript", "java"), false);
+      assertEquals(check_has_substring("openai", "closedai"), false);
+      assertEquals(check_has_substring("check", "cross"), false);
+    },
+  );
 });
 
 Deno.test("check_does_not_have_substring", async (t) => {
-	await t.step(
-		"should return true if the string does not include the substring",
-		() => {
-			assertEquals(
-				check_does_not_have_substring("hello world", "universe"),
-				true
-			);
-			assertEquals(check_does_not_have_substring("hello", "world"), true);
-			assertEquals(check_does_not_have_substring("typescript", "java"), true);
-			assertEquals(check_does_not_have_substring("openai", "closedai"), true);
-			assertEquals(check_does_not_have_substring("check", "cross"), true);
-		}
-	);
+  await t.step(
+    "should return true if the string does not include the substring",
+    () => {
+      assertEquals(
+        check_does_not_have_substring("hello world", "universe"),
+        true,
+      );
+      assertEquals(check_does_not_have_substring("hello", "world"), true);
+      assertEquals(check_does_not_have_substring("typescript", "java"), true);
+      assertEquals(check_does_not_have_substring("openai", "closedai"), true);
+      assertEquals(check_does_not_have_substring("check", "cross"), true);
+    },
+  );
 
-	await t.step(
-		"should return false if the string includes the substring",
-		() => {
-			assertEquals(
-				check_does_not_have_substring("hello world", "world"),
-				false
-			);
-			assertEquals(check_does_not_have_substring("hello", "ell"), false);
-			assertEquals(
-				check_does_not_have_substring("typescript", "script"),
-				false
-			);
-			assertEquals(check_does_not_have_substring("openai", "pen"), false);
-			assertEquals(check_does_not_have_substring("check", "check"), false);
-		}
-	);
+  await t.step(
+    "should return false if the string includes the substring",
+    () => {
+      assertEquals(
+        check_does_not_have_substring("hello world", "world"),
+        false,
+      );
+      assertEquals(check_does_not_have_substring("hello", "ell"), false);
+      assertEquals(
+        check_does_not_have_substring("typescript", "script"),
+        false,
+      );
+      assertEquals(check_does_not_have_substring("openai", "pen"), false);
+      assertEquals(check_does_not_have_substring("check", "check"), false);
+    },
+  );
 });

--- a/packages/string/src/checkISO8601Format/main.ts
+++ b/packages/string/src/checkISO8601Format/main.ts
@@ -8,34 +8,34 @@
  *
  * @example
  * // Returns true
- * checkIsISO8601Format('2023-08-30T10:30:00Z'); // Valid ISO 8601 date-time
+ * check_is_ISO8601_format('2023-08-30T10:30:00Z'); // Valid ISO 8601 date-time
  *
  * @example
  * // Returns false
- * checkIsISO8601Format('08/30/2023'); // The string is not in ISO 8601 format
+ * check_is_ISO8601_format('08/30/2023'); // The string is not in ISO 8601 format
  */
-export const checkIsISO8601Format = (str: string): boolean => {
-  const iso8601Regex =
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$/;
-  return iso8601Regex.test(str);
+export const check_is_ISO8601_format = (str: string): boolean => {
+	const iso8601Regex =
+		/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$/;
+	return iso8601Regex.test(str);
 };
 
 /**
  * Checks if a given string is not in ISO 8601 format.
  *
- * This is the inverse of `checkIsISO8601Format`.
+ * This is the inverse of `check_is_ISO8601_format`.
  *
  * @param {string} str - The string to check.
  * @returns {boolean} True if the string is not in ISO 8601 format, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotISO8601Format('08/30/2023'); // The string is not in ISO 8601 format
+ * check_is_not_ISO8601_format('08/30/2023'); // The string is not in ISO 8601 format
  *
  * @example
  * // Returns false
- * checkIsNotISO8601Format('2023-08-30T10:30:00Z'); // Valid ISO 8601 date-time
+ * check_is_not_ISO8601_format('2023-08-30T10:30:00Z'); // Valid ISO 8601 date-time
  */
-export const checkIsNotISO8601Format = (str: string): boolean => {
-  return !checkIsISO8601Format(str);
+export const check_is_not_ISO8601_format = (str: string): boolean => {
+	return !check_is_ISO8601_format(str);
 };

--- a/packages/string/src/checkISO8601Format/main.ts
+++ b/packages/string/src/checkISO8601Format/main.ts
@@ -15,9 +15,9 @@
  * check_is_ISO8601_format('08/30/2023'); // The string is not in ISO 8601 format
  */
 export const check_is_ISO8601_format = (str: string): boolean => {
-	const iso8601Regex =
-		/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$/;
-	return iso8601Regex.test(str);
+  const iso8601Regex =
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$/;
+  return iso8601Regex.test(str);
 };
 
 /**
@@ -37,5 +37,5 @@ export const check_is_ISO8601_format = (str: string): boolean => {
  * check_is_not_ISO8601_format('2023-08-30T10:30:00Z'); // Valid ISO 8601 date-time
  */
 export const check_is_not_ISO8601_format = (str: string): boolean => {
-	return !check_is_ISO8601_format(str);
+  return !check_is_ISO8601_format(str);
 };

--- a/packages/string/src/checkISO8601Format/test.ts
+++ b/packages/string/src/checkISO8601Format/test.ts
@@ -1,32 +1,32 @@
 import { assertEquals } from "../../deps.ts";
 import {
-	check_is_ISO8601_format,
-	check_is_not_ISO8601_format,
+  check_is_ISO8601_format,
+  check_is_not_ISO8601_format,
 } from "./main.ts";
 
 Deno.test("check_is_ISO8601_format", async (t) => {
-	await t.step("should return true for valid ISO 8601 strings", () => {
-		assertEquals(check_is_ISO8601_format("2023-08-30T10:30:00Z"), true);
-		assertEquals(check_is_ISO8601_format("2023-08-30T10:30:00+02:00"), true);
-	});
+  await t.step("should return true for valid ISO 8601 strings", () => {
+    assertEquals(check_is_ISO8601_format("2023-08-30T10:30:00Z"), true);
+    assertEquals(check_is_ISO8601_format("2023-08-30T10:30:00+02:00"), true);
+  });
 
-	await t.step("should return false for invalid ISO 8601 strings", () => {
-		assertEquals(check_is_ISO8601_format("08/30/2023"), false);
-		assertEquals(check_is_ISO8601_format("2023-08-30 10:30:00"), false);
-	});
+  await t.step("should return false for invalid ISO 8601 strings", () => {
+    assertEquals(check_is_ISO8601_format("08/30/2023"), false);
+    assertEquals(check_is_ISO8601_format("2023-08-30 10:30:00"), false);
+  });
 });
 
 Deno.test("check_is_not_ISO8601_format", async (t) => {
-	await t.step("should return true for invalid ISO 8601 strings", () => {
-		assertEquals(check_is_not_ISO8601_format("08/30/2023"), true);
-		assertEquals(check_is_not_ISO8601_format("2023-08-30 10:30:00"), true);
-	});
+  await t.step("should return true for invalid ISO 8601 strings", () => {
+    assertEquals(check_is_not_ISO8601_format("08/30/2023"), true);
+    assertEquals(check_is_not_ISO8601_format("2023-08-30 10:30:00"), true);
+  });
 
-	await t.step("should return false for valid ISO 8601 strings", () => {
-		assertEquals(check_is_not_ISO8601_format("2023-08-30T10:30:00Z"), false);
-		assertEquals(
-			check_is_not_ISO8601_format("2023-08-30T10:30:00+02:00"),
-			false
-		);
-	});
+  await t.step("should return false for valid ISO 8601 strings", () => {
+    assertEquals(check_is_not_ISO8601_format("2023-08-30T10:30:00Z"), false);
+    assertEquals(
+      check_is_not_ISO8601_format("2023-08-30T10:30:00+02:00"),
+      false,
+    );
+  });
 });

--- a/packages/string/src/checkISO8601Format/test.ts
+++ b/packages/string/src/checkISO8601Format/test.ts
@@ -1,26 +1,32 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsISO8601Format, checkIsNotISO8601Format } from "./main.ts";
+import {
+	check_is_ISO8601_format,
+	check_is_not_ISO8601_format,
+} from "./main.ts";
 
-Deno.test("checkIsISO8601Format", async (t) => {
-  await t.step("should return true for valid ISO 8601 strings", () => {
-    assertEquals(checkIsISO8601Format("2023-08-30T10:30:00Z"), true);
-    assertEquals(checkIsISO8601Format("2023-08-30T10:30:00+02:00"), true);
-  });
+Deno.test("check_is_ISO8601_format", async (t) => {
+	await t.step("should return true for valid ISO 8601 strings", () => {
+		assertEquals(check_is_ISO8601_format("2023-08-30T10:30:00Z"), true);
+		assertEquals(check_is_ISO8601_format("2023-08-30T10:30:00+02:00"), true);
+	});
 
-  await t.step("should return false for invalid ISO 8601 strings", () => {
-    assertEquals(checkIsISO8601Format("08/30/2023"), false);
-    assertEquals(checkIsISO8601Format("2023-08-30 10:30:00"), false);
-  });
+	await t.step("should return false for invalid ISO 8601 strings", () => {
+		assertEquals(check_is_ISO8601_format("08/30/2023"), false);
+		assertEquals(check_is_ISO8601_format("2023-08-30 10:30:00"), false);
+	});
 });
 
-Deno.test("checkIsNotISO8601Format", async (t) => {
-  await t.step("should return true for invalid ISO 8601 strings", () => {
-    assertEquals(checkIsNotISO8601Format("08/30/2023"), true);
-    assertEquals(checkIsNotISO8601Format("2023-08-30 10:30:00"), true);
-  });
+Deno.test("check_is_not_ISO8601_format", async (t) => {
+	await t.step("should return true for invalid ISO 8601 strings", () => {
+		assertEquals(check_is_not_ISO8601_format("08/30/2023"), true);
+		assertEquals(check_is_not_ISO8601_format("2023-08-30 10:30:00"), true);
+	});
 
-  await t.step("should return false for valid ISO 8601 strings", () => {
-    assertEquals(checkIsNotISO8601Format("2023-08-30T10:30:00Z"), false);
-    assertEquals(checkIsNotISO8601Format("2023-08-30T10:30:00+02:00"), false);
-  });
+	await t.step("should return false for valid ISO 8601 strings", () => {
+		assertEquals(check_is_not_ISO8601_format("2023-08-30T10:30:00Z"), false);
+		assertEquals(
+			check_is_not_ISO8601_format("2023-08-30T10:30:00+02:00"),
+			false
+		);
+	});
 });

--- a/packages/string/src/checkIndex/main.ts
+++ b/packages/string/src/checkIndex/main.ts
@@ -19,12 +19,12 @@
  * check_is_index_found(index); // The index is -1, as 'planet' is not found within the string
  */
 export const check_is_index_found = (index: number): boolean => {
-	return index !== -1;
+  return index !== -1;
 };
 
 /**
  * Checks if a given index is not found.
- * 
+ *
  * This is the inverse of `check_is_index_found`.
  *
  * This function is useful when working with string indices obtained from `str.indexOf()`.
@@ -45,5 +45,5 @@ export const check_is_index_found = (index: number): boolean => {
  * check_is_index_not_found(index); // The index is valid, as 'world' is found within the string
  */
 export const check_is_index_not_found = (index: number): boolean => {
-	return !check_is_index_found(index);
+  return !check_is_index_found(index);
 };

--- a/packages/string/src/checkIndex/main.ts
+++ b/packages/string/src/checkIndex/main.ts
@@ -11,19 +11,21 @@
  * @example
  * // Returns true
  * const index = 'hello world'.indexOf('world');
- * checkIsIndexFound(index); // The index is valid, as 'world' is found within the string
+ * check_is_index_found(index); // The index is valid, as 'world' is found within the string
  *
  * @example
  * // Returns false
  * const index = 'hello world'.indexOf('planet');
- * checkIsIndexFound(index); // The index is -1, as 'planet' is not found within the string
+ * check_is_index_found(index); // The index is -1, as 'planet' is not found within the string
  */
-export const checkIsIndexFound = (index: number): boolean => {
-  return index !== -1;
+export const check_is_index_found = (index: number): boolean => {
+	return index !== -1;
 };
 
 /**
  * Checks if a given index is not found.
+ * 
+ * This is the inverse of `check_is_index_found`.
  *
  * This function is useful when working with string indices obtained from `str.indexOf()`.
  * It checks if the index is equal to -1, which is the return value of `str.indexOf()`
@@ -35,13 +37,13 @@ export const checkIsIndexFound = (index: number): boolean => {
  * @example
  * // Returns true
  * const index = 'hello world'.indexOf('planet');
- * checkIsIndexNotFound(index); // The index is -1, as 'planet' is not found within the string
+ * check_is_index_not_found(index); // The index is -1, as 'planet' is not found within the string
  *
  * @example
  * // Returns false
  * const index = 'hello world'.indexOf('world');
- * checkIsIndexNotFound(index); // The index is valid, as 'world' is found within the string
+ * check_is_index_not_found(index); // The index is valid, as 'world' is found within the string
  */
-export const checkIsIndexNotFound = (index: number): boolean => {
-  return !checkIsIndexFound(index);
+export const check_is_index_not_found = (index: number): boolean => {
+	return !check_is_index_found(index);
 };

--- a/packages/string/src/checkIndex/test.ts
+++ b/packages/string/src/checkIndex/test.ts
@@ -2,49 +2,49 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_index_found, check_is_index_not_found } from "./main.ts";
 
 Deno.test("check_is_index_found", async (t) => {
-	const str1 = "hello world";
-	const str2 = "banana";
+  const str1 = "hello world";
+  const str2 = "banana";
 
-	await t.step("should return true for valid indexes (non -1)", () => {
-		assertEquals(check_is_index_found(0), true);
-		assertEquals(check_is_index_found(10), true);
+  await t.step("should return true for valid indexes (non -1)", () => {
+    assertEquals(check_is_index_found(0), true);
+    assertEquals(check_is_index_found(10), true);
 
-		assertEquals(check_is_index_found(str1.indexOf("h")), true);
-		assertEquals(check_is_index_found(str1.indexOf("world")), true);
+    assertEquals(check_is_index_found(str1.indexOf("h")), true);
+    assertEquals(check_is_index_found(str1.indexOf("world")), true);
 
-		assertEquals(check_is_index_found(str2.lastIndexOf("a")), true);
-		assertEquals(check_is_index_found(str2.lastIndexOf("n")), true);
-	});
+    assertEquals(check_is_index_found(str2.lastIndexOf("a")), true);
+    assertEquals(check_is_index_found(str2.lastIndexOf("n")), true);
+  });
 
-	await t.step("should return false for invalid indexes (-1)", () => {
-		assertEquals(check_is_index_found(-1), false);
+  await t.step("should return false for invalid indexes (-1)", () => {
+    assertEquals(check_is_index_found(-1), false);
 
-		assertEquals(check_is_index_found(str1.indexOf("z")), false);
+    assertEquals(check_is_index_found(str1.indexOf("z")), false);
 
-		assertEquals(check_is_index_found(str2.lastIndexOf("z")), false);
-	});
+    assertEquals(check_is_index_found(str2.lastIndexOf("z")), false);
+  });
 });
 
 Deno.test("check_is_index_not_found", async (t) => {
-	const str1 = "hello world";
-	const str2 = "banana";
+  const str1 = "hello world";
+  const str2 = "banana";
 
-	await t.step("should return true for invalid indexes (-1)", () => {
-		assertEquals(check_is_index_not_found(-1), true);
+  await t.step("should return true for invalid indexes (-1)", () => {
+    assertEquals(check_is_index_not_found(-1), true);
 
-		assertEquals(check_is_index_not_found(str1.indexOf("z")), true);
+    assertEquals(check_is_index_not_found(str1.indexOf("z")), true);
 
-		assertEquals(check_is_index_not_found(str2.lastIndexOf("z")), true);
-	});
+    assertEquals(check_is_index_not_found(str2.lastIndexOf("z")), true);
+  });
 
-	await t.step("should return false for valid indexes (non -1)", () => {
-		assertEquals(check_is_index_not_found(0), false);
-		assertEquals(check_is_index_not_found(10), false);
+  await t.step("should return false for valid indexes (non -1)", () => {
+    assertEquals(check_is_index_not_found(0), false);
+    assertEquals(check_is_index_not_found(10), false);
 
-		assertEquals(check_is_index_not_found(str1.indexOf("h")), false);
-		assertEquals(check_is_index_not_found(str1.indexOf("world")), false);
+    assertEquals(check_is_index_not_found(str1.indexOf("h")), false);
+    assertEquals(check_is_index_not_found(str1.indexOf("world")), false);
 
-		assertEquals(check_is_index_not_found(str2.lastIndexOf("a")), false);
-		assertEquals(check_is_index_not_found(str2.lastIndexOf("n")), false);
-	});
+    assertEquals(check_is_index_not_found(str2.lastIndexOf("a")), false);
+    assertEquals(check_is_index_not_found(str2.lastIndexOf("n")), false);
+  });
 });

--- a/packages/string/src/checkIndex/test.ts
+++ b/packages/string/src/checkIndex/test.ts
@@ -1,50 +1,50 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsIndexFound, checkIsIndexNotFound } from "./main.ts";
+import { check_is_index_found, check_is_index_not_found } from "./main.ts";
 
-Deno.test("checkIsIndexFound", async (t) => {
-  const str1 = "hello world";
-  const str2 = "banana";
+Deno.test("check_is_index_found", async (t) => {
+	const str1 = "hello world";
+	const str2 = "banana";
 
-  await t.step("should return true for valid indexes (non -1)", () => {
-    assertEquals(checkIsIndexFound(0), true);
-    assertEquals(checkIsIndexFound(10), true);
+	await t.step("should return true for valid indexes (non -1)", () => {
+		assertEquals(check_is_index_found(0), true);
+		assertEquals(check_is_index_found(10), true);
 
-    assertEquals(checkIsIndexFound(str1.indexOf("h")), true);
-    assertEquals(checkIsIndexFound(str1.indexOf("world")), true);
+		assertEquals(check_is_index_found(str1.indexOf("h")), true);
+		assertEquals(check_is_index_found(str1.indexOf("world")), true);
 
-    assertEquals(checkIsIndexFound(str2.lastIndexOf("a")), true);
-    assertEquals(checkIsIndexFound(str2.lastIndexOf("n")), true);
-  });
+		assertEquals(check_is_index_found(str2.lastIndexOf("a")), true);
+		assertEquals(check_is_index_found(str2.lastIndexOf("n")), true);
+	});
 
-  await t.step("should return false for invalid indexes (-1)", () => {
-    assertEquals(checkIsIndexFound(-1), false);
+	await t.step("should return false for invalid indexes (-1)", () => {
+		assertEquals(check_is_index_found(-1), false);
 
-    assertEquals(checkIsIndexFound(str1.indexOf("z")), false);
+		assertEquals(check_is_index_found(str1.indexOf("z")), false);
 
-    assertEquals(checkIsIndexFound(str2.lastIndexOf("z")), false);
-  });
+		assertEquals(check_is_index_found(str2.lastIndexOf("z")), false);
+	});
 });
 
-Deno.test("checkIsIndexNotFound", async (t) => {
-  const str1 = "hello world";
-  const str2 = "banana";
+Deno.test("check_is_index_not_found", async (t) => {
+	const str1 = "hello world";
+	const str2 = "banana";
 
-  await t.step("should return true for invalid indexes (-1)", () => {
-    assertEquals(checkIsIndexNotFound(-1), true);
+	await t.step("should return true for invalid indexes (-1)", () => {
+		assertEquals(check_is_index_not_found(-1), true);
 
-    assertEquals(checkIsIndexNotFound(str1.indexOf("z")), true);
+		assertEquals(check_is_index_not_found(str1.indexOf("z")), true);
 
-    assertEquals(checkIsIndexNotFound(str2.lastIndexOf("z")), true);
-  });
+		assertEquals(check_is_index_not_found(str2.lastIndexOf("z")), true);
+	});
 
-  await t.step("should return false for valid indexes (non -1)", () => {
-    assertEquals(checkIsIndexNotFound(0), false);
-    assertEquals(checkIsIndexNotFound(10), false);
+	await t.step("should return false for valid indexes (non -1)", () => {
+		assertEquals(check_is_index_not_found(0), false);
+		assertEquals(check_is_index_not_found(10), false);
 
-    assertEquals(checkIsIndexNotFound(str1.indexOf("h")), false);
-    assertEquals(checkIsIndexNotFound(str1.indexOf("world")), false);
+		assertEquals(check_is_index_not_found(str1.indexOf("h")), false);
+		assertEquals(check_is_index_not_found(str1.indexOf("world")), false);
 
-    assertEquals(checkIsIndexNotFound(str2.lastIndexOf("a")), false);
-    assertEquals(checkIsIndexNotFound(str2.lastIndexOf("n")), false);
-  });
+		assertEquals(check_is_index_not_found(str2.lastIndexOf("a")), false);
+		assertEquals(check_is_index_not_found(str2.lastIndexOf("n")), false);
+	});
 });

--- a/packages/string/src/checkInfinityString/main.ts
+++ b/packages/string/src/checkInfinityString/main.ts
@@ -9,50 +9,50 @@
  *
  * @example
  * // Returns true
- * checkIsInfinityString('Infinity'); // The string is "Infinity"
+ * check_is_infinity_string('Infinity'); // The string is "Infinity"
  *
  * @example
  * // Returns true
- * checkIsInfinityString('-Infinity'); // The string is "-Infinity"
+ * check_is_infinity_string('-Infinity'); // The string is "-Infinity"
  *
  * @example
  * // Returns false
- * checkIsInfinityString('123'); // The string is a regular numeric string, not infinity
+ * check_is_infinity_string('123'); // The string is a regular numeric string, not infinity
  *
  * @example
  * // Returns false
- * checkIsInfinityString('infinity'); // The string is not exactly "Infinity" or "-Infinity"
+ * check_is_infinity_string('infinity'); // The string is not exactly "Infinity" or "-Infinity"
  */
-export const checkIsInfinityString = (
-  str: string,
+export const check_is_infinity_string = (
+	str: string
 ): str is "Infinity" | "-Infinity" => {
-  return str === "Infinity" || str === "-Infinity";
+	return str === "Infinity" || str === "-Infinity";
 };
 
 /**
  * Checks if a given string does not represent infinity.
  *
- * This is the inverse of `checkIsInfinityString`.
+ * This is the inverse of `check_is_infinity_string`.
  *
  * @param {string} str - The string to check.
  * @returns {boolean} True if the string does not represent infinity, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotInfinityString('123'); // The string is a regular numeric string, not infinity
+ * check_is_not_infinity_string('123'); // The string is a regular numeric string, not infinity
  *
  * @example
  * // Returns true
- * checkIsNotInfinityString('infinity'); // The string is not exactly "Infinity" or "-Infinity"
+ * check_is_not_infinity_string('infinity'); // The string is not exactly "Infinity" or "-Infinity"
  *
  * @example
  * // Returns false
- * checkIsNotInfinityString('Infinity'); // The string is "Infinity"
+ * check_is_not_infinity_string('Infinity'); // The string is "Infinity"
  *
  * @example
  * // Returns false
- * checkIsNotInfinityString('-Infinity'); // The string is "-Infinity"
+ * check_is_not_infinity_string('-Infinity'); // The string is "-Infinity"
  */
-export const checkIsNotInfinityString = (str: string): boolean => {
-  return !checkIsInfinityString(str);
+export const check_is_not_infinity_string = (str: string): boolean => {
+	return !check_is_infinity_string(str);
 };

--- a/packages/string/src/checkInfinityString/main.ts
+++ b/packages/string/src/checkInfinityString/main.ts
@@ -24,9 +24,9 @@
  * check_is_infinity_string('infinity'); // The string is not exactly "Infinity" or "-Infinity"
  */
 export const check_is_infinity_string = (
-	str: string
+  str: string,
 ): str is "Infinity" | "-Infinity" => {
-	return str === "Infinity" || str === "-Infinity";
+  return str === "Infinity" || str === "-Infinity";
 };
 
 /**
@@ -54,5 +54,5 @@ export const check_is_infinity_string = (
  * check_is_not_infinity_string('-Infinity'); // The string is "-Infinity"
  */
 export const check_is_not_infinity_string = (str: string): boolean => {
-	return !check_is_infinity_string(str);
+  return !check_is_infinity_string(str);
 };

--- a/packages/string/src/checkInfinityString/test.ts
+++ b/packages/string/src/checkInfinityString/test.ts
@@ -1,54 +1,57 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkIsInfinityString, checkIsNotInfinityString } from "./main.ts";
+import {
+	check_is_infinity_string,
+	check_is_not_infinity_string,
+} from "./main.ts";
 
 Deno.test("checkIsInfinityString", async (t) => {
-  await t.step(
-    'should return true for "Infinity" or "-Infinity" strings',
-    () => {
-      assertEquals(checkIsInfinityString("Infinity"), true);
-      assertEquals(checkIsInfinityString("-Infinity"), true);
-    },
-  );
+	await t.step(
+		'should return true for "Infinity" or "-Infinity" strings',
+		() => {
+			assertEquals(check_is_infinity_string("Infinity"), true);
+			assertEquals(check_is_infinity_string("-Infinity"), true);
+		}
+	);
 
-  await t.step("should return false for non-Infinity strings", () => {
-    assertEquals(checkIsInfinityString("abc"), false);
-    assertEquals(checkIsInfinityString("123"), false);
-    assertEquals(checkIsInfinityString("NaN"), false);
-    assertEquals(checkIsInfinityString("1e5"), false);
-    assertEquals(checkIsInfinityString(""), false);
-    assertEquals(checkIsInfinityString(" "), false);
-    assertEquals(checkIsInfinityString("  Infinity  "), false); // with spaces
-    assertEquals(checkIsInfinityString("  -Infinity  "), false); // with spaces
-  });
+	await t.step("should return false for non-Infinity strings", () => {
+		assertEquals(check_is_infinity_string("abc"), false);
+		assertEquals(check_is_infinity_string("123"), false);
+		assertEquals(check_is_infinity_string("NaN"), false);
+		assertEquals(check_is_infinity_string("1e5"), false);
+		assertEquals(check_is_infinity_string(""), false);
+		assertEquals(check_is_infinity_string(" "), false);
+		assertEquals(check_is_infinity_string("  Infinity  "), false); // with spaces
+		assertEquals(check_is_infinity_string("  -Infinity  "), false); // with spaces
+	});
 
-  await t.step("should narrow 'Infinity' or '-Infinity", () => {
-    const value: string = "";
-    if (checkIsInfinityString(value)) {
-      assertType<IsExact<typeof value, "Infinity" | "-Infinity">>(true);
-    }
-  });
+	await t.step("should narrow 'Infinity' or '-Infinity", () => {
+		const value: string = "";
+		if (check_is_infinity_string(value)) {
+			assertType<IsExact<typeof value, "Infinity" | "-Infinity">>(true);
+		}
+	});
 });
 
 Deno.test("checkIsNotInfinityString", async (t) => {
-  await t.step(
-    'should return true for strings that are not "Infinity" or "-Infinity"',
-    () => {
-      assertEquals(checkIsNotInfinityString("abc"), true);
-      assertEquals(checkIsNotInfinityString("123"), true);
-      assertEquals(checkIsNotInfinityString("NaN"), true);
-      assertEquals(checkIsNotInfinityString("1e5"), true);
-      assertEquals(checkIsNotInfinityString(""), true);
-      assertEquals(checkIsNotInfinityString(" "), true);
-      assertEquals(checkIsNotInfinityString("  Infinity  "), true); // with spaces
-      assertEquals(checkIsNotInfinityString("  -Infinity  "), true); // with spaces
-    },
-  );
+	await t.step(
+		'should return true for strings that are not "Infinity" or "-Infinity"',
+		() => {
+			assertEquals(check_is_not_infinity_string("abc"), true);
+			assertEquals(check_is_not_infinity_string("123"), true);
+			assertEquals(check_is_not_infinity_string("NaN"), true);
+			assertEquals(check_is_not_infinity_string("1e5"), true);
+			assertEquals(check_is_not_infinity_string(""), true);
+			assertEquals(check_is_not_infinity_string(" "), true);
+			assertEquals(check_is_not_infinity_string("  Infinity  "), true); // with spaces
+			assertEquals(check_is_not_infinity_string("  -Infinity  "), true); // with spaces
+		}
+	);
 
-  await t.step(
-    'should return false for "Infinity" or "-Infinity" strings',
-    () => {
-      assertEquals(checkIsNotInfinityString("Infinity"), false);
-      assertEquals(checkIsNotInfinityString("-Infinity"), false);
-    },
-  );
+	await t.step(
+		'should return false for "Infinity" or "-Infinity" strings',
+		() => {
+			assertEquals(check_is_not_infinity_string("Infinity"), false);
+			assertEquals(check_is_not_infinity_string("-Infinity"), false);
+		}
+	);
 });

--- a/packages/string/src/checkInfinityString/test.ts
+++ b/packages/string/src/checkInfinityString/test.ts
@@ -1,57 +1,57 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import {
-	check_is_infinity_string,
-	check_is_not_infinity_string,
+  check_is_infinity_string,
+  check_is_not_infinity_string,
 } from "./main.ts";
 
 Deno.test("checkIsInfinityString", async (t) => {
-	await t.step(
-		'should return true for "Infinity" or "-Infinity" strings',
-		() => {
-			assertEquals(check_is_infinity_string("Infinity"), true);
-			assertEquals(check_is_infinity_string("-Infinity"), true);
-		}
-	);
+  await t.step(
+    'should return true for "Infinity" or "-Infinity" strings',
+    () => {
+      assertEquals(check_is_infinity_string("Infinity"), true);
+      assertEquals(check_is_infinity_string("-Infinity"), true);
+    },
+  );
 
-	await t.step("should return false for non-Infinity strings", () => {
-		assertEquals(check_is_infinity_string("abc"), false);
-		assertEquals(check_is_infinity_string("123"), false);
-		assertEquals(check_is_infinity_string("NaN"), false);
-		assertEquals(check_is_infinity_string("1e5"), false);
-		assertEquals(check_is_infinity_string(""), false);
-		assertEquals(check_is_infinity_string(" "), false);
-		assertEquals(check_is_infinity_string("  Infinity  "), false); // with spaces
-		assertEquals(check_is_infinity_string("  -Infinity  "), false); // with spaces
-	});
+  await t.step("should return false for non-Infinity strings", () => {
+    assertEquals(check_is_infinity_string("abc"), false);
+    assertEquals(check_is_infinity_string("123"), false);
+    assertEquals(check_is_infinity_string("NaN"), false);
+    assertEquals(check_is_infinity_string("1e5"), false);
+    assertEquals(check_is_infinity_string(""), false);
+    assertEquals(check_is_infinity_string(" "), false);
+    assertEquals(check_is_infinity_string("  Infinity  "), false); // with spaces
+    assertEquals(check_is_infinity_string("  -Infinity  "), false); // with spaces
+  });
 
-	await t.step("should narrow 'Infinity' or '-Infinity", () => {
-		const value: string = "";
-		if (check_is_infinity_string(value)) {
-			assertType<IsExact<typeof value, "Infinity" | "-Infinity">>(true);
-		}
-	});
+  await t.step("should narrow 'Infinity' or '-Infinity", () => {
+    const value: string = "";
+    if (check_is_infinity_string(value)) {
+      assertType<IsExact<typeof value, "Infinity" | "-Infinity">>(true);
+    }
+  });
 });
 
 Deno.test("checkIsNotInfinityString", async (t) => {
-	await t.step(
-		'should return true for strings that are not "Infinity" or "-Infinity"',
-		() => {
-			assertEquals(check_is_not_infinity_string("abc"), true);
-			assertEquals(check_is_not_infinity_string("123"), true);
-			assertEquals(check_is_not_infinity_string("NaN"), true);
-			assertEquals(check_is_not_infinity_string("1e5"), true);
-			assertEquals(check_is_not_infinity_string(""), true);
-			assertEquals(check_is_not_infinity_string(" "), true);
-			assertEquals(check_is_not_infinity_string("  Infinity  "), true); // with spaces
-			assertEquals(check_is_not_infinity_string("  -Infinity  "), true); // with spaces
-		}
-	);
+  await t.step(
+    'should return true for strings that are not "Infinity" or "-Infinity"',
+    () => {
+      assertEquals(check_is_not_infinity_string("abc"), true);
+      assertEquals(check_is_not_infinity_string("123"), true);
+      assertEquals(check_is_not_infinity_string("NaN"), true);
+      assertEquals(check_is_not_infinity_string("1e5"), true);
+      assertEquals(check_is_not_infinity_string(""), true);
+      assertEquals(check_is_not_infinity_string(" "), true);
+      assertEquals(check_is_not_infinity_string("  Infinity  "), true); // with spaces
+      assertEquals(check_is_not_infinity_string("  -Infinity  "), true); // with spaces
+    },
+  );
 
-	await t.step(
-		'should return false for "Infinity" or "-Infinity" strings',
-		() => {
-			assertEquals(check_is_not_infinity_string("Infinity"), false);
-			assertEquals(check_is_not_infinity_string("-Infinity"), false);
-		}
-	);
+  await t.step(
+    'should return false for "Infinity" or "-Infinity" strings',
+    () => {
+      assertEquals(check_is_not_infinity_string("Infinity"), false);
+      assertEquals(check_is_not_infinity_string("-Infinity"), false);
+    },
+  );
 });

--- a/packages/string/src/checkIntegerOrDecimalString/main.ts
+++ b/packages/string/src/checkIntegerOrDecimalString/main.ts
@@ -20,8 +20,8 @@
  * check_is_integer_or_decimal_string('123abc'); // The string contains non-numeric characters
  */
 export const check_is_integer_or_decimal_string = (str: string): boolean => {
-	const numericRegex = /^-?\d+(\.\d+)?$/;
-	return numericRegex.test(str);
+  const numericRegex = /^-?\d+(\.\d+)?$/;
+  return numericRegex.test(str);
 };
 
 /**
@@ -41,7 +41,7 @@ export const check_is_integer_or_decimal_string = (str: string): boolean => {
  * check_is_not_integer_or_decimal_string('123'); // The string represents a positive integer
  */
 export const check_is_not_integer_or_decimal_string = (
-	str: string
+  str: string,
 ): boolean => {
-	return !check_is_integer_or_decimal_string(str);
+  return !check_is_integer_or_decimal_string(str);
 };

--- a/packages/string/src/checkIntegerOrDecimalString/main.ts
+++ b/packages/string/src/checkIntegerOrDecimalString/main.ts
@@ -9,37 +9,39 @@
  *
  * @example
  * // Returns true
- * checkIsIntegerOrDecimalString('123'); // The string represents a positive integer
+ * check_is_integer_or_decimal_string('123'); // The string represents a positive integer
  *
  * @example
  * // Returns true
- * checkIsIntegerOrDecimalString('-123.45'); // The string represents a negative floating-point number
+ * check_is_integer_or_decimal_string('-123.45'); // The string represents a negative floating-point number
  *
  * @example
  * // Returns false
- * checkIsIntegerOrDecimalString('123abc'); // The string contains non-numeric characters
+ * check_is_integer_or_decimal_string('123abc'); // The string contains non-numeric characters
  */
-export const checkIsIntegerOrDecimalString = (str: string): boolean => {
-  const numericRegex = /^-?\d+(\.\d+)?$/;
-  return numericRegex.test(str);
+export const check_is_integer_or_decimal_string = (str: string): boolean => {
+	const numericRegex = /^-?\d+(\.\d+)?$/;
+	return numericRegex.test(str);
 };
 
 /**
  * Checks if a given string is not a numeric value.
  *
- * This is the inverse of `checkIsIntegerOrDecimalString`.
+ * This is the inverse of `check_is_integer_or_decimal_string`.
  *
  * @param {string} str - The string to check.
  * @returns {boolean} True if the string is not numeric, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotIntegerOrDecimalString('123abc'); // The string contains non-numeric characters
+ * check_is_not_integer_or_decimal_string('123abc'); // The string contains non-numeric characters
  *
  * @example
  * // Returns false
- * checkIsNotIntegerOrDecimalString('123'); // The string represents a positive integer
+ * check_is_not_integer_or_decimal_string('123'); // The string represents a positive integer
  */
-export const checkIsNotIntegerOrDecimalString = (str: string): boolean => {
-  return !checkIsIntegerOrDecimalString(str);
+export const check_is_not_integer_or_decimal_string = (
+	str: string
+): boolean => {
+	return !check_is_integer_or_decimal_string(str);
 };

--- a/packages/string/src/checkIntegerOrDecimalString/test.ts
+++ b/packages/string/src/checkIntegerOrDecimalString/test.ts
@@ -1,45 +1,45 @@
 import { assertEquals } from "../../deps.ts";
 import {
-	check_is_integer_or_decimal_string,
-	check_is_not_integer_or_decimal_string,
+  check_is_integer_or_decimal_string,
+  check_is_not_integer_or_decimal_string,
 } from "./main.ts";
 
 Deno.test("check_is_integer_or_decimal_string", async (t) => {
-	await t.step("should return true for numeric strings", () => {
-		assertEquals(check_is_integer_or_decimal_string("123"), true);
-		assertEquals(check_is_integer_or_decimal_string("0"), true);
-		assertEquals(check_is_integer_or_decimal_string("-123"), true);
-		assertEquals(check_is_integer_or_decimal_string("3.14"), true);
-		assertEquals(check_is_integer_or_decimal_string("-3.14"), true);
-	});
+  await t.step("should return true for numeric strings", () => {
+    assertEquals(check_is_integer_or_decimal_string("123"), true);
+    assertEquals(check_is_integer_or_decimal_string("0"), true);
+    assertEquals(check_is_integer_or_decimal_string("-123"), true);
+    assertEquals(check_is_integer_or_decimal_string("3.14"), true);
+    assertEquals(check_is_integer_or_decimal_string("-3.14"), true);
+  });
 
-	await t.step("should return false for non-numeric strings", () => {
-		assertEquals(check_is_integer_or_decimal_string("abc"), false);
-		assertEquals(check_is_integer_or_decimal_string("123abc"), false);
-		assertEquals(check_is_integer_or_decimal_string(""), false);
-		assertEquals(check_is_integer_or_decimal_string(" "), false);
-		assertEquals(check_is_integer_or_decimal_string("NaN"), false);
-		assertEquals(check_is_integer_or_decimal_string("Infinity"), false);
-		assertEquals(check_is_integer_or_decimal_string("1e5"), false);
-	});
+  await t.step("should return false for non-numeric strings", () => {
+    assertEquals(check_is_integer_or_decimal_string("abc"), false);
+    assertEquals(check_is_integer_or_decimal_string("123abc"), false);
+    assertEquals(check_is_integer_or_decimal_string(""), false);
+    assertEquals(check_is_integer_or_decimal_string(" "), false);
+    assertEquals(check_is_integer_or_decimal_string("NaN"), false);
+    assertEquals(check_is_integer_or_decimal_string("Infinity"), false);
+    assertEquals(check_is_integer_or_decimal_string("1e5"), false);
+  });
 });
 
 Deno.test("check_is_not_integer_or_decimal_string", async (t) => {
-	await t.step("should return true for non-numeric strings", () => {
-		assertEquals(check_is_not_integer_or_decimal_string("abc"), true);
-		assertEquals(check_is_not_integer_or_decimal_string("123abc"), true);
-		assertEquals(check_is_not_integer_or_decimal_string(""), true);
-		assertEquals(check_is_not_integer_or_decimal_string(" "), true);
-		assertEquals(check_is_not_integer_or_decimal_string("NaN"), true);
-		assertEquals(check_is_not_integer_or_decimal_string("Infinity"), true);
-		assertEquals(check_is_not_integer_or_decimal_string("1e5"), true);
-	});
+  await t.step("should return true for non-numeric strings", () => {
+    assertEquals(check_is_not_integer_or_decimal_string("abc"), true);
+    assertEquals(check_is_not_integer_or_decimal_string("123abc"), true);
+    assertEquals(check_is_not_integer_or_decimal_string(""), true);
+    assertEquals(check_is_not_integer_or_decimal_string(" "), true);
+    assertEquals(check_is_not_integer_or_decimal_string("NaN"), true);
+    assertEquals(check_is_not_integer_or_decimal_string("Infinity"), true);
+    assertEquals(check_is_not_integer_or_decimal_string("1e5"), true);
+  });
 
-	await t.step("should return false for numeric strings", () => {
-		assertEquals(check_is_not_integer_or_decimal_string("123"), false);
-		assertEquals(check_is_not_integer_or_decimal_string("0"), false);
-		assertEquals(check_is_not_integer_or_decimal_string("-123"), false);
-		assertEquals(check_is_not_integer_or_decimal_string("3.14"), false);
-		assertEquals(check_is_not_integer_or_decimal_string("-3.14"), false);
-	});
+  await t.step("should return false for numeric strings", () => {
+    assertEquals(check_is_not_integer_or_decimal_string("123"), false);
+    assertEquals(check_is_not_integer_or_decimal_string("0"), false);
+    assertEquals(check_is_not_integer_or_decimal_string("-123"), false);
+    assertEquals(check_is_not_integer_or_decimal_string("3.14"), false);
+    assertEquals(check_is_not_integer_or_decimal_string("-3.14"), false);
+  });
 });

--- a/packages/string/src/checkIntegerOrDecimalString/test.ts
+++ b/packages/string/src/checkIntegerOrDecimalString/test.ts
@@ -1,45 +1,45 @@
 import { assertEquals } from "../../deps.ts";
 import {
-  checkIsIntegerOrDecimalString,
-  checkIsNotIntegerOrDecimalString,
+	check_is_integer_or_decimal_string,
+	check_is_not_integer_or_decimal_string,
 } from "./main.ts";
 
-Deno.test("checkIsNumeric", async (t) => {
-  await t.step("should return true for numeric strings", () => {
-    assertEquals(checkIsIntegerOrDecimalString("123"), true);
-    assertEquals(checkIsIntegerOrDecimalString("0"), true);
-    assertEquals(checkIsIntegerOrDecimalString("-123"), true);
-    assertEquals(checkIsIntegerOrDecimalString("3.14"), true);
-    assertEquals(checkIsIntegerOrDecimalString("-3.14"), true);
-  });
+Deno.test("check_is_integer_or_decimal_string", async (t) => {
+	await t.step("should return true for numeric strings", () => {
+		assertEquals(check_is_integer_or_decimal_string("123"), true);
+		assertEquals(check_is_integer_or_decimal_string("0"), true);
+		assertEquals(check_is_integer_or_decimal_string("-123"), true);
+		assertEquals(check_is_integer_or_decimal_string("3.14"), true);
+		assertEquals(check_is_integer_or_decimal_string("-3.14"), true);
+	});
 
-  await t.step("should return false for non-numeric strings", () => {
-    assertEquals(checkIsIntegerOrDecimalString("abc"), false);
-    assertEquals(checkIsIntegerOrDecimalString("123abc"), false);
-    assertEquals(checkIsIntegerOrDecimalString(""), false);
-    assertEquals(checkIsIntegerOrDecimalString(" "), false);
-    assertEquals(checkIsIntegerOrDecimalString("NaN"), false);
-    assertEquals(checkIsIntegerOrDecimalString("Infinity"), false);
-    assertEquals(checkIsIntegerOrDecimalString("1e5"), false);
-  });
+	await t.step("should return false for non-numeric strings", () => {
+		assertEquals(check_is_integer_or_decimal_string("abc"), false);
+		assertEquals(check_is_integer_or_decimal_string("123abc"), false);
+		assertEquals(check_is_integer_or_decimal_string(""), false);
+		assertEquals(check_is_integer_or_decimal_string(" "), false);
+		assertEquals(check_is_integer_or_decimal_string("NaN"), false);
+		assertEquals(check_is_integer_or_decimal_string("Infinity"), false);
+		assertEquals(check_is_integer_or_decimal_string("1e5"), false);
+	});
 });
 
-Deno.test("checkIsNotNumeric", async (t) => {
-  await t.step("should return true for non-numeric strings", () => {
-    assertEquals(checkIsNotIntegerOrDecimalString("abc"), true);
-    assertEquals(checkIsNotIntegerOrDecimalString("123abc"), true);
-    assertEquals(checkIsNotIntegerOrDecimalString(""), true);
-    assertEquals(checkIsNotIntegerOrDecimalString(" "), true);
-    assertEquals(checkIsNotIntegerOrDecimalString("NaN"), true);
-    assertEquals(checkIsNotIntegerOrDecimalString("Infinity"), true);
-    assertEquals(checkIsNotIntegerOrDecimalString("1e5"), true);
-  });
+Deno.test("check_is_not_integer_or_decimal_string", async (t) => {
+	await t.step("should return true for non-numeric strings", () => {
+		assertEquals(check_is_not_integer_or_decimal_string("abc"), true);
+		assertEquals(check_is_not_integer_or_decimal_string("123abc"), true);
+		assertEquals(check_is_not_integer_or_decimal_string(""), true);
+		assertEquals(check_is_not_integer_or_decimal_string(" "), true);
+		assertEquals(check_is_not_integer_or_decimal_string("NaN"), true);
+		assertEquals(check_is_not_integer_or_decimal_string("Infinity"), true);
+		assertEquals(check_is_not_integer_or_decimal_string("1e5"), true);
+	});
 
-  await t.step("should return false for numeric strings", () => {
-    assertEquals(checkIsNotIntegerOrDecimalString("123"), false);
-    assertEquals(checkIsNotIntegerOrDecimalString("0"), false);
-    assertEquals(checkIsNotIntegerOrDecimalString("-123"), false);
-    assertEquals(checkIsNotIntegerOrDecimalString("3.14"), false);
-    assertEquals(checkIsNotIntegerOrDecimalString("-3.14"), false);
-  });
+	await t.step("should return false for numeric strings", () => {
+		assertEquals(check_is_not_integer_or_decimal_string("123"), false);
+		assertEquals(check_is_not_integer_or_decimal_string("0"), false);
+		assertEquals(check_is_not_integer_or_decimal_string("-123"), false);
+		assertEquals(check_is_not_integer_or_decimal_string("3.14"), false);
+		assertEquals(check_is_not_integer_or_decimal_string("-3.14"), false);
+	});
 });

--- a/packages/string/src/checkPrefix/main.ts
+++ b/packages/string/src/checkPrefix/main.ts
@@ -11,23 +11,23 @@
  *
  * @example
  * // Returns true
- * checkHasPrefix('hello world', 'hello'); // The string starts with 'hello'
+ * check_has_prefix('hello world', 'hello'); // The string starts with 'hello'
  *
  * @example
  * // Returns false
- * checkHasPrefix('hello world', 'world'); // The string does not start with 'world'
+ * check_has_prefix('hello world', 'world'); // The string does not start with 'world'
  */
-export const checkHasPrefix = <Prefix extends string>(
-  str: string,
-  prefix: Prefix,
+export const check_has_prefix = <Prefix extends string>(
+	str: string,
+	prefix: Prefix
 ): str is `${Prefix}${string}` => {
-  return str.startsWith(prefix);
+	return str.startsWith(prefix);
 };
 
 /**
  * Checks if a given string does not have a specific prefix.
  *
- * This is the inverse of `checkHasPrefix`.
+ * This is the inverse of `check_has_prefix`.
  *
  * @param {string} str - The string to check.
  * @param {string} prefix - The prefix to check against.
@@ -35,15 +35,15 @@ export const checkHasPrefix = <Prefix extends string>(
  *
  * @example
  * // Returns true
- * checkDoesNotHavePrefix('hello world', 'world'); // The string does not start with 'world'
+ * check_does_not_have_prefix('hello world', 'world'); // The string does not start with 'world'
  *
  * @example
  * // Returns false
- * checkDoesNotHavePrefix('hello world', 'hello'); // The string starts with 'hello'
+ * check_does_not_have_prefix('hello world', 'hello'); // The string starts with 'hello'
  */
-export const checkDoesNotHavePrefix = (
-  str: string,
-  prefix: string,
+export const check_does_not_have_prefix = (
+	str: string,
+	prefix: string
 ): boolean => {
-  return !checkHasPrefix(str, prefix);
+	return !check_has_prefix(str, prefix);
 };

--- a/packages/string/src/checkPrefix/main.ts
+++ b/packages/string/src/checkPrefix/main.ts
@@ -18,10 +18,10 @@
  * check_has_prefix('hello world', 'world'); // The string does not start with 'world'
  */
 export const check_has_prefix = <Prefix extends string>(
-	str: string,
-	prefix: Prefix
+  str: string,
+  prefix: Prefix,
 ): str is `${Prefix}${string}` => {
-	return str.startsWith(prefix);
+  return str.startsWith(prefix);
 };
 
 /**
@@ -42,8 +42,8 @@ export const check_has_prefix = <Prefix extends string>(
  * check_does_not_have_prefix('hello world', 'hello'); // The string starts with 'hello'
  */
 export const check_does_not_have_prefix = (
-	str: string,
-	prefix: string
+  str: string,
+  prefix: string,
 ): boolean => {
-	return !check_has_prefix(str, prefix);
+  return !check_has_prefix(str, prefix);
 };

--- a/packages/string/src/checkPrefix/test.ts
+++ b/packages/string/src/checkPrefix/test.ts
@@ -1,63 +1,63 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkDoesNotHavePrefix, checkHasPrefix } from "./main.ts";
+import { check_does_not_have_prefix, check_has_prefix } from "./main.ts";
 
-Deno.test("checkStartsWith", async (t) => {
-  await t.step(
-    "should return true when the string starts with the prefix",
-    () => {
-      assertEquals(checkHasPrefix("hello world", "hello"), true);
-      assertEquals(checkHasPrefix("deno land", "deno"), true);
-      assertEquals(checkHasPrefix("special!characters", "special!"), true);
-      assertEquals(checkHasPrefix("12345", "123"), true);
-      assertEquals(checkHasPrefix("test", "t"), true);
-    },
-  );
+Deno.test("check_has_prefix", async (t) => {
+	await t.step(
+		"should return true when the string starts with the prefix",
+		() => {
+			assertEquals(check_has_prefix("hello world", "hello"), true);
+			assertEquals(check_has_prefix("deno land", "deno"), true);
+			assertEquals(check_has_prefix("special!characters", "special!"), true);
+			assertEquals(check_has_prefix("12345", "123"), true);
+			assertEquals(check_has_prefix("test", "t"), true);
+		}
+	);
 
-  await t.step(
-    "should return false when the string does not start with the prefix",
-    () => {
-      assertEquals(checkHasPrefix("hello world", "world"), false);
-      assertEquals(checkHasPrefix("deno land", "land"), false);
-      assertEquals(checkHasPrefix("special!characters", "!special"), false);
-      assertEquals(checkHasPrefix("12345", "234"), false);
-      assertEquals(checkHasPrefix("test", "e"), false);
-    },
-  );
+	await t.step(
+		"should return false when the string does not start with the prefix",
+		() => {
+			assertEquals(check_has_prefix("hello world", "world"), false);
+			assertEquals(check_has_prefix("deno land", "land"), false);
+			assertEquals(check_has_prefix("special!characters", "!special"), false);
+			assertEquals(check_has_prefix("12345", "234"), false);
+			assertEquals(check_has_prefix("test", "e"), false);
+		}
+	);
 
-  await t.step("should narrow string with prefix type", () => {
-    const value: string = "hl";
-    if (checkHasPrefix(value, "prefix")) {
-      assertType<IsExact<typeof value, `prefix${string}`>>(true);
-    }
-  });
+	await t.step("should narrow string with prefix type", () => {
+		const value: string = "hl";
+		if (check_has_prefix(value, "prefix")) {
+			assertType<IsExact<typeof value, `prefix${string}`>>(true);
+		}
+	});
 });
 
-Deno.test("checkNotStartWith", async (t) => {
-  await t.step(
-    "should return true when the string does not start with the prefix",
-    () => {
-      assertEquals(checkDoesNotHavePrefix("hello world", "world"), true);
-      assertEquals(checkDoesNotHavePrefix("deno land", "land"), true);
-      assertEquals(
-        checkDoesNotHavePrefix("special!characters", "!special"),
-        true,
-      );
-      assertEquals(checkDoesNotHavePrefix("12345", "234"), true);
-      assertEquals(checkDoesNotHavePrefix("test", "e"), true);
-    },
-  );
+Deno.test("check_does_not_have_prefix", async (t) => {
+	await t.step(
+		"should return true when the string does not start with the prefix",
+		() => {
+			assertEquals(check_does_not_have_prefix("hello world", "world"), true);
+			assertEquals(check_does_not_have_prefix("deno land", "land"), true);
+			assertEquals(
+				check_does_not_have_prefix("special!characters", "!special"),
+				true
+			);
+			assertEquals(check_does_not_have_prefix("12345", "234"), true);
+			assertEquals(check_does_not_have_prefix("test", "e"), true);
+		}
+	);
 
-  await t.step(
-    "should return false when the string starts with the prefix",
-    () => {
-      assertEquals(checkDoesNotHavePrefix("hello world", "hello"), false);
-      assertEquals(checkDoesNotHavePrefix("deno land", "deno"), false);
-      assertEquals(
-        checkDoesNotHavePrefix("special!characters", "special!"),
-        false,
-      );
-      assertEquals(checkDoesNotHavePrefix("12345", "123"), false);
-      assertEquals(checkDoesNotHavePrefix("test", "t"), false);
-    },
-  );
+	await t.step(
+		"should return false when the string starts with the prefix",
+		() => {
+			assertEquals(check_does_not_have_prefix("hello world", "hello"), false);
+			assertEquals(check_does_not_have_prefix("deno land", "deno"), false);
+			assertEquals(
+				check_does_not_have_prefix("special!characters", "special!"),
+				false
+			);
+			assertEquals(check_does_not_have_prefix("12345", "123"), false);
+			assertEquals(check_does_not_have_prefix("test", "t"), false);
+		}
+	);
 });

--- a/packages/string/src/checkPrefix/test.ts
+++ b/packages/string/src/checkPrefix/test.ts
@@ -2,62 +2,62 @@ import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import { check_does_not_have_prefix, check_has_prefix } from "./main.ts";
 
 Deno.test("check_has_prefix", async (t) => {
-	await t.step(
-		"should return true when the string starts with the prefix",
-		() => {
-			assertEquals(check_has_prefix("hello world", "hello"), true);
-			assertEquals(check_has_prefix("deno land", "deno"), true);
-			assertEquals(check_has_prefix("special!characters", "special!"), true);
-			assertEquals(check_has_prefix("12345", "123"), true);
-			assertEquals(check_has_prefix("test", "t"), true);
-		}
-	);
+  await t.step(
+    "should return true when the string starts with the prefix",
+    () => {
+      assertEquals(check_has_prefix("hello world", "hello"), true);
+      assertEquals(check_has_prefix("deno land", "deno"), true);
+      assertEquals(check_has_prefix("special!characters", "special!"), true);
+      assertEquals(check_has_prefix("12345", "123"), true);
+      assertEquals(check_has_prefix("test", "t"), true);
+    },
+  );
 
-	await t.step(
-		"should return false when the string does not start with the prefix",
-		() => {
-			assertEquals(check_has_prefix("hello world", "world"), false);
-			assertEquals(check_has_prefix("deno land", "land"), false);
-			assertEquals(check_has_prefix("special!characters", "!special"), false);
-			assertEquals(check_has_prefix("12345", "234"), false);
-			assertEquals(check_has_prefix("test", "e"), false);
-		}
-	);
+  await t.step(
+    "should return false when the string does not start with the prefix",
+    () => {
+      assertEquals(check_has_prefix("hello world", "world"), false);
+      assertEquals(check_has_prefix("deno land", "land"), false);
+      assertEquals(check_has_prefix("special!characters", "!special"), false);
+      assertEquals(check_has_prefix("12345", "234"), false);
+      assertEquals(check_has_prefix("test", "e"), false);
+    },
+  );
 
-	await t.step("should narrow string with prefix type", () => {
-		const value: string = "hl";
-		if (check_has_prefix(value, "prefix")) {
-			assertType<IsExact<typeof value, `prefix${string}`>>(true);
-		}
-	});
+  await t.step("should narrow string with prefix type", () => {
+    const value: string = "hl";
+    if (check_has_prefix(value, "prefix")) {
+      assertType<IsExact<typeof value, `prefix${string}`>>(true);
+    }
+  });
 });
 
 Deno.test("check_does_not_have_prefix", async (t) => {
-	await t.step(
-		"should return true when the string does not start with the prefix",
-		() => {
-			assertEquals(check_does_not_have_prefix("hello world", "world"), true);
-			assertEquals(check_does_not_have_prefix("deno land", "land"), true);
-			assertEquals(
-				check_does_not_have_prefix("special!characters", "!special"),
-				true
-			);
-			assertEquals(check_does_not_have_prefix("12345", "234"), true);
-			assertEquals(check_does_not_have_prefix("test", "e"), true);
-		}
-	);
+  await t.step(
+    "should return true when the string does not start with the prefix",
+    () => {
+      assertEquals(check_does_not_have_prefix("hello world", "world"), true);
+      assertEquals(check_does_not_have_prefix("deno land", "land"), true);
+      assertEquals(
+        check_does_not_have_prefix("special!characters", "!special"),
+        true,
+      );
+      assertEquals(check_does_not_have_prefix("12345", "234"), true);
+      assertEquals(check_does_not_have_prefix("test", "e"), true);
+    },
+  );
 
-	await t.step(
-		"should return false when the string starts with the prefix",
-		() => {
-			assertEquals(check_does_not_have_prefix("hello world", "hello"), false);
-			assertEquals(check_does_not_have_prefix("deno land", "deno"), false);
-			assertEquals(
-				check_does_not_have_prefix("special!characters", "special!"),
-				false
-			);
-			assertEquals(check_does_not_have_prefix("12345", "123"), false);
-			assertEquals(check_does_not_have_prefix("test", "t"), false);
-		}
-	);
+  await t.step(
+    "should return false when the string starts with the prefix",
+    () => {
+      assertEquals(check_does_not_have_prefix("hello world", "hello"), false);
+      assertEquals(check_does_not_have_prefix("deno land", "deno"), false);
+      assertEquals(
+        check_does_not_have_prefix("special!characters", "special!"),
+        false,
+      );
+      assertEquals(check_does_not_have_prefix("12345", "123"), false);
+      assertEquals(check_does_not_have_prefix("test", "t"), false);
+    },
+  );
 });

--- a/packages/string/src/checkSpecialCharacter/main.ts
+++ b/packages/string/src/checkSpecialCharacter/main.ts
@@ -9,49 +9,49 @@
  *
  * @example
  * // Returns true
- * checkHasSpecialCharacter('hello@world'); // The string contains the special character '@'
+ * check_has_special_character('hello@world'); // The string contains the special character '@'
  *
  * @example
  * // Returns true
- * checkHasSpecialCharacter('password123!'); // The string contains the special character '!'
+ * check_has_special_character('password123!'); // The string contains the special character '!'
  *
  * @example
  * // Returns true
- * checkHasSpecialCharacter('C:\\Program Files\\'); // The string contains the special characters '\\'
+ * check_has_special_character('C:\\Program Files\\'); // The string contains the special characters '\\'
  *
  * @example
  * // Returns true
- * checkHasSpecialCharacter('welcome-home'); // The string contains the special character '-'
+ * check_has_special_character('welcome-home'); // The string contains the special character '-'
  *
  * @example
  * // Returns false
- * checkHasSpecialCharacter('helloworld'); // The string contains only letters and no special characters
+ * check_has_special_character('helloworld'); // The string contains only letters and no special characters
  *
  * @example
  * // Returns false
- * checkHasSpecialCharacter('123456'); // The string contains only numbers and no special characters
+ * check_has_special_character('123456'); // The string contains only numbers and no special characters
  */
-export const checkHasSpecialCharacter = (str: string): boolean => {
-  const specialCharacterRegex = /[!@#$%^&*(),.?":{}|<>~`'\-_=+\[\];/\\]/;
-  return specialCharacterRegex.test(str);
+export const check_has_special_character = (str: string): boolean => {
+	const specialCharacterRegex = /[!@#$%^&*(),.?":{}|<>~`'\-_=+\[\];/\\]/;
+	return specialCharacterRegex.test(str);
 };
 
 /**
  * Checks if a given string does not contain any special characters.
  *
- * This is the inverse of `checkStringHasSpecialCharacter`.
+ * This is the inverse of `check_has_special_character`.
  *
  * @param {string} str - The string to check.
  * @returns {boolean} True if the string does not contain special characters, otherwise false.
  *
  * @example
  * // Returns true
- * checkDoesNotHaveSpecialCharacter('helloworld'); // The string contains only letters and no special characters
+ * check_does_not_have_special_character('helloworld'); // The string contains only letters and no special characters
  *
  * @example
  * // Returns false
- * checkDoesNotHaveSpecialCharacter('hello@world'); // The string contains the special character '@'
+ * check_does_not_have_special_character('hello@world'); // The string contains the special character '@'
  */
-export const checkDoesNotHaveSpecialCharacter = (str: string): boolean => {
-  return !checkHasSpecialCharacter(str);
+export const check_does_not_have_special_character = (str: string): boolean => {
+	return !check_has_special_character(str);
 };

--- a/packages/string/src/checkSpecialCharacter/main.ts
+++ b/packages/string/src/checkSpecialCharacter/main.ts
@@ -32,8 +32,8 @@
  * check_has_special_character('123456'); // The string contains only numbers and no special characters
  */
 export const check_has_special_character = (str: string): boolean => {
-	const specialCharacterRegex = /[!@#$%^&*(),.?":{}|<>~`'\-_=+\[\];/\\]/;
-	return specialCharacterRegex.test(str);
+  const specialCharacterRegex = /[!@#$%^&*(),.?":{}|<>~`'\-_=+\[\];/\\]/;
+  return specialCharacterRegex.test(str);
 };
 
 /**
@@ -53,5 +53,5 @@ export const check_has_special_character = (str: string): boolean => {
  * check_does_not_have_special_character('hello@world'); // The string contains the special character '@'
  */
 export const check_does_not_have_special_character = (str: string): boolean => {
-	return !check_has_special_character(str);
+  return !check_has_special_character(str);
 };

--- a/packages/string/src/checkSpecialCharacter/test.ts
+++ b/packages/string/src/checkSpecialCharacter/test.ts
@@ -1,52 +1,55 @@
 import { assertEquals } from "../../deps.ts";
 import {
-  checkDoesNotHaveSpecialCharacter,
-  checkHasSpecialCharacter,
+	check_does_not_have_special_character,
+	check_has_special_character,
 } from "./main.ts";
 
-Deno.test("checkHasSpecialCharacter", async (t) => {
-  await t.step("should return true for strings with special characters", () => {
-    assertEquals(checkHasSpecialCharacter("hello!"), true);
-    assertEquals(checkHasSpecialCharacter("password#1"), true);
-    assertEquals(checkHasSpecialCharacter("welcome@home"), true);
-    assertEquals(checkHasSpecialCharacter("$100"), true);
-    assertEquals(checkHasSpecialCharacter("what's up?"), true);
-    assertEquals(checkHasSpecialCharacter("<tag>"), true);
-  });
+Deno.test("check_has_special_character", async (t) => {
+	await t.step("should return true for strings with special characters", () => {
+		assertEquals(check_has_special_character("hello!"), true);
+		assertEquals(check_has_special_character("password#1"), true);
+		assertEquals(check_has_special_character("welcome@home"), true);
+		assertEquals(check_has_special_character("$100"), true);
+		assertEquals(check_has_special_character("what's up?"), true);
+		assertEquals(check_has_special_character("<tag>"), true);
+	});
 
-  await t.step(
-    "should return false for strings without special characters",
-    () => {
-      assertEquals(checkHasSpecialCharacter("hello"), false);
-      assertEquals(checkHasSpecialCharacter("password1"), false);
-      assertEquals(checkHasSpecialCharacter("welcomehome"), false);
-      assertEquals(checkHasSpecialCharacter("hello123"), false);
-      assertEquals(checkHasSpecialCharacter("justText"), false);
-    },
-  );
+	await t.step(
+		"should return false for strings without special characters",
+		() => {
+			assertEquals(check_has_special_character("hello"), false);
+			assertEquals(check_has_special_character("password1"), false);
+			assertEquals(check_has_special_character("welcomehome"), false);
+			assertEquals(check_has_special_character("hello123"), false);
+			assertEquals(check_has_special_character("justText"), false);
+		}
+	);
 });
 
-Deno.test("checkNotHaveSpecialCharacter", async (t) => {
-  await t.step(
-    "should return true for strings without special characters",
-    () => {
-      assertEquals(checkDoesNotHaveSpecialCharacter("hello"), true);
-      assertEquals(checkDoesNotHaveSpecialCharacter("password1"), true);
-      assertEquals(checkDoesNotHaveSpecialCharacter("welcomehome"), true);
-      assertEquals(checkDoesNotHaveSpecialCharacter("hello123"), true);
-      assertEquals(checkDoesNotHaveSpecialCharacter("justText"), true);
-    },
-  );
+Deno.test("check_does_not_have_special_character", async (t) => {
+	await t.step(
+		"should return true for strings without special characters",
+		() => {
+			assertEquals(check_does_not_have_special_character("hello"), true);
+			assertEquals(check_does_not_have_special_character("password1"), true);
+			assertEquals(check_does_not_have_special_character("welcomehome"), true);
+			assertEquals(check_does_not_have_special_character("hello123"), true);
+			assertEquals(check_does_not_have_special_character("justText"), true);
+		}
+	);
 
-  await t.step(
-    "should return false for strings with special characters",
-    () => {
-      assertEquals(checkDoesNotHaveSpecialCharacter("hello!"), false);
-      assertEquals(checkDoesNotHaveSpecialCharacter("password#1"), false);
-      assertEquals(checkDoesNotHaveSpecialCharacter("welcome@home"), false);
-      assertEquals(checkDoesNotHaveSpecialCharacter("$100"), false);
-      assertEquals(checkDoesNotHaveSpecialCharacter("what's up?"), false);
-      assertEquals(checkDoesNotHaveSpecialCharacter("<tag>"), false);
-    },
-  );
+	await t.step(
+		"should return false for strings with special characters",
+		() => {
+			assertEquals(check_does_not_have_special_character("hello!"), false);
+			assertEquals(check_does_not_have_special_character("password#1"), false);
+			assertEquals(
+				check_does_not_have_special_character("welcome@home"),
+				false
+			);
+			assertEquals(check_does_not_have_special_character("$100"), false);
+			assertEquals(check_does_not_have_special_character("what's up?"), false);
+			assertEquals(check_does_not_have_special_character("<tag>"), false);
+		}
+	);
 });

--- a/packages/string/src/checkSpecialCharacter/test.ts
+++ b/packages/string/src/checkSpecialCharacter/test.ts
@@ -1,55 +1,55 @@
 import { assertEquals } from "../../deps.ts";
 import {
-	check_does_not_have_special_character,
-	check_has_special_character,
+  check_does_not_have_special_character,
+  check_has_special_character,
 } from "./main.ts";
 
 Deno.test("check_has_special_character", async (t) => {
-	await t.step("should return true for strings with special characters", () => {
-		assertEquals(check_has_special_character("hello!"), true);
-		assertEquals(check_has_special_character("password#1"), true);
-		assertEquals(check_has_special_character("welcome@home"), true);
-		assertEquals(check_has_special_character("$100"), true);
-		assertEquals(check_has_special_character("what's up?"), true);
-		assertEquals(check_has_special_character("<tag>"), true);
-	});
+  await t.step("should return true for strings with special characters", () => {
+    assertEquals(check_has_special_character("hello!"), true);
+    assertEquals(check_has_special_character("password#1"), true);
+    assertEquals(check_has_special_character("welcome@home"), true);
+    assertEquals(check_has_special_character("$100"), true);
+    assertEquals(check_has_special_character("what's up?"), true);
+    assertEquals(check_has_special_character("<tag>"), true);
+  });
 
-	await t.step(
-		"should return false for strings without special characters",
-		() => {
-			assertEquals(check_has_special_character("hello"), false);
-			assertEquals(check_has_special_character("password1"), false);
-			assertEquals(check_has_special_character("welcomehome"), false);
-			assertEquals(check_has_special_character("hello123"), false);
-			assertEquals(check_has_special_character("justText"), false);
-		}
-	);
+  await t.step(
+    "should return false for strings without special characters",
+    () => {
+      assertEquals(check_has_special_character("hello"), false);
+      assertEquals(check_has_special_character("password1"), false);
+      assertEquals(check_has_special_character("welcomehome"), false);
+      assertEquals(check_has_special_character("hello123"), false);
+      assertEquals(check_has_special_character("justText"), false);
+    },
+  );
 });
 
 Deno.test("check_does_not_have_special_character", async (t) => {
-	await t.step(
-		"should return true for strings without special characters",
-		() => {
-			assertEquals(check_does_not_have_special_character("hello"), true);
-			assertEquals(check_does_not_have_special_character("password1"), true);
-			assertEquals(check_does_not_have_special_character("welcomehome"), true);
-			assertEquals(check_does_not_have_special_character("hello123"), true);
-			assertEquals(check_does_not_have_special_character("justText"), true);
-		}
-	);
+  await t.step(
+    "should return true for strings without special characters",
+    () => {
+      assertEquals(check_does_not_have_special_character("hello"), true);
+      assertEquals(check_does_not_have_special_character("password1"), true);
+      assertEquals(check_does_not_have_special_character("welcomehome"), true);
+      assertEquals(check_does_not_have_special_character("hello123"), true);
+      assertEquals(check_does_not_have_special_character("justText"), true);
+    },
+  );
 
-	await t.step(
-		"should return false for strings with special characters",
-		() => {
-			assertEquals(check_does_not_have_special_character("hello!"), false);
-			assertEquals(check_does_not_have_special_character("password#1"), false);
-			assertEquals(
-				check_does_not_have_special_character("welcome@home"),
-				false
-			);
-			assertEquals(check_does_not_have_special_character("$100"), false);
-			assertEquals(check_does_not_have_special_character("what's up?"), false);
-			assertEquals(check_does_not_have_special_character("<tag>"), false);
-		}
-	);
+  await t.step(
+    "should return false for strings with special characters",
+    () => {
+      assertEquals(check_does_not_have_special_character("hello!"), false);
+      assertEquals(check_does_not_have_special_character("password#1"), false);
+      assertEquals(
+        check_does_not_have_special_character("welcome@home"),
+        false,
+      );
+      assertEquals(check_does_not_have_special_character("$100"), false);
+      assertEquals(check_does_not_have_special_character("what's up?"), false);
+      assertEquals(check_does_not_have_special_character("<tag>"), false);
+    },
+  );
 });

--- a/packages/string/src/checkSpecialNumeric/main.ts
+++ b/packages/string/src/checkSpecialNumeric/main.ts
@@ -1,6 +1,6 @@
-import { checkIsExponentialNotation } from "../checkExponentialNotation/main.ts";
-import { checkIsBinary } from "../checkBinary/main.ts";
-import { checkIsInfinityString } from "../checkInfinityString/main.ts";
+import { check_is_exponential_notation } from "../checkExponentialNotation/main.ts";
+import { check_is_binary } from "../checkBinary/main.ts";
+import { check_is_infinity_string } from "../checkInfinityString/main.ts";
 
 /**
  * Checks if a given string is a special numeric value.
@@ -15,44 +15,44 @@ import { checkIsInfinityString } from "../checkInfinityString/main.ts";
  *
  * @example
  * // Returns true
- * checkIsSpecialNumeric('1e5'); // The string is in exponential notation
+ * check_is_special_numeric('1e5'); // The string is in exponential notation
  *
  * @example
  * // Returns true
- * checkIsSpecialNumeric('0b1010'); // The string is a binary number
+ * check_is_special_numeric('0b1010'); // The string is a binary number
  *
  * @example
  * // Returns true
- * checkIsSpecialNumeric('Infinity'); // The string represents infinity
+ * check_is_special_numeric('Infinity'); // The string represents infinity
  *
  * @example
  * // Returns false
- * checkIsSpecialNumeric('123'); // The string is a regular number
+ * check_is_special_numeric('123'); // The string is a regular number
  */
-export const checkIsSpecialNumeric = (str: string): boolean => {
-  return (
-    checkIsExponentialNotation(str) ||
-    checkIsBinary(str) ||
-    checkIsInfinityString(str)
-  );
+export const check_is_special_numeric = (str: string): boolean => {
+	return (
+		check_is_exponential_notation(str) ||
+		check_is_binary(str) ||
+		check_is_infinity_string(str)
+	);
 };
 
 /**
  * Checks if a given string is not a special numeric value.
  *
- * This is the inverse of `checkStringIsSpecialNumeric`.
+ * This is the inverse of `check_is_special_numeric`.
  *
  * @param {string} str - The string to check.
  * @returns {boolean} True if the string is not a special numeric value, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotSpecialNumeric('123'); // The string is a regular number
+ * check_is_not_special_numeric('123'); // The string is a regular number
  *
  * @example
  * // Returns false
- * checkIsNotSpecialNumeric('1e5'); // The string is in exponential notation
+ * check_is_not_special_numeric('1e5'); // The string is in exponential notation
  */
-export const checkIsNotSpecialNumeric = (str: string): boolean => {
-  return !checkIsSpecialNumeric(str);
+export const check_is_not_special_numeric = (str: string): boolean => {
+	return !check_is_special_numeric(str);
 };

--- a/packages/string/src/checkSpecialNumeric/main.ts
+++ b/packages/string/src/checkSpecialNumeric/main.ts
@@ -30,11 +30,11 @@ import { check_is_infinity_string } from "../checkInfinityString/main.ts";
  * check_is_special_numeric('123'); // The string is a regular number
  */
 export const check_is_special_numeric = (str: string): boolean => {
-	return (
-		check_is_exponential_notation(str) ||
-		check_is_binary(str) ||
-		check_is_infinity_string(str)
-	);
+  return (
+    check_is_exponential_notation(str) ||
+    check_is_binary(str) ||
+    check_is_infinity_string(str)
+  );
 };
 
 /**
@@ -54,5 +54,5 @@ export const check_is_special_numeric = (str: string): boolean => {
  * check_is_not_special_numeric('1e5'); // The string is in exponential notation
  */
 export const check_is_not_special_numeric = (str: string): boolean => {
-	return !check_is_special_numeric(str);
+  return !check_is_special_numeric(str);
 };

--- a/packages/string/src/checkSpecialNumeric/test.ts
+++ b/packages/string/src/checkSpecialNumeric/test.ts
@@ -1,38 +1,41 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsNotSpecialNumeric, checkIsSpecialNumeric } from "./main.ts";
+import {
+	check_is_not_special_numeric,
+	check_is_special_numeric,
+} from "./main.ts";
 
-Deno.test("checkStringIsSpecialNumeric", async (t) => {
-  await t.step("should return true for special numeric strings", () => {
-    assertEquals(checkIsSpecialNumeric("1e5"), true); // exponential notation
-    assertEquals(checkIsSpecialNumeric("0b101"), true); // binary notation
-    assertEquals(checkIsSpecialNumeric("Infinity"), true); // infinity
-    assertEquals(checkIsSpecialNumeric("-Infinity"), true); // negative infinity
-  });
+Deno.test("check_is_special_numeric", async (t) => {
+	await t.step("should return true for special numeric strings", () => {
+		assertEquals(check_is_special_numeric("1e5"), true); // exponential notation
+		assertEquals(check_is_special_numeric("0b101"), true); // binary notation
+		assertEquals(check_is_special_numeric("Infinity"), true); // infinity
+		assertEquals(check_is_special_numeric("-Infinity"), true); // negative infinity
+	});
 
-  await t.step("should return false for non-special numeric strings", () => {
-    assertEquals(checkIsSpecialNumeric("123"), false);
-    assertEquals(checkIsSpecialNumeric("3.14"), false);
-    assertEquals(checkIsSpecialNumeric("abc"), false);
-    assertEquals(checkIsSpecialNumeric("0x1F"), false); // hexadecimal is not considered special here
-    assertEquals(checkIsSpecialNumeric(" "), false);
-    assertEquals(checkIsSpecialNumeric(""), false);
-  });
+	await t.step("should return false for non-special numeric strings", () => {
+		assertEquals(check_is_special_numeric("123"), false);
+		assertEquals(check_is_special_numeric("3.14"), false);
+		assertEquals(check_is_special_numeric("abc"), false);
+		assertEquals(check_is_special_numeric("0x1F"), false); // hexadecimal is not considered special here
+		assertEquals(check_is_special_numeric(" "), false);
+		assertEquals(check_is_special_numeric(""), false);
+	});
 });
 
-Deno.test("checkStringIsNotSpecialNumeric", async (t) => {
-  await t.step("should return true for non-special numeric strings", () => {
-    assertEquals(checkIsNotSpecialNumeric("123"), true);
-    assertEquals(checkIsNotSpecialNumeric("3.14"), true);
-    assertEquals(checkIsNotSpecialNumeric("abc"), true);
-    assertEquals(checkIsNotSpecialNumeric("0x1F"), true); // hexadecimal is not considered special here
-    assertEquals(checkIsNotSpecialNumeric(" "), true);
-    assertEquals(checkIsNotSpecialNumeric(""), true);
-  });
+Deno.test("check_is_not_special_numeric", async (t) => {
+	await t.step("should return true for non-special numeric strings", () => {
+		assertEquals(check_is_not_special_numeric("123"), true);
+		assertEquals(check_is_not_special_numeric("3.14"), true);
+		assertEquals(check_is_not_special_numeric("abc"), true);
+		assertEquals(check_is_not_special_numeric("0x1F"), true); // hexadecimal is not considered special here
+		assertEquals(check_is_not_special_numeric(" "), true);
+		assertEquals(check_is_not_special_numeric(""), true);
+	});
 
-  await t.step("should return false for special numeric strings", () => {
-    assertEquals(checkIsNotSpecialNumeric("1e5"), false); // exponential notation
-    assertEquals(checkIsNotSpecialNumeric("0b101"), false); // binary notation
-    assertEquals(checkIsNotSpecialNumeric("Infinity"), false); // infinity
-    assertEquals(checkIsNotSpecialNumeric("-Infinity"), false); // negative infinity
-  });
+	await t.step("should return false for special numeric strings", () => {
+		assertEquals(check_is_not_special_numeric("1e5"), false); // exponential notation
+		assertEquals(check_is_not_special_numeric("0b101"), false); // binary notation
+		assertEquals(check_is_not_special_numeric("Infinity"), false); // infinity
+		assertEquals(check_is_not_special_numeric("-Infinity"), false); // negative infinity
+	});
 });

--- a/packages/string/src/checkSpecialNumeric/test.ts
+++ b/packages/string/src/checkSpecialNumeric/test.ts
@@ -1,41 +1,41 @@
 import { assertEquals } from "../../deps.ts";
 import {
-	check_is_not_special_numeric,
-	check_is_special_numeric,
+  check_is_not_special_numeric,
+  check_is_special_numeric,
 } from "./main.ts";
 
 Deno.test("check_is_special_numeric", async (t) => {
-	await t.step("should return true for special numeric strings", () => {
-		assertEquals(check_is_special_numeric("1e5"), true); // exponential notation
-		assertEquals(check_is_special_numeric("0b101"), true); // binary notation
-		assertEquals(check_is_special_numeric("Infinity"), true); // infinity
-		assertEquals(check_is_special_numeric("-Infinity"), true); // negative infinity
-	});
+  await t.step("should return true for special numeric strings", () => {
+    assertEquals(check_is_special_numeric("1e5"), true); // exponential notation
+    assertEquals(check_is_special_numeric("0b101"), true); // binary notation
+    assertEquals(check_is_special_numeric("Infinity"), true); // infinity
+    assertEquals(check_is_special_numeric("-Infinity"), true); // negative infinity
+  });
 
-	await t.step("should return false for non-special numeric strings", () => {
-		assertEquals(check_is_special_numeric("123"), false);
-		assertEquals(check_is_special_numeric("3.14"), false);
-		assertEquals(check_is_special_numeric("abc"), false);
-		assertEquals(check_is_special_numeric("0x1F"), false); // hexadecimal is not considered special here
-		assertEquals(check_is_special_numeric(" "), false);
-		assertEquals(check_is_special_numeric(""), false);
-	});
+  await t.step("should return false for non-special numeric strings", () => {
+    assertEquals(check_is_special_numeric("123"), false);
+    assertEquals(check_is_special_numeric("3.14"), false);
+    assertEquals(check_is_special_numeric("abc"), false);
+    assertEquals(check_is_special_numeric("0x1F"), false); // hexadecimal is not considered special here
+    assertEquals(check_is_special_numeric(" "), false);
+    assertEquals(check_is_special_numeric(""), false);
+  });
 });
 
 Deno.test("check_is_not_special_numeric", async (t) => {
-	await t.step("should return true for non-special numeric strings", () => {
-		assertEquals(check_is_not_special_numeric("123"), true);
-		assertEquals(check_is_not_special_numeric("3.14"), true);
-		assertEquals(check_is_not_special_numeric("abc"), true);
-		assertEquals(check_is_not_special_numeric("0x1F"), true); // hexadecimal is not considered special here
-		assertEquals(check_is_not_special_numeric(" "), true);
-		assertEquals(check_is_not_special_numeric(""), true);
-	});
+  await t.step("should return true for non-special numeric strings", () => {
+    assertEquals(check_is_not_special_numeric("123"), true);
+    assertEquals(check_is_not_special_numeric("3.14"), true);
+    assertEquals(check_is_not_special_numeric("abc"), true);
+    assertEquals(check_is_not_special_numeric("0x1F"), true); // hexadecimal is not considered special here
+    assertEquals(check_is_not_special_numeric(" "), true);
+    assertEquals(check_is_not_special_numeric(""), true);
+  });
 
-	await t.step("should return false for special numeric strings", () => {
-		assertEquals(check_is_not_special_numeric("1e5"), false); // exponential notation
-		assertEquals(check_is_not_special_numeric("0b101"), false); // binary notation
-		assertEquals(check_is_not_special_numeric("Infinity"), false); // infinity
-		assertEquals(check_is_not_special_numeric("-Infinity"), false); // negative infinity
-	});
+  await t.step("should return false for special numeric strings", () => {
+    assertEquals(check_is_not_special_numeric("1e5"), false); // exponential notation
+    assertEquals(check_is_not_special_numeric("0b101"), false); // binary notation
+    assertEquals(check_is_not_special_numeric("Infinity"), false); // infinity
+    assertEquals(check_is_not_special_numeric("-Infinity"), false); // negative infinity
+  });
 });

--- a/packages/string/src/checkString/main.ts
+++ b/packages/string/src/checkString/main.ts
@@ -15,7 +15,7 @@
  * check_is_string(123); // The value is not a string, it is a number
  */
 export const check_is_string = (value: unknown): value is string => {
-	return typeof value === "string";
+  return typeof value === "string";
 };
 
 /**
@@ -36,7 +36,7 @@ export const check_is_string = (value: unknown): value is string => {
  * check_is_not_string('hello world'); // The value is a string
  */
 export const check_is_not_string = <T>(
-	value: T
+  value: T,
 ): value is Exclude<T, string> => {
-	return !check_is_string(value);
+  return !check_is_string(value);
 };

--- a/packages/string/src/checkString/main.ts
+++ b/packages/string/src/checkString/main.ts
@@ -8,20 +8,20 @@
  *
  * @example
  * // Returns true
- * checkIsString('hello world'); // The value is a string
+ * check_is_string('hello world'); // The value is a string
  *
  * @example
  * // Returns false
- * checkIsString(123); // The value is not a string, it is a number
+ * check_is_string(123); // The value is not a string, it is a number
  */
-export const checkIsString = (value: unknown): value is string => {
-  return typeof value === "string";
+export const check_is_string = (value: unknown): value is string => {
+	return typeof value === "string";
 };
 
 /**
  * Checks if a given value is not a string.
  *
- * This is the inverse of `checkIsString`.
+ * This is the inverse of `check_is_string`.
  *
  * @template T - The type of the value being checked.
  * @param {T} value - The value to check.
@@ -29,12 +29,14 @@ export const checkIsString = (value: unknown): value is string => {
  *
  * @example
  * // Returns true
- * checkIsNotString(123); // The value is not a string, it is a number
+ * check_is_not_string(123); // The value is not a string, it is a number
  *
  * @example
  * // Returns false
- * checkIsNotString('hello world'); // The value is a string
+ * check_is_not_string('hello world'); // The value is a string
  */
-export const checkIsNotString = <T>(value: T): value is Exclude<T, string> => {
-  return !checkIsString(value);
+export const check_is_not_string = <T>(
+	value: T
+): value is Exclude<T, string> => {
+	return !check_is_string(value);
 };

--- a/packages/string/src/checkString/test.ts
+++ b/packages/string/src/checkString/test.ts
@@ -1,52 +1,52 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkIsNotString, checkIsString } from "./main.ts";
+import { check_is_not_string, check_is_string } from "./main.ts";
 
-Deno.test("checkIsString", async (t) => {
-  await t.step("should return true for strings", () => {
-    assertEquals(checkIsString("hello"), true);
-    assertEquals(checkIsString(""), true);
-    assertEquals(checkIsString("123"), true);
-  });
+Deno.test("check_is_string", async (t) => {
+	await t.step("should return true for strings", () => {
+		assertEquals(check_is_string("hello"), true);
+		assertEquals(check_is_string(""), true);
+		assertEquals(check_is_string("123"), true);
+	});
 
-  await t.step("should return false for non-strings", () => {
-    assertEquals(checkIsString(123), false);
-    assertEquals(checkIsString(true), false);
-    assertEquals(checkIsString({}), false);
-    assertEquals(checkIsString([]), false);
-    assertEquals(checkIsString(null), false);
-    assertEquals(checkIsString(undefined), false);
-  });
+	await t.step("should return false for non-strings", () => {
+		assertEquals(check_is_string(123), false);
+		assertEquals(check_is_string(true), false);
+		assertEquals(check_is_string({}), false);
+		assertEquals(check_is_string([]), false);
+		assertEquals(check_is_string(null), false);
+		assertEquals(check_is_string(undefined), false);
+	});
 
-  await t.step("should narrow string type", () => {
-    type Value = string | number;
-    const value = {} as Value;
-    if (checkIsString(value)) {
-      assertType<IsExact<typeof value, string>>(true);
-    }
-  });
+	await t.step("should narrow string type", () => {
+		type Value = string | number;
+		const value = {} as Value;
+		if (check_is_string(value)) {
+			assertType<IsExact<typeof value, string>>(true);
+		}
+	});
 });
 
-Deno.test("checkIsNotString", async (t) => {
-  await t.step("should return true for non-strings", () => {
-    assertEquals(checkIsNotString(123), true);
-    assertEquals(checkIsNotString(true), true);
-    assertEquals(checkIsNotString({}), true);
-    assertEquals(checkIsNotString([]), true);
-    assertEquals(checkIsNotString(null), true);
-    assertEquals(checkIsNotString(undefined), true);
-  });
+Deno.test("check_is_not_string", async (t) => {
+	await t.step("should return true for non-strings", () => {
+		assertEquals(check_is_not_string(123), true);
+		assertEquals(check_is_not_string(true), true);
+		assertEquals(check_is_not_string({}), true);
+		assertEquals(check_is_not_string([]), true);
+		assertEquals(check_is_not_string(null), true);
+		assertEquals(check_is_not_string(undefined), true);
+	});
 
-  await t.step("should return false for strings", () => {
-    assertEquals(checkIsNotString("hello"), false);
-    assertEquals(checkIsNotString(""), false);
-    assertEquals(checkIsNotString("123"), false);
-  });
+	await t.step("should return false for strings", () => {
+		assertEquals(check_is_not_string("hello"), false);
+		assertEquals(check_is_not_string(""), false);
+		assertEquals(check_is_not_string("123"), false);
+	});
 
-  await t.step("should exclude string type", () => {
-    type Value = string | number;
-    const value = {} as Value;
-    if (checkIsNotString(value)) {
-      assertType<IsExact<typeof value, number>>(true);
-    }
-  });
+	await t.step("should exclude string type", () => {
+		type Value = string | number;
+		const value = {} as Value;
+		if (check_is_not_string(value)) {
+			assertType<IsExact<typeof value, number>>(true);
+		}
+	});
 });

--- a/packages/string/src/checkString/test.ts
+++ b/packages/string/src/checkString/test.ts
@@ -2,51 +2,51 @@ import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import { check_is_not_string, check_is_string } from "./main.ts";
 
 Deno.test("check_is_string", async (t) => {
-	await t.step("should return true for strings", () => {
-		assertEquals(check_is_string("hello"), true);
-		assertEquals(check_is_string(""), true);
-		assertEquals(check_is_string("123"), true);
-	});
+  await t.step("should return true for strings", () => {
+    assertEquals(check_is_string("hello"), true);
+    assertEquals(check_is_string(""), true);
+    assertEquals(check_is_string("123"), true);
+  });
 
-	await t.step("should return false for non-strings", () => {
-		assertEquals(check_is_string(123), false);
-		assertEquals(check_is_string(true), false);
-		assertEquals(check_is_string({}), false);
-		assertEquals(check_is_string([]), false);
-		assertEquals(check_is_string(null), false);
-		assertEquals(check_is_string(undefined), false);
-	});
+  await t.step("should return false for non-strings", () => {
+    assertEquals(check_is_string(123), false);
+    assertEquals(check_is_string(true), false);
+    assertEquals(check_is_string({}), false);
+    assertEquals(check_is_string([]), false);
+    assertEquals(check_is_string(null), false);
+    assertEquals(check_is_string(undefined), false);
+  });
 
-	await t.step("should narrow string type", () => {
-		type Value = string | number;
-		const value = {} as Value;
-		if (check_is_string(value)) {
-			assertType<IsExact<typeof value, string>>(true);
-		}
-	});
+  await t.step("should narrow string type", () => {
+    type Value = string | number;
+    const value = {} as Value;
+    if (check_is_string(value)) {
+      assertType<IsExact<typeof value, string>>(true);
+    }
+  });
 });
 
 Deno.test("check_is_not_string", async (t) => {
-	await t.step("should return true for non-strings", () => {
-		assertEquals(check_is_not_string(123), true);
-		assertEquals(check_is_not_string(true), true);
-		assertEquals(check_is_not_string({}), true);
-		assertEquals(check_is_not_string([]), true);
-		assertEquals(check_is_not_string(null), true);
-		assertEquals(check_is_not_string(undefined), true);
-	});
+  await t.step("should return true for non-strings", () => {
+    assertEquals(check_is_not_string(123), true);
+    assertEquals(check_is_not_string(true), true);
+    assertEquals(check_is_not_string({}), true);
+    assertEquals(check_is_not_string([]), true);
+    assertEquals(check_is_not_string(null), true);
+    assertEquals(check_is_not_string(undefined), true);
+  });
 
-	await t.step("should return false for strings", () => {
-		assertEquals(check_is_not_string("hello"), false);
-		assertEquals(check_is_not_string(""), false);
-		assertEquals(check_is_not_string("123"), false);
-	});
+  await t.step("should return false for strings", () => {
+    assertEquals(check_is_not_string("hello"), false);
+    assertEquals(check_is_not_string(""), false);
+    assertEquals(check_is_not_string("123"), false);
+  });
 
-	await t.step("should exclude string type", () => {
-		type Value = string | number;
-		const value = {} as Value;
-		if (check_is_not_string(value)) {
-			assertType<IsExact<typeof value, number>>(true);
-		}
-	});
+  await t.step("should exclude string type", () => {
+    type Value = string | number;
+    const value = {} as Value;
+    if (check_is_not_string(value)) {
+      assertType<IsExact<typeof value, number>>(true);
+    }
+  });
 });

--- a/packages/string/src/checkSuffix/main.ts
+++ b/packages/string/src/checkSuffix/main.ts
@@ -11,23 +11,23 @@
  *
  * @example
  * // Returns true
- * checkHasSuffix('hello world', 'world'); // The string ends with 'world'
+ * check_has_suffix('hello world', 'world'); // The string ends with 'world'
  *
  * @example
  * // Returns false
- * checkHasSuffix('hello world', 'hello'); // The string does not end with 'hello'
+ * check_has_suffix('hello world', 'hello'); // The string does not end with 'hello'
  */
-export const checkHasSuffix = <Suffix extends string>(
-  str: string,
-  suffix: Suffix,
+export const check_has_suffix = <Suffix extends string>(
+	str: string,
+	suffix: Suffix
 ): str is `${string}${Suffix}` => {
-  return str.endsWith(suffix);
+	return str.endsWith(suffix);
 };
 
 /**
  * Checks if a given string does not end with a specific suffix.
  *
- * This is the inverse of `checkHasSuffix`.
+ * This is the inverse of `check_has_suffix`.
  *
  * @param {string} str - The string to check.
  * @param {string} suffix - The suffix to check against.
@@ -35,15 +35,15 @@ export const checkHasSuffix = <Suffix extends string>(
  *
  * @example
  * // Returns true
- * checkDoesNotHaveSuffix('hello world', 'hello'); // The string does not end with 'hello'
+ * check_does_not_have_suffix('hello world', 'hello'); // The string does not end with 'hello'
  *
  * @example
  * // Returns false
- * checkDoesNotHaveSuffix('hello world', 'world'); // The string ends with 'world'
+ * check_does_not_have_suffix('hello world', 'world'); // The string ends with 'world'
  */
-export const checkDoesNotHaveSuffix = (
-  str: string,
-  suffix: string,
+export const check_does_not_have_suffix = (
+	str: string,
+	suffix: string
 ): boolean => {
-  return !checkHasSuffix(str, suffix);
+	return !check_has_suffix(str, suffix);
 };

--- a/packages/string/src/checkSuffix/main.ts
+++ b/packages/string/src/checkSuffix/main.ts
@@ -18,10 +18,10 @@
  * check_has_suffix('hello world', 'hello'); // The string does not end with 'hello'
  */
 export const check_has_suffix = <Suffix extends string>(
-	str: string,
-	suffix: Suffix
+  str: string,
+  suffix: Suffix,
 ): str is `${string}${Suffix}` => {
-	return str.endsWith(suffix);
+  return str.endsWith(suffix);
 };
 
 /**
@@ -42,8 +42,8 @@ export const check_has_suffix = <Suffix extends string>(
  * check_does_not_have_suffix('hello world', 'world'); // The string ends with 'world'
  */
 export const check_does_not_have_suffix = (
-	str: string,
-	suffix: string
+  str: string,
+  suffix: string,
 ): boolean => {
-	return !check_has_suffix(str, suffix);
+  return !check_has_suffix(str, suffix);
 };

--- a/packages/string/src/checkSuffix/test.ts
+++ b/packages/string/src/checkSuffix/test.ts
@@ -1,57 +1,57 @@
 import { assertEquals, assertType, type IsExact } from "../../deps.ts";
-import { checkDoesNotHaveSuffix, checkHasSuffix } from "./main.ts";
+import { check_does_not_have_suffix, check_has_suffix } from "./main.ts";
 
 Deno.test("checkEndsWith", async (t) => {
-  await t.step(
-    "should return true for strings that end with the given suffix",
-    () => {
-      assertEquals(checkHasSuffix("hello world", "world"), true);
-      assertEquals(checkHasSuffix("hello", "o"), true);
-      assertEquals(checkHasSuffix("typescript", "script"), true);
-      assertEquals(checkHasSuffix("openai", "ai"), true);
-      assertEquals(checkHasSuffix("end", "end"), true);
-    },
-  );
+	await t.step(
+		"should return true for strings that end with the given suffix",
+		() => {
+			assertEquals(check_has_suffix("hello world", "world"), true);
+			assertEquals(check_has_suffix("hello", "o"), true);
+			assertEquals(check_has_suffix("typescript", "script"), true);
+			assertEquals(check_has_suffix("openai", "ai"), true);
+			assertEquals(check_has_suffix("end", "end"), true);
+		}
+	);
 
-  await t.step(
-    "should return false for strings that do not end with the given suffix",
-    () => {
-      assertEquals(checkHasSuffix("hello world", "hello"), false);
-      assertEquals(checkHasSuffix("hello", "l"), false);
-      assertEquals(checkHasSuffix("typescript", "type"), false);
-      assertEquals(checkHasSuffix("openai", "open"), false);
-      assertEquals(checkHasSuffix("end", "start"), false);
-    },
-  );
+	await t.step(
+		"should return false for strings that do not end with the given suffix",
+		() => {
+			assertEquals(check_has_suffix("hello world", "hello"), false);
+			assertEquals(check_has_suffix("hello", "l"), false);
+			assertEquals(check_has_suffix("typescript", "type"), false);
+			assertEquals(check_has_suffix("openai", "open"), false);
+			assertEquals(check_has_suffix("end", "start"), false);
+		}
+	);
 
-  await t.step("should narrow string with suffix type", () => {
-    const value: string = "";
-    if (checkHasSuffix(value, "suffix")) {
-      assertType<IsExact<typeof value, `${string}suffix`>>(true);
-    }
-  });
+	await t.step("should narrow string with suffix type", () => {
+		const value: string = "";
+		if (check_has_suffix(value, "suffix")) {
+			assertType<IsExact<typeof value, `${string}suffix`>>(true);
+		}
+	});
 });
 
 Deno.test("checkNotEndWith", async (t) => {
-  await t.step(
-    "should return true for strings that do not end with the given suffix",
-    () => {
-      assertEquals(checkDoesNotHaveSuffix("hello world", "hello"), true);
-      assertEquals(checkDoesNotHaveSuffix("hello", "l"), true);
-      assertEquals(checkDoesNotHaveSuffix("typescript", "type"), true);
-      assertEquals(checkDoesNotHaveSuffix("openai", "open"), true);
-      assertEquals(checkDoesNotHaveSuffix("end", "start"), true);
-    },
-  );
+	await t.step(
+		"should return true for strings that do not end with the given suffix",
+		() => {
+			assertEquals(check_does_not_have_suffix("hello world", "hello"), true);
+			assertEquals(check_does_not_have_suffix("hello", "l"), true);
+			assertEquals(check_does_not_have_suffix("typescript", "type"), true);
+			assertEquals(check_does_not_have_suffix("openai", "open"), true);
+			assertEquals(check_does_not_have_suffix("end", "start"), true);
+		}
+	);
 
-  await t.step(
-    "should return false for strings that end with the given suffix",
-    () => {
-      assertEquals(checkDoesNotHaveSuffix("hello world", "world"), false);
-      assertEquals(checkDoesNotHaveSuffix("hello", "o"), false);
-      assertEquals(checkDoesNotHaveSuffix("typescript", "script"), false);
-      assertEquals(checkDoesNotHaveSuffix("openai", "ai"), false);
-      assertEquals(checkDoesNotHaveSuffix("end", "end"), false);
-    },
-  );
+	await t.step(
+		"should return false for strings that end with the given suffix",
+		() => {
+			assertEquals(check_does_not_have_suffix("hello world", "world"), false);
+			assertEquals(check_does_not_have_suffix("hello", "o"), false);
+			assertEquals(check_does_not_have_suffix("typescript", "script"), false);
+			assertEquals(check_does_not_have_suffix("openai", "ai"), false);
+			assertEquals(check_does_not_have_suffix("end", "end"), false);
+		}
+	);
 });

--- a/packages/string/src/checkSuffix/test.ts
+++ b/packages/string/src/checkSuffix/test.ts
@@ -2,56 +2,56 @@ import { assertEquals, assertType, type IsExact } from "../../deps.ts";
 import { check_does_not_have_suffix, check_has_suffix } from "./main.ts";
 
 Deno.test("checkEndsWith", async (t) => {
-	await t.step(
-		"should return true for strings that end with the given suffix",
-		() => {
-			assertEquals(check_has_suffix("hello world", "world"), true);
-			assertEquals(check_has_suffix("hello", "o"), true);
-			assertEquals(check_has_suffix("typescript", "script"), true);
-			assertEquals(check_has_suffix("openai", "ai"), true);
-			assertEquals(check_has_suffix("end", "end"), true);
-		}
-	);
+  await t.step(
+    "should return true for strings that end with the given suffix",
+    () => {
+      assertEquals(check_has_suffix("hello world", "world"), true);
+      assertEquals(check_has_suffix("hello", "o"), true);
+      assertEquals(check_has_suffix("typescript", "script"), true);
+      assertEquals(check_has_suffix("openai", "ai"), true);
+      assertEquals(check_has_suffix("end", "end"), true);
+    },
+  );
 
-	await t.step(
-		"should return false for strings that do not end with the given suffix",
-		() => {
-			assertEquals(check_has_suffix("hello world", "hello"), false);
-			assertEquals(check_has_suffix("hello", "l"), false);
-			assertEquals(check_has_suffix("typescript", "type"), false);
-			assertEquals(check_has_suffix("openai", "open"), false);
-			assertEquals(check_has_suffix("end", "start"), false);
-		}
-	);
+  await t.step(
+    "should return false for strings that do not end with the given suffix",
+    () => {
+      assertEquals(check_has_suffix("hello world", "hello"), false);
+      assertEquals(check_has_suffix("hello", "l"), false);
+      assertEquals(check_has_suffix("typescript", "type"), false);
+      assertEquals(check_has_suffix("openai", "open"), false);
+      assertEquals(check_has_suffix("end", "start"), false);
+    },
+  );
 
-	await t.step("should narrow string with suffix type", () => {
-		const value: string = "";
-		if (check_has_suffix(value, "suffix")) {
-			assertType<IsExact<typeof value, `${string}suffix`>>(true);
-		}
-	});
+  await t.step("should narrow string with suffix type", () => {
+    const value: string = "";
+    if (check_has_suffix(value, "suffix")) {
+      assertType<IsExact<typeof value, `${string}suffix`>>(true);
+    }
+  });
 });
 
 Deno.test("checkNotEndWith", async (t) => {
-	await t.step(
-		"should return true for strings that do not end with the given suffix",
-		() => {
-			assertEquals(check_does_not_have_suffix("hello world", "hello"), true);
-			assertEquals(check_does_not_have_suffix("hello", "l"), true);
-			assertEquals(check_does_not_have_suffix("typescript", "type"), true);
-			assertEquals(check_does_not_have_suffix("openai", "open"), true);
-			assertEquals(check_does_not_have_suffix("end", "start"), true);
-		}
-	);
+  await t.step(
+    "should return true for strings that do not end with the given suffix",
+    () => {
+      assertEquals(check_does_not_have_suffix("hello world", "hello"), true);
+      assertEquals(check_does_not_have_suffix("hello", "l"), true);
+      assertEquals(check_does_not_have_suffix("typescript", "type"), true);
+      assertEquals(check_does_not_have_suffix("openai", "open"), true);
+      assertEquals(check_does_not_have_suffix("end", "start"), true);
+    },
+  );
 
-	await t.step(
-		"should return false for strings that end with the given suffix",
-		() => {
-			assertEquals(check_does_not_have_suffix("hello world", "world"), false);
-			assertEquals(check_does_not_have_suffix("hello", "o"), false);
-			assertEquals(check_does_not_have_suffix("typescript", "script"), false);
-			assertEquals(check_does_not_have_suffix("openai", "ai"), false);
-			assertEquals(check_does_not_have_suffix("end", "end"), false);
-		}
-	);
+  await t.step(
+    "should return false for strings that end with the given suffix",
+    () => {
+      assertEquals(check_does_not_have_suffix("hello world", "world"), false);
+      assertEquals(check_does_not_have_suffix("hello", "o"), false);
+      assertEquals(check_does_not_have_suffix("typescript", "script"), false);
+      assertEquals(check_does_not_have_suffix("openai", "ai"), false);
+      assertEquals(check_does_not_have_suffix("end", "end"), false);
+    },
+  );
 });

--- a/packages/string/src/checkURLFormat/main.ts
+++ b/packages/string/src/checkURLFormat/main.ts
@@ -8,33 +8,33 @@
  *
  * @example
  * // Returns true
- * checkIsURLFormat('https://www.example.com'); // Valid URL
+ * check_is_url_format('https://www.example.com'); // Valid URL
  *
  * @example
  * // Returns false
- * checkIsURLFormat('invalid-url'); // The string is not a valid URL
+ * check_is_url_format('invalid-url'); // The string is not a valid URL
  */
-export const checkIsURLFormat = (str: string): boolean => {
-  const urlRegex = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/i;
-  return urlRegex.test(str);
+export const check_is_URL_format = (str: string): boolean => {
+	const urlRegex = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/i;
+	return urlRegex.test(str);
 };
 
 /**
  * Checks if a given string is not in URL format.
  *
- * This is the inverse of `checkIsURLFormat`.
+ * This is the inverse of `check_is_url_format`.
  *
  * @param {string} str - The string to check.
  * @returns {boolean} True if the string is not in URL format, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotURLFormat('invalid-url'); // The string is not a valid URL
+ * check_is_not_url_format('invalid-url'); // The string is not a valid URL
  *
  * @example
  * // Returns false
- * checkIsNotURLFormat('https://www.example.com'); // Valid URL
+ * check_is_not_url_format('https://www.example.com'); // Valid URL
  */
-export const checkIsNotURLFormat = (str: string): boolean => {
-  return !checkIsURLFormat(str);
+export const check_is_not_URL_format = (str: string): boolean => {
+	return !check_is_URL_format(str);
 };

--- a/packages/string/src/checkURLFormat/main.ts
+++ b/packages/string/src/checkURLFormat/main.ts
@@ -15,8 +15,8 @@
  * check_is_url_format('invalid-url'); // The string is not a valid URL
  */
 export const check_is_URL_format = (str: string): boolean => {
-	const urlRegex = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/i;
-	return urlRegex.test(str);
+  const urlRegex = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/i;
+  return urlRegex.test(str);
 };
 
 /**
@@ -36,5 +36,5 @@ export const check_is_URL_format = (str: string): boolean => {
  * check_is_not_url_format('https://www.example.com'); // Valid URL
  */
 export const check_is_not_URL_format = (str: string): boolean => {
-	return !check_is_URL_format(str);
+  return !check_is_URL_format(str);
 };

--- a/packages/string/src/checkURLFormat/test.ts
+++ b/packages/string/src/checkURLFormat/test.ts
@@ -1,26 +1,26 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsNotURLFormat, checkIsURLFormat } from "./main.ts";
+import { check_is_not_URL_format, check_is_URL_format } from "./main.ts";
 
-Deno.test("checkIsURLFormat", async (t) => {
-  await t.step("should return true for valid URLs", () => {
-    assertEquals(checkIsURLFormat("https://example.com"), true);
-    assertEquals(checkIsURLFormat("ftp://example.com/resource"), true);
-  });
+Deno.test("check_is_URL_format", async (t) => {
+	await t.step("should return true for valid URLs", () => {
+		assertEquals(check_is_URL_format("https://example.com"), true);
+		assertEquals(check_is_URL_format("ftp://example.com/resource"), true);
+	});
 
-  await t.step("should return false for invalid URLs", () => {
-    assertEquals(checkIsURLFormat("invalid-url"), false);
-    assertEquals(checkIsURLFormat("http://"), false);
-  });
+	await t.step("should return false for invalid URLs", () => {
+		assertEquals(check_is_URL_format("invalid-url"), false);
+		assertEquals(check_is_URL_format("http://"), false);
+	});
 });
 
-Deno.test("checkIsNotURLFormat", async (t) => {
-  await t.step("should return true for invalid URLs", () => {
-    assertEquals(checkIsNotURLFormat("invalid-url"), true);
-    assertEquals(checkIsNotURLFormat("http://"), true);
-  });
+Deno.test("check_is_not_URL_format", async (t) => {
+	await t.step("should return true for invalid URLs", () => {
+		assertEquals(check_is_not_URL_format("invalid-url"), true);
+		assertEquals(check_is_not_URL_format("http://"), true);
+	});
 
-  await t.step("should return false for valid URLs", () => {
-    assertEquals(checkIsNotURLFormat("https://example.com"), false);
-    assertEquals(checkIsNotURLFormat("ftp://example.com/resource"), false);
-  });
+	await t.step("should return false for valid URLs", () => {
+		assertEquals(check_is_not_URL_format("https://example.com"), false);
+		assertEquals(check_is_not_URL_format("ftp://example.com/resource"), false);
+	});
 });

--- a/packages/string/src/checkURLFormat/test.ts
+++ b/packages/string/src/checkURLFormat/test.ts
@@ -2,25 +2,25 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_not_URL_format, check_is_URL_format } from "./main.ts";
 
 Deno.test("check_is_URL_format", async (t) => {
-	await t.step("should return true for valid URLs", () => {
-		assertEquals(check_is_URL_format("https://example.com"), true);
-		assertEquals(check_is_URL_format("ftp://example.com/resource"), true);
-	});
+  await t.step("should return true for valid URLs", () => {
+    assertEquals(check_is_URL_format("https://example.com"), true);
+    assertEquals(check_is_URL_format("ftp://example.com/resource"), true);
+  });
 
-	await t.step("should return false for invalid URLs", () => {
-		assertEquals(check_is_URL_format("invalid-url"), false);
-		assertEquals(check_is_URL_format("http://"), false);
-	});
+  await t.step("should return false for invalid URLs", () => {
+    assertEquals(check_is_URL_format("invalid-url"), false);
+    assertEquals(check_is_URL_format("http://"), false);
+  });
 });
 
 Deno.test("check_is_not_URL_format", async (t) => {
-	await t.step("should return true for invalid URLs", () => {
-		assertEquals(check_is_not_URL_format("invalid-url"), true);
-		assertEquals(check_is_not_URL_format("http://"), true);
-	});
+  await t.step("should return true for invalid URLs", () => {
+    assertEquals(check_is_not_URL_format("invalid-url"), true);
+    assertEquals(check_is_not_URL_format("http://"), true);
+  });
 
-	await t.step("should return false for valid URLs", () => {
-		assertEquals(check_is_not_URL_format("https://example.com"), false);
-		assertEquals(check_is_not_URL_format("ftp://example.com/resource"), false);
-	});
+  await t.step("should return false for valid URLs", () => {
+    assertEquals(check_is_not_URL_format("https://example.com"), false);
+    assertEquals(check_is_not_URL_format("ftp://example.com/resource"), false);
+  });
 });

--- a/packages/string/src/checkUUIDFormat/main.ts
+++ b/packages/string/src/checkUUIDFormat/main.ts
@@ -10,15 +10,13 @@ import type { UUIDFormat } from "../types.ts";
  *
  * @example
  * // Returns true
- * checkIsUUIDFormat('123e4567-e89b-12d3-a456-426614174000'); // Valid UUID
+ * check_is_UUID_format('123e4567-e89b-12d3-a456-426614174000'); // Valid UUID
  *
  * @example
  * // Returns false
- * checkIsUUIDFormat('invalid-uuid'); // The string is not a valid UUID format
+ * check_is_UUID_format('invalid-uuid'); // The string is not a valid UUID format
  */
-export const checkIsUUIDFormat = (
-	str: string
-): str is UUIDFormat => {
+export const check_is_UUID_format = (str: string): str is UUIDFormat => {
 	const uuidRegex =
 		/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 	return uuidRegex.test(str);
@@ -27,21 +25,21 @@ export const checkIsUUIDFormat = (
 /**
  * Checks if a given string is not in UUID format.
  *
- * This is the inverse of `checkIsUUIDFormat`.
+ * This is the inverse of `check_is_UUID_format`.
  *
  * @param {string} str - The string to check.
  * @returns {boolean} True if the string is not in UUID format, otherwise false.
  *
  * @example
  * // Returns true
- * checkIsNotUUIDFormat('invalid-uuid'); // The string is not a valid UUID format
+ * check_is_not_UUID_format('invalid-uuid'); // The string is not a valid UUID format
  *
  * @example
  * // Returns false
- * checkIsNotUUIDFormat('123e4567-e89b-12d3-a456-426614174000'); // Valid UUID
+ * check_is_not_UUID_format('123e4567-e89b-12d3-a456-426614174000'); // Valid UUID
  */
-export const checkIsNotUUIDFormat = <T extends string>(
+export const check_is_not_UUID_format = <T extends string>(
 	str: T
 ): str is Exclude<T, UUIDFormat> => {
-	return !checkIsUUIDFormat(str);
+	return !check_is_UUID_format(str);
 };

--- a/packages/string/src/checkUUIDFormat/main.ts
+++ b/packages/string/src/checkUUIDFormat/main.ts
@@ -17,9 +17,9 @@ import type { UUIDFormat } from "../types.ts";
  * check_is_UUID_format('invalid-uuid'); // The string is not a valid UUID format
  */
 export const check_is_UUID_format = (str: string): str is UUIDFormat => {
-	const uuidRegex =
-		/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-	return uuidRegex.test(str);
+  const uuidRegex =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  return uuidRegex.test(str);
 };
 
 /**
@@ -39,7 +39,7 @@ export const check_is_UUID_format = (str: string): str is UUIDFormat => {
  * check_is_not_UUID_format('123e4567-e89b-12d3-a456-426614174000'); // Valid UUID
  */
 export const check_is_not_UUID_format = <T extends string>(
-	str: T
+  str: T,
 ): str is Exclude<T, UUIDFormat> => {
-	return !check_is_UUID_format(str);
+  return !check_is_UUID_format(str);
 };

--- a/packages/string/src/checkUUIDFormat/test.ts
+++ b/packages/string/src/checkUUIDFormat/test.ts
@@ -1,57 +1,57 @@
 import { assertEquals } from "../../deps.ts";
-import { checkIsNotUUIDFormat, checkIsUUIDFormat } from "./main.ts";
+import { check_is_not_UUID_format, check_is_UUID_format } from "./main.ts";
 
 Deno.test("checkIsUUIDFormat", async (t) => {
-  await t.step("should return true for valid UUIDs", () => {
-    assertEquals(
-      checkIsUUIDFormat("123e4567-e89b-12d3-a456-426614174000"),
-      true,
-    );
-    assertEquals(
-      checkIsUUIDFormat("550e8400-e29b-41d4-a716-446655440000"),
-      true,
-    );
+	await t.step("should return true for valid UUIDs", () => {
+		assertEquals(
+			check_is_UUID_format("123e4567-e89b-12d3-a456-426614174000"),
+			true
+		);
+		assertEquals(
+			check_is_UUID_format("550e8400-e29b-41d4-a716-446655440000"),
+			true
+		);
 
-    // only numbers
-    assertEquals(
-      checkIsUUIDFormat("12345678-1234-1234-1234-123456789012"),
-      true,
-    );
-  });
+		// only numbers
+		assertEquals(
+			check_is_UUID_format("12345678-1234-1234-1234-123456789012"),
+			true
+		);
+	});
 
-  await t.step("should return false for invalid UUIDs", () => {
-    assertEquals(checkIsUUIDFormat("invalid-uuid"), false);
+	await t.step("should return false for invalid UUIDs", () => {
+		assertEquals(check_is_UUID_format("invalid-uuid"), false);
 
-    // shortened UUID
-    assertEquals(
-      checkIsUUIDFormat("123e4567-e89b-12d3-a456-42661417400"),
-      false,
-    );
-  });
+		// shortened UUID
+		assertEquals(
+			check_is_UUID_format("123e4567-e89b-12d3-a456-42661417400"),
+			false
+		);
+	});
 });
 
 Deno.test("checkIsNotUUIDFormat", async (t) => {
-  await t.step("should return true for invalid UUIDs", () => {
-    assertEquals(checkIsNotUUIDFormat("invalid-uuid"), true);
-    assertEquals(
-      checkIsNotUUIDFormat("123e4567-e89b-12d3-a456-42661417400"),
-      true,
-    );
-  });
+	await t.step("should return true for invalid UUIDs", () => {
+		assertEquals(check_is_not_UUID_format("invalid-uuid"), true);
+		assertEquals(
+			check_is_not_UUID_format("123e4567-e89b-12d3-a456-42661417400"),
+			true
+		);
+	});
 
-  await t.step("should return false for valid UUIDs", () => {
-    assertEquals(
-      checkIsNotUUIDFormat("123e4567-e89b-12d3-a456-426614174000"),
-      false,
-    );
-    assertEquals(
-      checkIsNotUUIDFormat("550e8400-e29b-41d4-a716-446655440000"),
-      false,
-    );
+	await t.step("should return false for valid UUIDs", () => {
+		assertEquals(
+			check_is_not_UUID_format("123e4567-e89b-12d3-a456-426614174000"),
+			false
+		);
+		assertEquals(
+			check_is_not_UUID_format("550e8400-e29b-41d4-a716-446655440000"),
+			false
+		);
 
-    assertEquals(
-      checkIsNotUUIDFormat("12345678-1234-1234-1234-123456789012"),
-      false,
-    );
-  });
+		assertEquals(
+			check_is_not_UUID_format("12345678-1234-1234-1234-123456789012"),
+			false
+		);
+	});
 });

--- a/packages/string/src/checkUUIDFormat/test.ts
+++ b/packages/string/src/checkUUIDFormat/test.ts
@@ -2,56 +2,56 @@ import { assertEquals } from "../../deps.ts";
 import { check_is_not_UUID_format, check_is_UUID_format } from "./main.ts";
 
 Deno.test("checkIsUUIDFormat", async (t) => {
-	await t.step("should return true for valid UUIDs", () => {
-		assertEquals(
-			check_is_UUID_format("123e4567-e89b-12d3-a456-426614174000"),
-			true
-		);
-		assertEquals(
-			check_is_UUID_format("550e8400-e29b-41d4-a716-446655440000"),
-			true
-		);
+  await t.step("should return true for valid UUIDs", () => {
+    assertEquals(
+      check_is_UUID_format("123e4567-e89b-12d3-a456-426614174000"),
+      true,
+    );
+    assertEquals(
+      check_is_UUID_format("550e8400-e29b-41d4-a716-446655440000"),
+      true,
+    );
 
-		// only numbers
-		assertEquals(
-			check_is_UUID_format("12345678-1234-1234-1234-123456789012"),
-			true
-		);
-	});
+    // only numbers
+    assertEquals(
+      check_is_UUID_format("12345678-1234-1234-1234-123456789012"),
+      true,
+    );
+  });
 
-	await t.step("should return false for invalid UUIDs", () => {
-		assertEquals(check_is_UUID_format("invalid-uuid"), false);
+  await t.step("should return false for invalid UUIDs", () => {
+    assertEquals(check_is_UUID_format("invalid-uuid"), false);
 
-		// shortened UUID
-		assertEquals(
-			check_is_UUID_format("123e4567-e89b-12d3-a456-42661417400"),
-			false
-		);
-	});
+    // shortened UUID
+    assertEquals(
+      check_is_UUID_format("123e4567-e89b-12d3-a456-42661417400"),
+      false,
+    );
+  });
 });
 
 Deno.test("checkIsNotUUIDFormat", async (t) => {
-	await t.step("should return true for invalid UUIDs", () => {
-		assertEquals(check_is_not_UUID_format("invalid-uuid"), true);
-		assertEquals(
-			check_is_not_UUID_format("123e4567-e89b-12d3-a456-42661417400"),
-			true
-		);
-	});
+  await t.step("should return true for invalid UUIDs", () => {
+    assertEquals(check_is_not_UUID_format("invalid-uuid"), true);
+    assertEquals(
+      check_is_not_UUID_format("123e4567-e89b-12d3-a456-42661417400"),
+      true,
+    );
+  });
 
-	await t.step("should return false for valid UUIDs", () => {
-		assertEquals(
-			check_is_not_UUID_format("123e4567-e89b-12d3-a456-426614174000"),
-			false
-		);
-		assertEquals(
-			check_is_not_UUID_format("550e8400-e29b-41d4-a716-446655440000"),
-			false
-		);
+  await t.step("should return false for valid UUIDs", () => {
+    assertEquals(
+      check_is_not_UUID_format("123e4567-e89b-12d3-a456-426614174000"),
+      false,
+    );
+    assertEquals(
+      check_is_not_UUID_format("550e8400-e29b-41d4-a716-446655440000"),
+      false,
+    );
 
-		assertEquals(
-			check_is_not_UUID_format("12345678-1234-1234-1234-123456789012"),
-			false
-		);
-	});
+    assertEquals(
+      check_is_not_UUID_format("12345678-1234-1234-1234-123456789012"),
+      false,
+    );
+  });
 });

--- a/packages/string/src/types.ts
+++ b/packages/string/src/types.ts
@@ -1,2 +1,2 @@
 export type UUIDFormat = `${string}-${string}-${string}-${string}-${string}`;
-export type EnterKey = 'Enter';
+export type EnterKey = "Enter";


### PR DESCRIPTION
snake_case scales better than camelCase and is more readable, so I decided to shift the names of all functions provided by this library from camelCase to snake_case.